### PR TITLE
allow adding gateway endpoints to vpc

### DIFF
--- a/charts/internal/aws-infra/templates/main.tf
+++ b/charts/internal/aws-infra/templates/main.tf
@@ -24,6 +24,15 @@ resource "aws_vpc" "vpc" {
 {{ include "aws-infra.common-tags" .Values | indent 2 }}
 }
 
+{{ range $ep := .Values.vpc.gatewayEndpoints }}
+resource "aws_vpc_endpoint" "vpc_gwep_{{ $ep }}" {
+  vpc_id       = "${aws_vpc.vpc.id}"
+  service_name = "com.amazonaws.{{ .Values.aws.region }}.{{ $ep }}"
+
+{{ include "aws-infra.tags-with-suffix" (set $.Values "suffix" (print "gw-" $ep)) | indent 2 }}
+}
+{{ end }}
+
 resource "aws_vpc_dhcp_options_association" "vpc_dhcp_options_association" {
   vpc_id          = "${aws_vpc.vpc.id}"
   dhcp_options_id = "${aws_vpc_dhcp_options.vpc_dhcp_options.id}"
@@ -379,4 +388,3 @@ tags = {
   "kubernetes.io/cluster/{{ required "clusterName is required" .clusterName }}" = "1"
 }
 {{- end -}}
-

--- a/charts/internal/aws-infra/values.yaml
+++ b/charts/internal/aws-infra/values.yaml
@@ -14,6 +14,7 @@ vpc:
   cidr: 10.10.10.10/6
   dhcpDomainName: eu-west-1.compute.internal
   internetGatewayID: ${aws_internet_gateway.igw.id}
+  gatewayEndpoints: []
 
 zones:
 - name: eu-west-1a

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -37,6 +37,8 @@ networks:
   vpc: # specify either 'id' or 'cidr'
   # id: vpc-123456
     cidr: 10.250.0.0/16
+  # gatewayEndpoints:
+  # - s3
   zones:
   - name: eu-west-1a
     internal: 10.250.112.0/22
@@ -54,6 +56,7 @@ Please make sure that the VPC has attached an internet gateway - the AWS control
 * If `networks.vpc.cidr` is given then you have to specify the VPC CIDR of a new VPC that will be created during shoot creation.
 You can freely choose a private CIDR range.
 * Either `networks.vpc.id` or `networks.vpc.cidr` must be present, but not both at the same time.
+* `networks.vpc.gatewayEndpoints` is optional. If specified then each item is used as service name in a corresponding Gateway VPC Endpoint.
 
 The `networks.zones` section describes which subnets you want to create in availability zones.
 For every zone, the AWS extension creates three subnets:
@@ -64,6 +67,22 @@ For every zone, the AWS extension creates three subnets:
 
 For every subnet, you have to specify a CIDR range contained in the VPC CIDR specified above, or the VPC CIDR of your already existing VPC.
 You can freely choose these CIDR and it is your responsibility to properly design the network layout to suit your needs.
+
+You can configure [Gateway VPC Endpoints](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-gateway.html) by adding items in the optional list `networks.vpc.gatewayEndpoints`. Each item in the list is used as a service name and a corresponding endpoint is created for it. All created endpoints point to the service within the cluster's region. For example, consider this (partial) shoot config:
+```yaml
+spec:
+  region: eu-central-1
+  provider:
+    type: aws
+    infrastructureConfig:
+      apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
+      kind: InfrastructureConfig
+      networks:
+        vpc:
+          gatewayEndpoints:
+          - s3
+```
+The service name of the S3 Gateway VPC Endpoint in this example is `com.amazonaws.eu-central-1.s3`.
 
 If you want to use multiple availability zones then add a second, third, ... entry to the `networks.zones[]` list and properly specify the AZ name in `networks.zones[].name`.
 

--- a/example/30-infrastructure.yaml
+++ b/example/30-infrastructure.yaml
@@ -47,6 +47,10 @@ spec:
       vpc: # specify either 'id' or 'cidr'
       # id: vpc-123456
         cidr: 10.250.0.0/16
+      # you can define custom service names for adding Gateway VPC Endpoints
+      # gatewayEndpoints:
+      # - s3
+      #   given the region above, this translates to service name com.amazonaws.eu-west-1.s3
       zones:
       - name: eu-west-1a
         internal: 10.250.112.0/22

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -868,6 +868,18 @@ string
 <p>CIDR is the VPC CIDR.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>gatewayEndpoints</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>GatewayEndpoints service names to configure as gateway endpoints in the VPC.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="aws.provider.extensions.gardener.cloud/v1alpha1.VPCStatus">VPCStatus

--- a/pkg/apis/aws/types_infrastructure.go
+++ b/pkg/apis/aws/types_infrastructure.go
@@ -87,6 +87,8 @@ type VPC struct {
 	ID *string
 	// CIDR is the VPC CIDR.
 	CIDR *string
+	// GatewayEndpoints service names to configure as gateway endpoints in the VPC.
+	GatewayEndpoints []string
 }
 
 // VPCStatus contains information about a generated VPC or resources inside an existing VPC.

--- a/pkg/apis/aws/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/aws/v1alpha1/types_infrastructure.go
@@ -91,6 +91,9 @@ type VPC struct {
 	// CIDR is the VPC CIDR.
 	// +optional
 	CIDR *string `json:"cidr,omitempty"`
+	// GatewayEndpoints service names to configure as gateway endpoints in the VPC.
+	// +optional
+	GatewayEndpoints []string `json:"gatewayEndpoints,omitempty"`
 }
 
 // VPCStatus contains information about a generated VPC or resources inside an existing VPC.

--- a/pkg/apis/aws/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.conversion.go
@@ -631,6 +631,7 @@ func Convert_aws_Subnet_To_v1alpha1_Subnet(in *aws.Subnet, out *Subnet, s conver
 func autoConvert_v1alpha1_VPC_To_aws_VPC(in *VPC, out *aws.VPC, s conversion.Scope) error {
 	out.ID = (*string)(unsafe.Pointer(in.ID))
 	out.CIDR = (*string)(unsafe.Pointer(in.CIDR))
+	out.GatewayEndpoints = *(*[]string)(unsafe.Pointer(&in.GatewayEndpoints))
 	return nil
 }
 
@@ -642,6 +643,7 @@ func Convert_v1alpha1_VPC_To_aws_VPC(in *VPC, out *aws.VPC, s conversion.Scope) 
 func autoConvert_aws_VPC_To_v1alpha1_VPC(in *aws.VPC, out *VPC, s conversion.Scope) error {
 	out.ID = (*string)(unsafe.Pointer(in.ID))
 	out.CIDR = (*string)(unsafe.Pointer(in.CIDR))
+	out.GatewayEndpoints = *(*[]string)(unsafe.Pointer(&in.GatewayEndpoints))
 	return nil
 }
 

--- a/pkg/apis/aws/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.deepcopy.go
@@ -385,6 +385,11 @@ func (in *VPC) DeepCopyInto(out *VPC) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.GatewayEndpoints != nil {
+		in, out := &in.GatewayEndpoints, &out.GatewayEndpoints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/aws/validation/infrastructure.go
+++ b/pkg/apis/aws/validation/infrastructure.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"fmt"
+	"regexp"
 
 	apisaws "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -83,6 +84,16 @@ func ValidateInfrastructureConfig(infra *apisaws.InfrastructureConfig, nodesCIDR
 	networksPath := field.NewPath("networks")
 	if len(infra.Networks.Zones) == 0 {
 		allErrs = append(allErrs, field.Required(networksPath.Child("zones"), "must specify at least the networks for one zone"))
+	}
+
+	if len(infra.Networks.VPC.GatewayEndpoints) > 0 {
+		epsPath := networksPath.Child("vpc", "gatewayEndpoints")
+		re := regexp.MustCompile(`^\w+$`)
+		for i, svc := range infra.Networks.VPC.GatewayEndpoints {
+			if !re.MatchString(svc) {
+				allErrs = append(allErrs, field.Invalid(epsPath.Index(i), svc, "must be alphanumeric"))
+			}
+		}
 	}
 
 	var (

--- a/pkg/apis/aws/validation/infrastructure_test.go
+++ b/pkg/apis/aws/validation/infrastructure_test.go
@@ -331,6 +331,28 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				}))
 			})
 		})
+
+		Context("gatewayEndpoints", func() {
+			It("should accept empty list", func() {
+				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
+				Expect(errorList).To(BeEmpty())
+			})
+			It("should reject non-alpthanumeric endpoints", func() {
+				infrastructureConfig.Networks.VPC.GatewayEndpoints = []string{"s3", "my-endpoint"}
+				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
+				Expect(errorList).To(ConsistOfFields(Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("networks.vpc.gatewayEndpoints[1]"),
+					"BadValue": Equal("my-endpoint"),
+					"Detail":   Equal("must be alphanumeric"),
+				}))
+			})
+			It("should accept all-valid lists", func() {
+				infrastructureConfig.Networks.VPC.GatewayEndpoints = []string{"myservice", "s3"}
+				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
+				Expect(errorList).To(BeEmpty())
+			})
+		})
 	})
 
 	Describe("#ValidateInfrastructureConfigUpdate", func() {

--- a/pkg/apis/aws/zz_generated.deepcopy.go
+++ b/pkg/apis/aws/zz_generated.deepcopy.go
@@ -385,6 +385,11 @@ func (in *VPC) DeepCopyInto(out *VPC) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.GatewayEndpoints != nil {
+		in, out := &in.GatewayEndpoints, &out.GatewayEndpoints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -149,6 +149,7 @@ func generateTerraformInfraConfig(ctx context.Context, infrastructure *extension
 			"cidr":              vpcCIDR,
 			"dhcpDomainName":    dhcpDomainName,
 			"internetGatewayID": internetGatewayID,
+			"gatewayEndpoints":  infrastructureConfig.Networks.VPC.GatewayEndpoints,
 		},
 		"clusterName": infrastructure.Namespace,
 		"zones":       zones,


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow adding gateway endpoints to the VPC of an AWS cluster. Example for adding an endpoint for S3:
```yaml
apiVersion: core.gardener.cloud/v1alpha1
kind: Shoot
spec:
  provider:
    type: aws
    infrastructureConfig:
      apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
      kind: InfrastructureConfig
      networks:
        vpc:
          gatewayEndpoints:
          - "s3"
```

More info about gateway endpoints
https://docs.aws.amazon.com/vpc/latest/userguide/vpce-gateway.html

Relevant terraform resource
https://www.terraform.io/docs/providers/aws/r/vpc_endpoint.html

**Release note**:
```improvement operator
Now it is possible to define VPC Gateway Endpoints for AWS shoots. The new list "gatewayEdnpoints" inside "vpc" sections is a list endpoint service names. Each item is mapped to a vpc gateway endpoint for a service "com.amazonaws.<region>.<service>", region being the shoot region.
```
