### PR TITLE
Validate zones order

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	k8s.io/gengo v0.0.0-20190826232639-a874a240740c
 	k8s.io/klog v1.0.0
 	k8s.io/kubelet v0.0.0-20190918162654-250a1838aa2c
+	k8s.io/utils v0.0.0-20190801114015-581e00157fb1
 	sigs.k8s.io/controller-runtime v0.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -414,6 +414,7 @@ github.com/prometheus/procfs v0.0.3 h1:CTwfnzjQ+8dS6MhHHu4YswVAD99sL2wjPqP+VkURm
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=

--- a/pkg/apis/aws/validation/infrastructure.go
+++ b/pkg/apis/aws/validation/infrastructure.go
@@ -156,23 +156,17 @@ func ValidateInfrastructureConfigUpdate(oldConfig, newConfig *apisaws.Infrastruc
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newConfig.Networks.VPC, oldConfig.Networks.VPC, field.NewPath("networks.vpc"))...)
 
 	var (
-		oldZones     = oldConfig.Networks.Zones
-		newZones     = newConfig.Networks.Zones
-		missingZones = sets.NewString()
+		oldZones = oldConfig.Networks.Zones
+		newZones = newConfig.Networks.Zones
 	)
 
-	for i, oldZone := range oldZones {
-		missingZones.Insert(oldZone.Name)
-		for j, newZone := range newZones {
-			if newZone.Name == oldZone.Name {
-				missingZones.Delete(newZone.Name)
-				allErrs = append(allErrs, apivalidation.ValidateImmutableField(newConfig.Networks.Zones[j], oldConfig.Networks.Zones[j], field.NewPath("networks.zones").Index(i))...)
-			}
-		}
+	if len(oldZones) > len(newZones) {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("networks.zones"), "removing zones is not allowed"))
+		return allErrs
 	}
 
-	for zone := range missingZones {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("networks.zones"), zone, "zone is missing - removing a zone is not supported"))
+	for i, oldZone := range oldZones {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldZone, newConfig.Networks.Zones[i], field.NewPath("networks.zones").Index(i))...)
 	}
 
 	return allErrs

--- a/pkg/apis/aws/validation/infrastructure_test.go
+++ b/pkg/apis/aws/validation/infrastructure_test.go
@@ -361,7 +361,6 @@ var _ = Describe("InfrastructureConfig validation", func() {
 		})
 
 		It("should allow adding a zone", func() {
-
 			newInfrastructureConfig := infrastructureConfig.DeepCopy()
 			newInfrastructureConfig.Networks.Zones = append(newInfrastructureConfig.Networks.Zones, awsZone2)
 
@@ -420,18 +419,19 @@ var _ = Describe("InfrastructureConfig validation", func() {
 		})
 
 		It("should forbid removing a zone", func() {
+			infrastructureConfig.Networks.Zones = append(infrastructureConfig.Networks.Zones, awsZone2)
 			newInfrastructureConfig := infrastructureConfig.DeepCopy()
-			newInfrastructureConfig.Networks.Zones[0] = awsZone2
+			newInfrastructureConfig.Networks.Zones = newInfrastructureConfig.Networks.Zones[:1]
 
 			errorList := ValidateInfrastructureConfigUpdate(infrastructureConfig, newInfrastructureConfig)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
+				"Type":  Equal(field.ErrorTypeForbidden),
 				"Field": Equal("networks.zones"),
 			}))))
 		})
 
-		It("should allow adding a zone but forbid removing a zone", func() {
+		It("should allow adding a zone but forbid changing one", func() {
 			newInfrastructureConfig := infrastructureConfig.DeepCopy()
 			newInfrastructureConfig.Networks.Zones = append(newInfrastructureConfig.Networks.Zones, awsZone2)
 			newInfrastructureConfig.Networks.Zones[0].Name = "zone3"
@@ -440,8 +440,28 @@ var _ = Describe("InfrastructureConfig validation", func() {
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("networks.zones"),
+				"Field": Equal("networks.zones[0]"),
 			}))))
+		})
+
+		It("should forbid changing the order of zones", func() {
+			infrastructureConfig.Networks.Zones = append(infrastructureConfig.Networks.Zones, awsZone2)
+			newInfrastructureConfig := infrastructureConfig.DeepCopy()
+			newInfrastructureConfig.Networks.Zones[0] = infrastructureConfig.Networks.Zones[1]
+			newInfrastructureConfig.Networks.Zones[1] = infrastructureConfig.Networks.Zones[0]
+
+			errorList := ValidateInfrastructureConfigUpdate(infrastructureConfig, newInfrastructureConfig)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("networks.zones[0]"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("networks.zones[1]"),
+				})),
+			))
 		})
 	})
 })

--- a/pkg/validator/shoot_handler.go
+++ b/pkg/validator/shoot_handler.go
@@ -57,7 +57,7 @@ func (v *Shoot) Handle(ctx context.Context, req admission.Request) admission.Res
 		}
 	case admissionv1beta1.Update:
 		oldShoot := &core.Shoot{}
-		if err := util.Decode(v.decoder, req.Object.Raw, oldShoot); err != nil {
+		if err := util.Decode(v.decoder, req.OldObject.Raw, oldShoot); err != nil {
 			v.Logger.Error(err, "failed to decode old shoot", string(req.OldObject.Raw))
 			return admission.Errored(http.StatusBadRequest, err)
 		}

--- a/pkg/validator/shoot_validator.go
+++ b/pkg/validator/shoot_validator.go
@@ -106,7 +106,7 @@ func (v *Shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 		return field.Required(fldPath.Child("infrastructureConfig"), "InfrastructureConfig must be set for AWS shoots")
 	}
 
-	infraConfig, err := decodeInfrastructureConfig(v.decoder, shoot.Spec.Provider.InfrastructureConfig, fldPath)
+	infraConfig, err := decodeInfrastructureConfig(v.decoder, shoot.Spec.Provider.InfrastructureConfig, fldPath.Child("infrastructureConfig"))
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (v *Shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 		return field.InternalError(fldPath.Child("infrastructureConfig"), errors.New("InfrastructureConfig is not available on old shoot"))
 	}
 
-	oldInfraConfig, err := decodeInfrastructureConfig(v.decoder, oldShoot.Spec.Provider.InfrastructureConfig, fldPath)
+	oldInfraConfig, err := decodeInfrastructureConfig(v.decoder, oldShoot.Spec.Provider.InfrastructureConfig, fldPath.Child("infrastructureConfig"))
 	if err != nil {
 		return err
 	}
@@ -124,6 +124,10 @@ func (v *Shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 		if errList := awsvalidation.ValidateInfrastructureConfigUpdate(oldInfraConfig, infraConfig); len(errList) != 0 {
 			return errList.ToAggregate()
 		}
+	}
+
+	if errList := awsvalidation.ValidateWorkersUpdate(oldShoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers, fldPath.Child("workers")); len(errList) != 0 {
+		return errList.ToAggregate()
 	}
 
 	return v.validateShoot(ctx, shoot)

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/helper/helpers.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/helper/helpers.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
+
+	"github.com/Masterminds/semver"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GetConditionIndex returns the index of the condition with the given <conditionType> out of the list of <conditions>.
+// In case the required type could not be found, it returns -1.
+func GetConditionIndex(conditions []core.Condition, conditionType core.ConditionType) int {
+	for index, condition := range conditions {
+		if condition.Type == conditionType {
+			return index
+		}
+	}
+	return -1
+}
+
+// GetCondition returns the condition with the given <conditionType> out of the list of <conditions>.
+// In case the required type could not be found, it returns nil.
+func GetCondition(conditions []core.Condition, conditionType core.ConditionType) *core.Condition {
+	if index := GetConditionIndex(conditions, conditionType); index != -1 {
+		return &conditions[index]
+	}
+	return nil
+}
+
+// QuotaScope returns the scope of a quota scope reference.
+func QuotaScope(scopeRef corev1.ObjectReference) (string, error) {
+	if gvk := schema.FromAPIVersionAndKind(scopeRef.APIVersion, scopeRef.Kind); gvk.Group == "core.gardener.cloud" && gvk.Kind == "Project" {
+		return "project", nil
+	}
+	if scopeRef.APIVersion == "v1" && scopeRef.Kind == "Secret" {
+		return "secret", nil
+	}
+	return "", fmt.Errorf("unknown quota scope")
+}
+
+// DetermineLatestExpirableVersion determines the latest ExpirableVersion from a slice of ExpirableVersions
+func DetermineLatestExpirableVersion(offeredVersions []core.ExpirableVersion) (core.ExpirableVersion, error) {
+	var latestExpirableVersion core.ExpirableVersion
+
+	for _, version := range offeredVersions {
+		if len(latestExpirableVersion.Version) == 0 {
+			latestExpirableVersion = version
+			continue
+		}
+		isGreater, err := versionutils.CompareVersions(version.Version, ">", latestExpirableVersion.Version)
+		if err != nil {
+			return core.ExpirableVersion{}, fmt.Errorf("error while comparing versions: %s", err.Error())
+		}
+		if isGreater {
+			latestExpirableVersion = version
+		}
+	}
+	return latestExpirableVersion, nil
+}
+
+// DetermineLatestMachineImageVersions determines the latest versions (semVer) of the given machine images from a slice of machine images
+func DetermineLatestMachineImageVersions(images []core.MachineImage) (map[string]core.ExpirableVersion, error) {
+	resultMapVersions := make(map[string]core.ExpirableVersion)
+
+	for _, image := range images {
+		latestMachineImageVersion, err := DetermineLatestMachineImageVersion(image)
+		if err != nil {
+			return nil, err
+		}
+		resultMapVersions[image.Name] = latestMachineImageVersion
+	}
+	return resultMapVersions, nil
+}
+
+// DetermineLatestMachineImageVersion determines the latest MachineImageVersion from a MachineImage
+func DetermineLatestMachineImageVersion(image core.MachineImage) (core.ExpirableVersion, error) {
+	var (
+		latestSemVerVersion       *semver.Version
+		latestMachineImageVersion core.ExpirableVersion
+	)
+
+	for _, imageVersion := range image.Versions {
+		v, err := semver.NewVersion(imageVersion.Version)
+		if err != nil {
+			return core.ExpirableVersion{}, fmt.Errorf("error while parsing machine image version '%s' of machine image '%s': version not valid: %s", imageVersion.Version, image.Name, err.Error())
+		}
+		if latestSemVerVersion == nil || v.GreaterThan(latestSemVerVersion) {
+			latestSemVerVersion = v
+			latestMachineImageVersion = imageVersion
+		}
+	}
+	return latestMachineImageVersion, nil
+}
+
+// ShootWantsBasicAuthentication returns true if basic authentication is not configured or
+// if it is set explicitly to 'true'.
+func ShootWantsBasicAuthentication(kubeAPIServerConfig *core.KubeAPIServerConfig) bool {
+	if kubeAPIServerConfig == nil {
+		return true
+	}
+	if kubeAPIServerConfig.EnableBasicAuthentication == nil {
+		return true
+	}
+	return *kubeAPIServerConfig.EnableBasicAuthentication
+}
+
+// TaintsHave returns true if the given key is part of the taints list.
+func TaintsHave(taints []core.SeedTaint, key string) bool {
+	for _, taint := range taints {
+		if taint.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// ShootUsesUnmanagedDNS returns true if the shoot's DNS section is marked as 'unmanaged'.
+func ShootUsesUnmanagedDNS(shoot *core.Shoot) bool {
+	return shoot.Spec.DNS != nil && len(shoot.Spec.DNS.Providers) > 0 && shoot.Spec.DNS.Providers[0].Type != nil && *shoot.Spec.DNS.Providers[0].Type == core.DNSUnmanaged
+}
+
+// FindWorkerByName tries to find the worker with the given name. If it cannot be found it returns nil.
+func FindWorkerByName(workers []core.Worker, name string) *core.Worker {
+	for _, w := range workers {
+		if w.Name == name {
+			return &w
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/backupbucket.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/backupbucket.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateBackupBucket validates a BackupBucket object.
+func ValidateBackupBucket(backupBucket *core.BackupBucket) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&backupBucket.ObjectMeta, false, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateBackupBucketSpec(&backupBucket.Spec, field.NewPath("spec"))...)
+
+	return allErrs
+}
+
+// ValidateBackupBucketUpdate validates a BackupBucket object before an update.
+func ValidateBackupBucketUpdate(newBackupBucket, oldBackupBucket *core.BackupBucket) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newBackupBucket.ObjectMeta, &oldBackupBucket.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateBackupBucketSpecUpdate(&newBackupBucket.Spec, &oldBackupBucket.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateBackupBucket(newBackupBucket)...)
+
+	return allErrs
+}
+
+// ValidateBackupBucketSpec validates the specification of a BackupBucket object.
+func ValidateBackupBucketSpec(spec *core.BackupBucketSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(spec.Provider.Type) == 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("provider.type"), spec.Provider.Type, "type name must not be empty"))
+	}
+	if len(spec.Provider.Region) == 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("provider.region"), spec.Provider.Region, "region must not be empty"))
+	}
+
+	if spec.SeedName == nil || len(*spec.SeedName) == 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("seedName"), spec.SeedName, "seed must not be empty"))
+	}
+
+	allErrs = append(allErrs, validateSecretReference(spec.SecretRef, fldPath.Child("secretRef"))...)
+
+	return allErrs
+}
+
+// ValidateBackupBucketSpecUpdate validates the specification of a BackupBucket object.
+func ValidateBackupBucketSpecUpdate(newSpec, oldSpec *core.BackupBucketSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Provider, oldSpec.Provider, fldPath.Child("provider"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.SeedName, oldSpec.SeedName, fldPath.Child("seedName"))...)
+
+	return allErrs
+}
+
+// ValidateBackupBucketStatusUpdate validates the status field of a BackupBucket object.
+func ValidateBackupBucketStatusUpdate(newBackupBucket, oldBackupBucket *core.BackupBucket) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	return allErrs
+}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/backupentry.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/backupentry.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateBackupEntry validates a BackupEntry object.
+func ValidateBackupEntry(backupEntry *core.BackupEntry) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&backupEntry.ObjectMeta, true, validateBackupEntryName, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateBackupEntrySpec(&backupEntry.Spec, field.NewPath("spec"))...)
+
+	return allErrs
+}
+
+// ValidateBackupEntryUpdate validates a BackupEntry object before an update.
+func ValidateBackupEntryUpdate(newBackupEntry, oldBackupEntry *core.BackupEntry) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newBackupEntry.ObjectMeta, &oldBackupEntry.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateBackupEntrySpecUpdate(&newBackupEntry.Spec, &oldBackupEntry.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateBackupEntry(newBackupEntry)...)
+
+	return allErrs
+}
+
+// ValidateBackupEntrySpec validates the specification of a BackupEntry object.
+func ValidateBackupEntrySpec(spec *core.BackupEntrySpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(spec.BucketName) == 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("bucketName"), spec.BucketName, "bucketName must not be empty"))
+	}
+
+	return allErrs
+}
+
+// ValidateBackupEntrySpecUpdate validates the specification of a BackupEntry object.
+func ValidateBackupEntrySpecUpdate(newSpec, oldSpec *core.BackupEntrySpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.BucketName, oldSpec.BucketName, fldPath.Child("bucketName"))...)
+
+	return allErrs
+}
+
+// ValidateBackupEntryStatusUpdate validates the status field of a BackupEntry object.
+func ValidateBackupEntryStatusUpdate(newBackupEntry, oldBackupEntry *core.BackupEntry) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	return allErrs
+}
+
+func validateBackupEntryName(name string, prefix bool) []string {
+	return []string{}
+}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/cloudprofile.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/cloudprofile.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/helper"
+	"github.com/gardener/gardener/pkg/utils"
+
+	"github.com/Masterminds/semver"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateCloudProfile validates a CloudProfile object.
+func ValidateCloudProfile(cloudProfile *core.CloudProfile) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&cloudProfile.ObjectMeta, false, ValidateName, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateCloudProfileSpec(&cloudProfile.Spec, field.NewPath("spec"))...)
+
+	return allErrs
+}
+
+// ValidateCloudProfileUpdate validates a CloudProfile object before an update.
+func ValidateCloudProfileUpdate(newProfile, oldProfile *core.CloudProfile) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newProfile.ObjectMeta, &oldProfile.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateCloudProfile(newProfile)...)
+
+	return allErrs
+}
+
+// ValidateCloudProfileSpec validates the specification of a CloudProfile object.
+func ValidateCloudProfileSpec(spec *core.CloudProfileSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(spec.Type) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "must provide a provider type"))
+	}
+
+	allErrs = append(allErrs, validateKubernetesSettings(spec.Kubernetes, fldPath.Child("kubernetes"))...)
+	allErrs = append(allErrs, validateMachineImages(spec.MachineImages, fldPath.Child("machineImages"))...)
+	allErrs = append(allErrs, validateMachineTypes(spec.MachineTypes, fldPath.Child("machineTypes"))...)
+	allErrs = append(allErrs, validateVolumeTypes(spec.VolumeTypes, fldPath.Child("volumeTypes"))...)
+	allErrs = append(allErrs, validateRegions(spec.Regions, fldPath.Child("regions"))...)
+	if spec.SeedSelector != nil {
+		allErrs = append(allErrs, metav1validation.ValidateLabelSelector(spec.SeedSelector, fldPath.Child("seedSelector"))...)
+	}
+
+	if spec.CABundle != nil {
+		_, err := utils.DecodeCertificate([]byte(*(spec.CABundle)))
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("caBundle"), *(spec.CABundle), "caBundle is not a valid PEM-encoded certificate"))
+		}
+	}
+
+	return allErrs
+}
+
+func validateKubernetesSettings(kubernetes core.KubernetesSettings, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if len(kubernetes.Versions) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("versions"), "must provide at least one Kubernetes version"))
+	}
+	latestKubernetesVersion, err := helper.DetermineLatestExpirableVersion(kubernetes.Versions)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, latestKubernetesVersion, "failed to determine latest kubernetes version from cloud profile"))
+	}
+	if latestKubernetesVersion.ExpirationDate != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("versions[]").Child("expirationDate"), latestKubernetesVersion.ExpirationDate, fmt.Sprintf("expiration date of latest kubernetes version ('%s') must not be set", latestKubernetesVersion.Version)))
+	}
+
+	versionsFound := sets.NewString()
+	r, _ := regexp.Compile(`^([0-9]+\.){2}[0-9]+$`)
+	for i, version := range kubernetes.Versions {
+		idxPath := fldPath.Child("versions").Index(i)
+		if !r.MatchString(version.Version) {
+			allErrs = append(allErrs, field.Invalid(idxPath, version, fmt.Sprintf("all Kubernetes versions must match the regex %s", r)))
+		} else if versionsFound.Has(version.Version) {
+			allErrs = append(allErrs, field.Duplicate(idxPath.Child("version"), version.Version))
+		} else {
+			versionsFound.Insert(version.Version)
+		}
+	}
+
+	return allErrs
+}
+
+func validateMachineTypes(machineTypes []core.MachineType, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(machineTypes) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath, "must provide at least one machine type"))
+	}
+
+	names := make(map[string]struct{}, len(machineTypes))
+
+	for i, machineType := range machineTypes {
+		idxPath := fldPath.Index(i)
+		namePath := idxPath.Child("name")
+		cpuPath := idxPath.Child("cpu")
+		gpuPath := idxPath.Child("gpu")
+		memoryPath := idxPath.Child("memory")
+
+		if len(machineType.Name) == 0 {
+			allErrs = append(allErrs, field.Required(namePath, "must provide a name"))
+		}
+
+		if _, ok := names[machineType.Name]; ok {
+			allErrs = append(allErrs, field.Duplicate(namePath, machineType.Name))
+			break
+		}
+		names[machineType.Name] = struct{}{}
+
+		allErrs = append(allErrs, validateResourceQuantityValue("cpu", machineType.CPU, cpuPath)...)
+		allErrs = append(allErrs, validateResourceQuantityValue("gpu", machineType.GPU, gpuPath)...)
+		allErrs = append(allErrs, validateResourceQuantityValue("memory", machineType.Memory, memoryPath)...)
+	}
+
+	return allErrs
+}
+
+func validateMachineImages(machineImages []core.MachineImage, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(machineImages) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath, "must provide at least one machine image"))
+	}
+
+	latestMachineImages, err := helper.DetermineLatestMachineImageVersions(machineImages)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, latestMachineImages, "failed to determine latest machine images from cloud profile"))
+	}
+
+	for imageName, latestImage := range latestMachineImages {
+		if latestImage.ExpirationDate != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("expirationDate"), latestImage.ExpirationDate, fmt.Sprintf("expiration date of latest image ('%s','%s') must not be set", imageName, latestImage.Version)))
+		}
+	}
+
+	duplicateNameVersion := sets.String{}
+	duplicateName := sets.String{}
+	for i, image := range machineImages {
+		idxPath := fldPath.Index(i)
+		if duplicateName.Has(image.Name) {
+			allErrs = append(allErrs, field.Duplicate(idxPath, image.Name))
+		}
+		duplicateName.Insert(image.Name)
+
+		if len(image.Name) == 0 {
+			allErrs = append(allErrs, field.Required(idxPath.Child("name"), "machine image name must not be empty"))
+		}
+
+		if len(image.Versions) == 0 {
+			allErrs = append(allErrs, field.Required(idxPath.Child("versions"), fmt.Sprintf("must provide at least one version for the machine image '%s'", image.Name)))
+		}
+
+		for index, machineVersion := range image.Versions {
+			versionsPath := idxPath.Child("versions").Index(index)
+			key := fmt.Sprintf("%s-%s", image.Name, machineVersion.Version)
+			if duplicateNameVersion.Has(key) {
+				allErrs = append(allErrs, field.Duplicate(versionsPath, key))
+			}
+			duplicateNameVersion.Insert(key)
+			if len(machineVersion.Version) == 0 {
+				allErrs = append(allErrs, field.Required(versionsPath.Child("version"), machineVersion.Version))
+			}
+
+			_, err := semver.NewVersion(machineVersion.Version)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(versionsPath.Child("version"), machineVersion.Version, "could not parse version. Use SemanticVersioning. In case there is no semVer version for this image use the extensibility provider (define mapping in the ControllerRegistration) to map to the actual non-semVer version"))
+			}
+		}
+	}
+
+	return allErrs
+}
+
+func validateVolumeTypes(volumeTypes []core.VolumeType, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	names := make(map[string]struct{}, len(volumeTypes))
+
+	for i, volumeType := range volumeTypes {
+		idxPath := fldPath.Index(i)
+		namePath := idxPath.Child("name")
+		classPath := idxPath.Child("class")
+
+		if len(volumeType.Name) == 0 {
+			allErrs = append(allErrs, field.Required(namePath, "must provide a name"))
+		}
+
+		if _, ok := names[volumeType.Name]; ok {
+			allErrs = append(allErrs, field.Duplicate(namePath, volumeType.Name))
+			break
+		}
+		names[volumeType.Name] = struct{}{}
+
+		if len(volumeType.Class) == 0 {
+			allErrs = append(allErrs, field.Required(classPath, "must provide a class"))
+		}
+	}
+
+	return allErrs
+}
+
+func validateRegions(regions []core.Region, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(regions) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath, "must provide at least one region"))
+	}
+
+	regionsFound := sets.NewString()
+	for i, region := range regions {
+		idxPath := fldPath.Index(i)
+		namePath := idxPath.Child("name")
+		zonesPath := idxPath.Child("zones")
+
+		if len(region.Name) == 0 {
+			allErrs = append(allErrs, field.Required(namePath, "must provide a region name"))
+		} else if regionsFound.Has(region.Name) {
+			allErrs = append(allErrs, field.Duplicate(namePath, region.Name))
+		} else {
+			regionsFound.Insert(region.Name)
+		}
+
+		zonesFound := sets.NewString()
+		for j, zone := range region.Zones {
+			namePath := zonesPath.Index(j).Child("name")
+			if len(zone.Name) == 0 {
+				allErrs = append(allErrs, field.Required(namePath, "zone name cannot be empty"))
+			} else if zonesFound.Has(zone.Name) {
+				allErrs = append(allErrs, field.Duplicate(namePath, zone.Name))
+			} else {
+				zonesFound.Insert(zone.Name)
+			}
+		}
+	}
+	return allErrs
+}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/controllerinstallation.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/controllerinstallation.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateControllerInstallation validates a ControllerInstallation object.
+func ValidateControllerInstallation(controllerInstallation *core.ControllerInstallation) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&controllerInstallation.ObjectMeta, false, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateControllerInstallationSpec(&controllerInstallation.Spec, field.NewPath("spec"))...)
+
+	return allErrs
+}
+
+// ValidateControllerInstallationUpdate validates a ControllerInstallation object before an update.
+func ValidateControllerInstallationUpdate(new, old *core.ControllerInstallation) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateControllerInstallationSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateControllerInstallation(new)...)
+
+	return allErrs
+}
+
+// ValidateControllerInstallationSpec validates the specification of a ControllerInstallation object.
+func ValidateControllerInstallationSpec(spec *core.ControllerInstallationSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	registrationRefPath := fldPath.Child("registrationRef")
+	if len(spec.RegistrationRef.Name) == 0 {
+		allErrs = append(allErrs, field.Required(registrationRefPath.Child("name"), "field is required"))
+	}
+
+	seedRef := fldPath.Child("seedRef")
+	if len(spec.SeedRef.Name) == 0 {
+		allErrs = append(allErrs, field.Required(seedRef.Child("name"), "field is required"))
+	}
+
+	return allErrs
+}
+
+// ValidateControllerInstallationSpecUpdate validates the spec of a ControllerInstallation object before an update.
+func ValidateControllerInstallationSpecUpdate(new, old *core.ControllerInstallationSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new, old, fldPath)...)
+		return allErrs
+	}
+
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.RegistrationRef.Name, old.RegistrationRef.Name, fldPath.Child("registrationRef", "name"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.SeedRef.Name, old.SeedRef.Name, fldPath.Child("seedRef", "name"))...)
+
+	return allErrs
+}
+
+// ValidateControllerInstallationStatus validates the status of a ControllerInstallation object.
+func ValidateControllerInstallationStatus(spec *core.ControllerInstallationStatus, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	return allErrs
+}
+
+// ValidateControllerInstallationStatusUpdate validates the status field of a ControllerInstallation object.
+func ValidateControllerInstallationStatusUpdate(newStatus, oldStatus core.ControllerInstallationStatus) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	return allErrs
+}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/controllerregistration.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/controllerregistration.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateControllerRegistration validates a ControllerRegistration object.
+func ValidateControllerRegistration(controllerRegistration *core.ControllerRegistration) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&controllerRegistration.ObjectMeta, false, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateControllerRegistrationSpec(&controllerRegistration.Spec, field.NewPath("spec"))...)
+
+	return allErrs
+}
+
+// ValidateControllerRegistrationSpec validates the specification of a ControllerRegistration object.
+func ValidateControllerRegistrationSpec(spec *core.ControllerRegistrationSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	var (
+		resources     = make(map[string]string, len(spec.Resources))
+		resourcesPath = fldPath.Child("resources")
+	)
+
+	for i, resource := range spec.Resources {
+		idxPath := resourcesPath.Index(i)
+
+		if len(resource.Kind) == 0 {
+			allErrs = append(allErrs, field.Required(idxPath.Child("kind"), "field is required"))
+		}
+		if len(resource.Type) == 0 {
+			allErrs = append(allErrs, field.Required(idxPath.Child("type"), "field is required"))
+		}
+		if t, ok := resources[resource.Kind]; ok && t == resource.Type {
+			allErrs = append(allErrs, field.Duplicate(idxPath, fmt.Sprintf("%s/%s", resource.Kind, resource.Type)))
+		}
+		if resource.GloballyEnabled != nil && resource.Kind != v1alpha1.ExtensionResource {
+			allErrs = append(allErrs, field.Forbidden(idxPath.Child("globallyEnabled"), fmt.Sprintf("field must not be set when kind != %s", v1alpha1.ExtensionResource)))
+		}
+
+		resources[resource.Kind] = resource.Type
+	}
+
+	return allErrs
+}
+
+// ValidateControllerRegistrationUpdate validates a ControllerRegistration object before an update.
+func ValidateControllerRegistrationUpdate(new, old *core.ControllerRegistration) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateControllerRegistrationSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateControllerRegistration(new)...)
+
+	return allErrs
+}
+
+func ValidateControllerRegistrationSpecUpdate(new, old *core.ControllerRegistrationSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new, old, fldPath)...)
+		return allErrs
+	}
+
+	return allErrs
+}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/plant.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/plant.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidatePlant validates a Plant object.
+func ValidatePlant(plant *core.Plant) field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&plant.ObjectMeta, true, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidatePlantSpec(&plant.Spec, field.NewPath("spec"))...)
+
+	return allErrs
+}
+
+// ValidatePlantUpdate validates a Plant object before an update.
+func ValidatePlantUpdate(new, old *core.Plant) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidatePlantSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidatePlant(new)...)
+
+	return allErrs
+}
+
+// ValidatePlantSpec validates the specification of a Plant object.
+func ValidatePlantSpec(spec *core.PlantSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	registrationRefPath := fldPath.Child("secretRef")
+	if len(spec.SecretRef.Name) == 0 {
+		allErrs = append(allErrs, field.Required(registrationRefPath.Child("name"), "field is required"))
+	}
+
+	return allErrs
+}
+
+// ValidatePlantSpecUpdate validates the spec of a Plant object before an update.
+func ValidatePlantSpecUpdate(new, old *core.PlantSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new, old, fldPath)...)
+		return allErrs
+	}
+
+	return allErrs
+}
+
+// ValidatePlantStatus validates the status of a Plant object.
+func ValidatePlantStatus(spec *core.PlantStatus, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	return allErrs
+}
+
+// ValidatePlantStatusUpdate validates the status field of a Plant object.
+func ValidatePlantStatusUpdate(newStatus, oldStatus core.PlantStatus) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	return allErrs
+}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/project.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/project.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateProject validates a Project object.
+func ValidateProject(project *core.Project) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&project.ObjectMeta, false, ValidateName, field.NewPath("metadata"))...)
+	maxProjectNameLength := 10
+	if len(project.Name) > maxProjectNameLength {
+		allErrs = append(allErrs, field.TooLong(field.NewPath("metadata", "name"), project.Name, maxProjectNameLength))
+	}
+	allErrs = append(allErrs, validateNameConsecutiveHyphens(project.Name, field.NewPath("metadata", "name"))...)
+	allErrs = append(allErrs, ValidateProjectSpec(&project.Spec, field.NewPath("spec"))...)
+
+	return allErrs
+}
+
+// ValidateProjectUpdate validates a Project object before an update.
+func ValidateProjectUpdate(newProject, oldProject *core.Project) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newProject.ObjectMeta, &oldProject.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateProject(newProject)...)
+
+	if oldProject.Spec.CreatedBy != nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProject.Spec.CreatedBy, oldProject.Spec.CreatedBy, field.NewPath("spec", "createdBy"))...)
+	}
+	if oldProject.Spec.Namespace != nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProject.Spec.Namespace, oldProject.Spec.Namespace, field.NewPath("spec", "namespace"))...)
+	}
+	if oldProject.Spec.Owner != nil && newProject.Spec.Owner == nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "owner"), newProject.Spec.Owner, "owner cannot be reset"))
+	}
+
+	return allErrs
+}
+
+// ValidateProjectSpec validates the specification of a Project object.
+func ValidateProjectSpec(projectSpec *core.ProjectSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for i, member := range projectSpec.Members {
+		allErrs = append(allErrs, ValidateSubject(member.Subject, fldPath.Child("members").Index(i))...)
+	}
+	if createdBy := projectSpec.CreatedBy; createdBy != nil {
+		allErrs = append(allErrs, ValidateSubject(*createdBy, fldPath.Child("createdBy"))...)
+	}
+	if owner := projectSpec.Owner; owner != nil {
+		allErrs = append(allErrs, ValidateSubject(*owner, fldPath.Child("owner"))...)
+	}
+	if description := projectSpec.Description; description != nil && len(*description) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("description"), "must provide a description when key is present"))
+	}
+	if purpose := projectSpec.Description; purpose != nil && len(*purpose) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("purpose"), "must provide a purpose when key is present"))
+	}
+
+	return allErrs
+}
+
+// ValidateSubject validates the subject representing the owner.
+func ValidateSubject(subject rbacv1.Subject, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(subject.Name) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), ""))
+	}
+
+	switch subject.Kind {
+	case rbacv1.ServiceAccountKind:
+		if len(subject.Name) > 0 {
+			for _, msg := range apivalidation.ValidateServiceAccountName(subject.Name, false) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), subject.Name, msg))
+			}
+		}
+		if len(subject.APIGroup) > 0 {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("apiGroup"), subject.APIGroup, []string{""}))
+		}
+		if len(subject.Namespace) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("namespace"), ""))
+		}
+
+	case rbacv1.UserKind, rbacv1.GroupKind:
+		if subject.APIGroup != rbacv1.GroupName {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("apiGroup"), subject.APIGroup, []string{rbacv1.GroupName}))
+		}
+
+	default:
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("kind"), subject.Kind, []string{rbacv1.ServiceAccountKind, rbacv1.UserKind, rbacv1.GroupKind}))
+	}
+
+	return allErrs
+}
+
+// ValidateProjectStatusUpdate validates the status field of a Project object.
+func ValidateProjectStatusUpdate(newProject, oldProject *core.Project) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(oldProject.Status.Phase) > 0 && len(newProject.Status.Phase) == 0 {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("status").Child("phase"), "phase cannot be updated to an empty string"))
+	}
+
+	return allErrs
+}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/quota.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/quota.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/helper"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateQuota validates a Quota object.
+func ValidateQuota(quota *core.Quota) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&quota.ObjectMeta, true, ValidateName, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateQuotaSpec(&quota.Spec, field.NewPath("spec"))...)
+
+	return allErrs
+}
+
+// ValidateQuotaUpdate validates a Quota object before an update.
+func ValidateQuotaUpdate(newQuota, oldQuota *core.Quota) field.ErrorList {
+	allErrs := apivalidation.ValidateObjectMetaUpdate(&newQuota.ObjectMeta, &oldQuota.ObjectMeta, field.NewPath("metadata"))
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(&newQuota.Spec.Scope, &oldQuota.Spec.Scope, field.NewPath("spec").Child("scope"))...)
+	allErrs = append(allErrs, ValidateQuota(newQuota)...)
+	return allErrs
+}
+
+// ValidateQuotaStatusUpdate validates the status field of a Quota object.
+func ValidateQuotaStatusUpdate(newQuota, oldQuota *core.Quota) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	return allErrs
+}
+
+// ValidateQuotaSpec validates the specification of a Quota object.
+func ValidateQuotaSpec(quotaSpec *core.QuotaSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	scopeRef := quotaSpec.Scope
+	if _, err := helper.QuotaScope(scopeRef); err != nil {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("scope"), scopeRef, []string{"project", "secret"}))
+	}
+
+	metricsFldPath := fldPath.Child("metrics")
+	for k, v := range quotaSpec.Metrics {
+		keyPath := metricsFldPath.Key(string(k))
+		if !isValidQuotaMetric(corev1.ResourceName(k)) {
+			allErrs = append(allErrs, field.Invalid(keyPath, v.String(), fmt.Sprintf("%s is no supported quota metric", string(k))))
+		}
+		allErrs = append(allErrs, validateResourceQuantityValue(string(k), v, keyPath)...)
+	}
+
+	return allErrs
+}
+
+func isValidQuotaMetric(metric corev1.ResourceName) bool {
+	switch metric {
+	case
+		core.QuotaMetricCPU,
+		core.QuotaMetricGPU,
+		core.QuotaMetricMemory,
+		core.QuotaMetricStorageStandard,
+		core.QuotaMetricStoragePremium,
+		core.QuotaMetricLoadbalancer:
+		return true
+	}
+	return false
+}
+
+// validateResourceQuantityValue validates the value of a resource quantity.
+func validateResourceQuantityValue(key string, value resource.Quantity, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if value.Cmp(resource.Quantity{}) < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath, value.String(), fmt.Sprintf("%s value must not be negative", key)))
+	}
+
+	return allErrs
+}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/secretbinding.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/secretbinding.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core"
+
+	corev1 "k8s.io/api/core/v1"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateSecretBinding validates a SecretBinding object.
+func ValidateSecretBinding(binding *core.SecretBinding) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&binding.ObjectMeta, true, ValidateName, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, validateSecretReferenceOptionalNamespace(binding.SecretRef, field.NewPath("secretRef"))...)
+	for i, quota := range binding.Quotas {
+		allErrs = append(allErrs, validateObjectReferenceOptionalNamespace(quota, field.NewPath("quotas").Index(i))...)
+	}
+
+	return allErrs
+}
+
+// ValidateSecretBindingUpdate validates a SecretBinding object before an update.
+func ValidateSecretBindingUpdate(newBinding, oldBinding *core.SecretBinding) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newBinding.ObjectMeta, &oldBinding.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newBinding.SecretRef, oldBinding.SecretRef, field.NewPath("secretRef"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newBinding.Quotas, oldBinding.Quotas, field.NewPath("quotas"))...)
+	allErrs = append(allErrs, ValidateSecretBinding(newBinding)...)
+
+	return allErrs
+}
+
+func validateAuditPolicyConfigMapReference(ref *corev1.ObjectReference, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(ref.Name) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "must provide a name"))
+	}
+
+	return allErrs
+}
+
+func validateObjectReferenceOptionalNamespace(ref corev1.ObjectReference, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(ref.Name) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "must provide a name"))
+	}
+
+	return allErrs
+}
+
+func validateSecretReferenceOptionalNamespace(ref corev1.SecretReference, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(ref.Name) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "must provide a name"))
+	}
+
+	return allErrs
+}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/seed.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/seed.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/operation/common"
+	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
+
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateSeed validates a Seed object.
+func ValidateSeed(seed *core.Seed) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&seed.ObjectMeta, false, ValidateName, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateSeedSpec(&seed.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateSeedAnnotation(seed.ObjectMeta.Annotations, field.NewPath("metadata", "annotations"))...)
+
+	return allErrs
+}
+
+// ValidateSeedUpdate validates a Seed object before an update.
+func ValidateSeedUpdate(newSeed, oldSeed *core.Seed) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newSeed.ObjectMeta, &oldSeed.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateSeedSpecUpdate(&newSeed.Spec, &oldSeed.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateSeed(newSeed)...)
+
+	return allErrs
+}
+
+//ValidateSeedAnnotation validates the annotations of seed
+func ValidateSeedAnnotation(annotations map[string]string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if annotations != nil {
+		if v, ok := annotations[common.AnnotatePersistentVolumeMinimumSize]; ok {
+			volumeSizeRegex, _ := regexp.Compile(`^(\d)+Gi$`)
+			if !volumeSizeRegex.MatchString(v) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Key(common.AnnotatePersistentVolumeMinimumSize), v, fmt.Sprintf("volume size must match the regex %s", volumeSizeRegex)))
+			}
+		}
+	}
+	return allErrs
+}
+
+// ValidateSeedSpec validates the specification of a Seed object.
+func ValidateSeedSpec(seedSpec *core.SeedSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	providerPath := fldPath.Child("provider")
+	if len(seedSpec.Provider.Type) == 0 {
+		allErrs = append(allErrs, field.Required(providerPath.Child("type"), "must provide a provider type"))
+	}
+	if len(seedSpec.Provider.Region) == 0 {
+		allErrs = append(allErrs, field.Required(providerPath.Child("region"), "must provide a provider region"))
+	}
+
+	allErrs = append(allErrs, validateDNS1123Subdomain(seedSpec.DNS.IngressDomain, fldPath.Child("dns", "ingressDomain"))...)
+	if seedSpec.SecretRef != nil {
+		allErrs = append(allErrs, validateSecretReference(*seedSpec.SecretRef, fldPath.Child("secretRef"))...)
+	}
+
+	networksPath := fldPath.Child("networks")
+
+	networks := []cidrvalidation.CIDR{
+		cidrvalidation.NewCIDR(seedSpec.Networks.Pods, networksPath.Child("pods")),
+		cidrvalidation.NewCIDR(seedSpec.Networks.Services, networksPath.Child("services")),
+	}
+	if seedSpec.Networks.Nodes != nil {
+		networks = append(networks, cidrvalidation.NewCIDR(*seedSpec.Networks.Nodes, networksPath.Child("nodes")))
+	}
+	if shootDefaults := seedSpec.Networks.ShootDefaults; shootDefaults != nil {
+		if shootDefaults.Pods != nil {
+			networks = append(networks, cidrvalidation.NewCIDR(*shootDefaults.Pods, networksPath.Child("shootDefaults", "pods")))
+		}
+		if shootDefaults.Services != nil {
+			networks = append(networks, cidrvalidation.NewCIDR(*shootDefaults.Services, networksPath.Child("shootDefaults", "services")))
+		}
+	}
+
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(networks...)...)
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(networks, networks, false)...)
+
+	if seedSpec.Backup != nil {
+		if len(seedSpec.Backup.Provider) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("backup", "provider"), "must provide a backup cloud provider name"))
+		}
+
+		if seedSpec.Provider.Type != seedSpec.Backup.Provider && (seedSpec.Backup.Region == nil || len(*seedSpec.Backup.Region) == 0) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("backup", "region"), "", "region must be specified for if backup provider is different from provider used in `spec.cloud`"))
+		}
+
+		allErrs = append(allErrs, validateSecretReference(seedSpec.Backup.SecretRef, fldPath.Child("backup", "secretRef"))...)
+	}
+
+	var (
+		supportedTaintKeys = sets.NewString(core.SeedTaintDisableCapacityReservation, core.SeedTaintDisableDNS, core.SeedTaintProtected, core.SeedTaintInvisible, core.SeedTaintDisableCapacityReservation)
+		foundTaintKeys     = sets.NewString()
+	)
+
+	for i, taint := range seedSpec.Taints {
+		idxPath := fldPath.Child("taints").Index(i)
+		if len(taint.Key) == 0 {
+			allErrs = append(allErrs, field.Required(idxPath.Child("key"), "cannot be empty"))
+		}
+		if foundTaintKeys.Has(taint.Key) {
+			allErrs = append(allErrs, field.Duplicate(idxPath.Child("key"), taint.Key))
+		}
+		if !supportedTaintKeys.Has(taint.Key) {
+			allErrs = append(allErrs, field.NotSupported(idxPath.Child("key"), taint.Key, supportedTaintKeys.List()))
+		}
+		foundTaintKeys.Insert(taint.Key)
+	}
+
+	if seedSpec.Volume != nil {
+		if seedSpec.Volume.MinimumSize != nil {
+			allErrs = append(allErrs, validateResourceQuantityValue("minimumSize", *seedSpec.Volume.MinimumSize, fldPath.Child("volume", "minimumSize"))...)
+		}
+
+		volumeProviderPurposes := make(map[string]struct{}, len(seedSpec.Volume.Providers))
+		for i, provider := range seedSpec.Volume.Providers {
+			idxPath := fldPath.Child("volume", "providers").Index(i)
+			if len(provider.Purpose) == 0 {
+				allErrs = append(allErrs, field.Required(idxPath.Child("purpose"), "cannot be empty"))
+			}
+			if len(provider.Name) == 0 {
+				allErrs = append(allErrs, field.Required(idxPath.Child("name"), "cannot be empty"))
+			}
+			if _, ok := volumeProviderPurposes[provider.Purpose]; ok {
+				allErrs = append(allErrs, field.Duplicate(idxPath.Child("purpose"), provider.Purpose))
+			}
+			volumeProviderPurposes[provider.Purpose] = struct{}{}
+		}
+	}
+
+	return allErrs
+}
+
+func validateCIDR(cidr string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if _, _, err := net.ParseCIDR(string(cidr)); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, cidr, err.Error()))
+	}
+
+	return allErrs
+}
+
+// ValidateSeedSpecUpdate validates the specification updates of a Seed object.
+func ValidateSeedSpecUpdate(newSeedSpec, oldSeedSpec *core.SeedSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Networks.Pods, oldSeedSpec.Networks.Pods, fldPath.Child("networks", "pods"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Networks.Services, oldSeedSpec.Networks.Services, fldPath.Child("networks", "services"))...)
+	if oldSeedSpec.Networks.Nodes != nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Networks.Nodes, oldSeedSpec.Networks.Nodes, fldPath.Child("networks", "nodes"))...)
+	}
+
+	if oldSeedSpec.Backup != nil {
+		if newSeedSpec.Backup != nil {
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Backup.Provider, oldSeedSpec.Backup.Provider, fldPath.Child("backup", "provider"))...)
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Backup.Region, oldSeedSpec.Backup.Region, fldPath.Child("backup", "region"))...)
+		} else {
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Backup, oldSeedSpec.Backup, fldPath.Child("backup"))...)
+		}
+	}
+	// If oldSeedSpec doesn't have backup configured, we allow to add it; but not the vice versa.
+
+	return allErrs
+}
+
+// ValidateSeedStatusUpdate validates the status field of a Seed object.
+func ValidateSeedStatusUpdate(newSeed, oldSeed *core.Seed) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	return allErrs
+}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/shoot.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/shoot.go
@@ -1,0 +1,1047 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/helper"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/utils"
+	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
+
+	"github.com/Masterminds/semver"
+	"github.com/robfig/cron"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var (
+	availableProxyMode = sets.NewString(
+		string(core.ProxyModeIPTables),
+		string(core.ProxyModeIPVS),
+	)
+	availableKubernetesDashboardAuthenticationModes = sets.NewString(
+		core.KubernetesDashboardAuthModeBasic,
+		core.KubernetesDashboardAuthModeToken,
+	)
+	availableNginxIngressExternalTrafficPolicies = sets.NewString(
+		string(corev1.ServiceExternalTrafficPolicyTypeCluster),
+		string(corev1.ServiceExternalTrafficPolicyTypeLocal),
+	)
+	availableShootPurposes = sets.NewString(
+		string(core.ShootPurposeEvaluation),
+		string(core.ShootPurposeTesting),
+		string(core.ShootPurposeDevelopment),
+		string(core.ShootPurposeProduction),
+	)
+)
+
+// ValidateShoot validates a Shoot object.
+func ValidateShoot(shoot *core.Shoot) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&shoot.ObjectMeta, true, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, validateNameConsecutiveHyphens(shoot.Name, field.NewPath("metadata", "name"))...)
+	allErrs = append(allErrs, ValidateShootSpec(shoot.ObjectMeta, &shoot.Spec, field.NewPath("spec"))...)
+
+	return allErrs
+}
+
+// ValidateShootUpdate validates a Shoot object before an update.
+func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newShoot.ObjectMeta, &oldShoot.ObjectMeta, field.NewPath("metadata"))...)
+
+	// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.
+	if metav1.HasAnnotation(oldShoot.ObjectMeta, common.ShootExperimentalAddonKyma) && !metav1.HasAnnotation(newShoot.ObjectMeta, common.ShootExperimentalAddonKyma) {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("metadata", "annotations", common.ShootExperimentalAddonKyma), "experimental kyma addon can not be removed/uninstalled - please delete your cluster if you want to get rid of it"))
+	}
+
+	allErrs = append(allErrs, ValidateShootSpecUpdate(&newShoot.Spec, &oldShoot.Spec, newShoot.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateShoot(newShoot)...)
+
+	return allErrs
+}
+
+// ValidateShootSpec validates the specification of a Shoot object.
+func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, validateAddons(spec.Addons, spec.Kubernetes.KubeAPIServer, fldPath.Child("addons"))...)
+	allErrs = append(allErrs, validateDNS(spec.DNS, fldPath.Child("dns"))...)
+	allErrs = append(allErrs, validateExtensions(spec.Extensions, fldPath.Child("extensions"))...)
+	allErrs = append(allErrs, validateKubernetes(spec.Kubernetes, fldPath.Child("kubernetes"))...)
+	allErrs = append(allErrs, validateNetworking(spec.Networking, fldPath.Child("networking"))...)
+	allErrs = append(allErrs, validateMaintenance(spec.Maintenance, fldPath.Child("maintenance"))...)
+	allErrs = append(allErrs, validateMonitoring(spec.Monitoring, fldPath.Child("monitoring"))...)
+	allErrs = append(allErrs, ValidateHibernation(spec.Hibernation, fldPath.Child("hibernation"))...)
+	allErrs = append(allErrs, validateProvider(spec.Provider, spec.Kubernetes, fldPath.Child("provider"))...)
+
+	if len(spec.Region) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("region"), "must specify a region"))
+	}
+	if len(spec.CloudProfileName) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("cloudProfileName"), "must specify a cloud profile"))
+	}
+	if len(spec.SecretBindingName) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("secretBindingName"), "must specify a name"))
+	}
+	if spec.SeedName != nil && len(*spec.SeedName) == 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("seedName"), spec.SeedName, "seed name must not be empty when providing the key"))
+	}
+	if purpose := spec.Purpose; purpose != nil {
+		allowedShootPurposes := availableShootPurposes
+		if meta.Namespace == v1beta1constants.GardenNamespace {
+			allowedShootPurposes = sets.NewString(append(availableShootPurposes.List(), string(core.ShootPurposeInfrastructure))...)
+		}
+
+		if !allowedShootPurposes.Has(string(*purpose)) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("purpose"), *purpose, allowedShootPurposes.List()))
+		}
+	}
+
+	// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.
+	if metav1.HasAnnotation(meta, common.ShootExperimentalAddonKyma) {
+		kubernetesGeq114Less116, err := versionutils.CheckVersionMeetsConstraint(spec.Kubernetes.Version, ">= 1.14, < 1.16")
+		if err != nil {
+			kubernetesGeq114Less116 = false
+		}
+		if !kubernetesGeq114Less116 {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("kubernetes", "version"), "experimental kyma addon needs Kubernetes >= 1.14 and < 1.16"))
+		}
+	}
+
+	return allErrs
+}
+
+// ValidateShootSpecUpdate validates the specification of a Shoot object.
+func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec, oldSpec, fldPath)...)
+		return allErrs
+	}
+
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Region, oldSpec.Region, fldPath.Child("region"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.CloudProfileName, oldSpec.CloudProfileName, fldPath.Child("cloudProfileName"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.SecretBindingName, oldSpec.SecretBindingName, fldPath.Child("secretBindingName"))...)
+	if oldSpec.SeedName != nil {
+		// allow initial seed assignment
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.SeedName, oldSpec.SeedName, fldPath.Child("seedName"))...)
+	}
+
+	seedGotAssigned := oldSpec.SeedName == nil && newSpec.SeedName != nil
+
+	allErrs = append(allErrs, validateDNSUpdate(newSpec.DNS, oldSpec.DNS, seedGotAssigned, fldPath.Child("dns"))...)
+	allErrs = append(allErrs, validateKubernetesVersionUpdate(newSpec.Kubernetes.Version, oldSpec.Kubernetes.Version, fldPath.Child("kubernetes", "version"))...)
+	allErrs = append(allErrs, validateKubeProxyModeUpdate(newSpec.Kubernetes.KubeProxy, oldSpec.Kubernetes.KubeProxy, newSpec.Kubernetes.Version, fldPath.Child("kubernetes", "kubeProxy"))...)
+	allErrs = append(allErrs, validateKubeControllerManagerConfiguration(newSpec.Kubernetes.KubeControllerManager, oldSpec.Kubernetes.KubeControllerManager, fldPath.Child("kubernetes", "kubeControllerManager"))...)
+
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Provider.Type, oldSpec.Provider.Type, fldPath.Child("provider", "type"))...)
+	for i, worker := range newSpec.Provider.Workers {
+		if ShouldEnforceImmutability(worker.Zones, oldSpec.Provider.Workers[i].Zones) {
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(worker.Zones, oldSpec.Provider.Workers[i].Zones, fldPath.Child("provider", "workers").Index(i).Child("zones"))...)
+		}
+	}
+
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Networking.Type, oldSpec.Networking.Type, fldPath.Child("networking", "type"))...)
+	if oldSpec.Networking.Pods != nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Networking.Pods, oldSpec.Networking.Pods, fldPath.Child("networking", "pods"))...)
+	}
+	if oldSpec.Networking.Services != nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Networking.Services, oldSpec.Networking.Services, fldPath.Child("networking", "services"))...)
+	}
+	if oldSpec.Networking.Nodes != nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Networking.Nodes, oldSpec.Networking.Nodes, fldPath.Child("networking", "nodes"))...)
+	}
+
+	return allErrs
+}
+
+// ValidateShootStatusUpdate validates the status field of a Shoot object.
+func ValidateShootStatusUpdate(newStatus, oldStatus core.ShootStatus) field.ErrorList {
+	var (
+		allErrs = field.ErrorList{}
+		fldPath = field.NewPath("status")
+	)
+
+	if len(oldStatus.UID) > 0 {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newStatus.UID, oldStatus.UID, fldPath.Child("uid"))...)
+	}
+	if len(oldStatus.TechnicalID) > 0 {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newStatus.TechnicalID, oldStatus.TechnicalID, fldPath.Child("technicalID"))...)
+	}
+
+	return allErrs
+}
+
+func validateAddons(addons *core.Addons, kubeAPIServerConfig *core.KubeAPIServerConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if addons == nil {
+		return allErrs
+	}
+
+	if addons.NginxIngress != nil && addons.NginxIngress.Enabled {
+		if policy := addons.NginxIngress.ExternalTrafficPolicy; policy != nil {
+			if !availableNginxIngressExternalTrafficPolicies.Has(string(*policy)) {
+				allErrs = append(allErrs, field.NotSupported(fldPath.Child("nginx-ingress", "externalTrafficPolicy"), *policy, availableNginxIngressExternalTrafficPolicies.List()))
+			}
+		}
+	}
+
+	if addons.KubernetesDashboard != nil && addons.KubernetesDashboard.Enabled {
+		if authMode := addons.KubernetesDashboard.AuthenticationMode; authMode != nil {
+			if !availableKubernetesDashboardAuthenticationModes.Has(*authMode) {
+				allErrs = append(allErrs, field.NotSupported(fldPath.Child("kubernetes-dashboard", "authenticationMode"), *authMode, availableKubernetesDashboardAuthenticationModes.List()))
+			}
+
+			if *authMode == core.KubernetesDashboardAuthModeBasic && !helper.ShootWantsBasicAuthentication(kubeAPIServerConfig) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("kubernetes-dashboard", "authenticationMode"), *authMode, "cannot use basic auth mode when basic auth is not enabled in kube-apiserver configuration"))
+			}
+		}
+	}
+
+	return allErrs
+}
+
+// ValidateNodeCIDRMaskWithMaxPod validates if the Pod Network has enough ip addresses (configured via the NodeCIDRMask on the kube controller manager) to support the highest max pod setting on the shoot
+func ValidateNodeCIDRMaskWithMaxPod(maxPod int32, nodeCIDRMaskSize int32) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	free := float64(32 - nodeCIDRMaskSize)
+	// first and last ips are reserved
+	ipAdressesAvailable := int32(math.Pow(2, free) - 2)
+
+	if ipAdressesAvailable < maxPod {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("kubernetes").Child("kubeControllerManager").Child("nodeCIDRMaskSize"), nodeCIDRMaskSize, fmt.Sprintf("kubelet or kube-controller configuration incorrect. Please adjust the NodeCIDRMaskSize of the kube-controller to support the highest maxPod on any worker pool. The NodeCIDRMaskSize of '%d (default: 24)' of the kube-controller only supports '%d' ip adresses. Highest maxPod setting on kubelet is '%d (default: 110)'. Please choose a NodeCIDRMaskSize that at least supports %d ip adresses", nodeCIDRMaskSize, ipAdressesAvailable, maxPod, maxPod)))
+	}
+
+	return allErrs
+}
+
+func validateKubeControllerManagerConfiguration(newConfig, oldConfig *core.KubeControllerManagerConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	var (
+		newSize *int32
+		oldSize *int32
+	)
+
+	if newConfig != nil {
+		newSize = newConfig.NodeCIDRMaskSize
+	}
+	if oldConfig != nil {
+		oldSize = oldConfig.NodeCIDRMaskSize
+	}
+
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSize, oldSize, fldPath.Child("nodeCIDRMaskSize"))...)
+
+	return allErrs
+}
+
+func validateKubeProxyModeUpdate(newConfig, oldConfig *core.KubeProxyConfig, version string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	newMode := core.ProxyModeIPTables
+	oldMode := core.ProxyModeIPTables
+	if newConfig != nil {
+		newMode = *newConfig.Mode
+	}
+	if oldConfig != nil {
+		oldMode = *oldConfig.Mode
+	}
+	if ok, _ := versionutils.CheckVersionMeetsConstraint(version, ">= 1.14.1"); ok {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newMode, oldMode, fldPath.Child("mode"))...)
+	}
+	return allErrs
+}
+
+func validateDNSUpdate(new, old *core.DNS, seedGotAssigned bool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if old != nil && new == nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new, old, fldPath)...)
+	}
+
+	if new != nil && old != nil {
+		if old.Domain != nil && new.Domain != old.Domain {
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Domain, old.Domain, fldPath.Child("domain"))...)
+		}
+
+		// allow to finalize DNS configuration during seed assignment. this is required because
+		// some decisions about the DNS setup can only be taken once the target seed is clarified.
+		if !seedGotAssigned {
+			providersNew := len(new.Providers)
+			providersOld := len(old.Providers)
+
+			if providersNew != providersOld {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("providers"), "adding or removing providers is not yet allowed"))
+				return allErrs
+			}
+
+			for i, provider := range new.Providers {
+				if provider.Type != old.Providers[i].Type {
+					allErrs = append(allErrs, apivalidation.ValidateImmutableField(provider.Type, old.Providers[i].Type, fldPath.Child("providers").Index(i).Child("type"))...)
+				}
+			}
+		}
+	}
+
+	return allErrs
+}
+
+func validateKubernetesVersionUpdate(new, old string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(new) == 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath, new, "cannot validate kubernetes version upgrade because it is unset"))
+		return allErrs
+	}
+
+	// Forbid Kubernetes version downgrade
+	downgrade, err := versionutils.CompareVersions(new, "<", old)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, new, err.Error()))
+	}
+	if downgrade {
+		allErrs = append(allErrs, field.Forbidden(fldPath, "kubernetes version downgrade is not supported"))
+	}
+
+	// Forbid Kubernetes version upgrade which skips a minor version
+	oldVersion, err := semver.NewVersion(old)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, old, err.Error()))
+	}
+	nextMinorVersion := oldVersion.IncMinor().IncMinor()
+
+	skippingMinorVersion, err := versionutils.CompareVersions(new, ">=", nextMinorVersion.String())
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, new, err.Error()))
+	}
+	if skippingMinorVersion {
+		allErrs = append(allErrs, field.Forbidden(fldPath, "kubernetes version upgrade cannot skip a minor version"))
+	}
+
+	return allErrs
+}
+
+func validateDNS(dns *core.DNS, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if dns == nil {
+		return allErrs
+	}
+
+	if dns.Domain != nil {
+		allErrs = append(allErrs, validateDNS1123Subdomain(*dns.Domain, fldPath.Child("domain"))...)
+	}
+
+	for i, provider := range dns.Providers {
+		idxPath := fldPath.Child("providers").Index(i)
+		if providerType := provider.Type; providerType != nil {
+			if *providerType == core.DNSUnmanaged && provider.SecretName != nil {
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("secretName"), provider.SecretName, fmt.Sprintf("secretName must not be set when type is %q", core.DNSUnmanaged)))
+			}
+
+			if *providerType != core.DNSUnmanaged && dns.Domain == nil {
+				allErrs = append(allErrs, field.Required(idxPath.Child("domain"), fmt.Sprintf("domain must be set when type is not set to %q", core.DNSUnmanaged)))
+			}
+		}
+
+		if provider.SecretName != nil && provider.Type == nil {
+			allErrs = append(allErrs, field.Required(idxPath.Child("type"), "type must be set when secretName is set"))
+		}
+	}
+
+	return allErrs
+}
+
+func validateExtensions(extensions []core.Extension, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for i, extension := range extensions {
+		if extension.Type == "" {
+			allErrs = append(allErrs, field.Required(fldPath.Index(i).Child("type"), "field must not be empty"))
+		}
+	}
+	return allErrs
+}
+
+func validateKubernetes(kubernetes core.Kubernetes, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(kubernetes.Version) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("version"), "kubernetes version must not be empty"))
+		return allErrs
+	}
+
+	if kubeAPIServer := kubernetes.KubeAPIServer; kubeAPIServer != nil {
+		if oidc := kubeAPIServer.OIDCConfig; oidc != nil {
+			oidcPath := fldPath.Child("kubeAPIServer", "oidcConfig")
+
+			geqKubernetes111, err := versionutils.CheckVersionMeetsConstraint(kubernetes.Version, ">= 1.11")
+			if err != nil {
+				geqKubernetes111 = false
+			}
+
+			if oidc.CABundle != nil {
+				if _, err := utils.DecodeCertificate([]byte(*oidc.CABundle)); err != nil {
+					allErrs = append(allErrs, field.Invalid(oidcPath.Child("caBundle"), *oidc.CABundle, "caBundle is not a valid PEM-encoded certificate"))
+				}
+			}
+			if oidc.ClientID != nil && len(*oidc.ClientID) == 0 {
+				allErrs = append(allErrs, field.Invalid(oidcPath.Child("clientID"), *oidc.ClientID, "client id cannot be empty when key is provided"))
+			}
+			if oidc.GroupsClaim != nil && len(*oidc.GroupsClaim) == 0 {
+				allErrs = append(allErrs, field.Invalid(oidcPath.Child("groupsClaim"), *oidc.GroupsClaim, "groups claim cannot be empty when key is provided"))
+			}
+			if oidc.GroupsPrefix != nil && len(*oidc.GroupsPrefix) == 0 {
+				allErrs = append(allErrs, field.Invalid(oidcPath.Child("groupsPrefix"), *oidc.GroupsPrefix, "groups prefix cannot be empty when key is provided"))
+			}
+			if oidc.IssuerURL != nil && len(*oidc.IssuerURL) == 0 {
+				allErrs = append(allErrs, field.Invalid(oidcPath.Child("issuerURL"), *oidc.IssuerURL, "issuer url cannot be empty when key is provided"))
+			}
+			if oidc.SigningAlgs != nil && len(oidc.SigningAlgs) == 0 {
+				allErrs = append(allErrs, field.Invalid(oidcPath.Child("signingAlgs"), oidc.SigningAlgs, "signings algs cannot be empty when key is provided"))
+			}
+			if !geqKubernetes111 && oidc.RequiredClaims != nil {
+				allErrs = append(allErrs, field.Forbidden(oidcPath.Child("requiredClaims"), "required claims cannot be provided when version is not greater or equal 1.11"))
+			}
+			if oidc.UsernameClaim != nil && len(*oidc.UsernameClaim) == 0 {
+				allErrs = append(allErrs, field.Invalid(oidcPath.Child("usernameClaim"), *oidc.UsernameClaim, "username claim cannot be empty when key is provided"))
+			}
+			if oidc.UsernamePrefix != nil && len(*oidc.UsernamePrefix) == 0 {
+				allErrs = append(allErrs, field.Invalid(oidcPath.Child("usernamePrefix"), *oidc.UsernamePrefix, "username prefix cannot be empty when key is provided"))
+			}
+		}
+
+		admissionPluginsPath := fldPath.Child("kubeAPIServer", "admissionPlugins")
+		for i, plugin := range kubeAPIServer.AdmissionPlugins {
+			idxPath := admissionPluginsPath.Index(i)
+
+			if len(plugin.Name) == 0 {
+				allErrs = append(allErrs, field.Required(idxPath.Child("name"), "must provide a name"))
+			}
+		}
+
+		if auditConfig := kubeAPIServer.AuditConfig; auditConfig != nil {
+			auditPath := fldPath.Child("kubeAPIServer", "auditConfig")
+			if auditPolicy := auditConfig.AuditPolicy; auditPolicy != nil && auditConfig.AuditPolicy.ConfigMapRef != nil {
+				allErrs = append(allErrs, validateAuditPolicyConfigMapReference(auditPolicy.ConfigMapRef, auditPath.Child("auditPolicy", "configMapRef"))...)
+			}
+		}
+	}
+
+	allErrs = append(allErrs, validateKubeControllerManager(kubernetes.Version, kubernetes.KubeControllerManager, fldPath.Child("kubeControllerManager"))...)
+	allErrs = append(allErrs, validateKubeProxy(kubernetes.KubeProxy, fldPath.Child("kubeProxy"))...)
+	if clusterAutoscaler := kubernetes.ClusterAutoscaler; clusterAutoscaler != nil {
+		allErrs = append(allErrs, ValidateClusterAutoscaler(*clusterAutoscaler, fldPath.Child("clusterAutoscaler"))...)
+	}
+
+	return allErrs
+}
+
+func validateNetworking(networking core.Networking, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(networking.Type) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "networking type must be provided"))
+	}
+
+	if networking.Nodes != nil {
+		path := fldPath.Child("nodes")
+		cidr := cidrvalidation.NewCIDR(*networking.Nodes, path)
+
+		allErrs = append(allErrs, cidr.ValidateParse()...)
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(path, cidr.GetCIDR())...)
+	}
+
+	if networking.Pods != nil {
+		path := fldPath.Child("pods")
+		cidr := cidrvalidation.NewCIDR(*networking.Pods, path)
+
+		allErrs = append(allErrs, cidr.ValidateParse()...)
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(path, cidr.GetCIDR())...)
+	}
+
+	if networking.Services != nil {
+		path := fldPath.Child("services")
+		cidr := cidrvalidation.NewCIDR(*networking.Services, path)
+
+		allErrs = append(allErrs, cidr.ValidateParse()...)
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(path, cidr.GetCIDR())...)
+	}
+
+	return allErrs
+}
+
+// ValidateClusterAutoscaler validates the given ClusterAutoscaler fields.
+func ValidateClusterAutoscaler(autoScaler core.ClusterAutoscaler, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if threshold := autoScaler.ScaleDownUtilizationThreshold; threshold != nil {
+		if *threshold < 0.0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("scaleDownUtilizationThreshold"), *threshold, "can not be negative"))
+		}
+		if *threshold > 1.0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("scaleDownUtilizationThreshold"), *threshold, "can not be greater than 1.0"))
+		}
+	}
+	return allErrs
+}
+
+func validateKubeControllerManager(kubernetesVersion string, kcm *core.KubeControllerManagerConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	k8sVersionLessThan112, err := versionutils.CompareVersions(kubernetesVersion, "<", "1.12")
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, kubernetesVersion, err.Error()))
+	}
+	if kcm != nil {
+		if maskSize := kcm.NodeCIDRMaskSize; maskSize != nil {
+			if *maskSize < 16 || *maskSize > 28 {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeCIDRMaskSize"), *maskSize, "nodeCIDRMaskSize must be between 16 and 28"))
+			}
+		}
+		if hpa := kcm.HorizontalPodAutoscalerConfig; hpa != nil {
+			fldPath = fldPath.Child("horizontalPodAutoscaler")
+
+			if hpa.SyncPeriod != nil && hpa.SyncPeriod.Duration < 1*time.Second {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("syncPeriod"), *hpa.SyncPeriod, "syncPeriod must not be less than a second"))
+			}
+			if hpa.Tolerance != nil && *hpa.Tolerance <= 0 {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("tolerance"), *hpa.Tolerance, "tolerance of must be greater than 0"))
+			}
+
+			if k8sVersionLessThan112 {
+				if hpa.DownscaleDelay != nil && hpa.DownscaleDelay.Duration < 0 {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("downscaleDelay"), *hpa.DownscaleDelay, "downscale delay must not be negative"))
+				}
+				if hpa.UpscaleDelay != nil && hpa.UpscaleDelay.Duration < 0 {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("upscaleDelay"), *hpa.UpscaleDelay, "upscale delay must not be negative"))
+				}
+				if hpa.DownscaleStabilization != nil {
+					allErrs = append(allErrs, field.Forbidden(fldPath.Child("downscaleStabilization"), "downscale stabilization is not supported in k8s versions < 1.12"))
+				}
+				if hpa.InitialReadinessDelay != nil {
+					allErrs = append(allErrs, field.Forbidden(fldPath.Child("initialReadinessDelay"), "initial readiness delay is not supported in k8s versions < 1.12"))
+				}
+				if hpa.CPUInitializationPeriod != nil {
+					allErrs = append(allErrs, field.Forbidden(fldPath.Child("cpuInitializationPeriod"), "cpu initialization period is not supported in k8s versions < 1.12"))
+				}
+			} else {
+				if hpa.DownscaleDelay != nil {
+					allErrs = append(allErrs, field.Forbidden(fldPath.Child("downscaleDelay"), "downscale delay is not supported in k8s versions >= 1.12"))
+				}
+				if hpa.UpscaleDelay != nil {
+					allErrs = append(allErrs, field.Forbidden(fldPath.Child("upscaleDelay"), "upscale delay is not supported in k8s versions >= 1.12"))
+				}
+				if hpa.DownscaleStabilization != nil && hpa.DownscaleStabilization.Duration < 1*time.Second {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("downscaleStabilization"), *hpa.DownscaleStabilization, "downScale stabilization must not be less than a second"))
+				}
+				if hpa.InitialReadinessDelay != nil && hpa.InitialReadinessDelay.Duration <= 0 {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("initialReadinessDelay"), *hpa.InitialReadinessDelay, "initial readiness delay must be greater than 0"))
+				}
+				if hpa.CPUInitializationPeriod != nil && hpa.CPUInitializationPeriod.Duration < 1*time.Second {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("cpuInitializationPeriod"), *hpa.CPUInitializationPeriod, "cpu initialization period must not be less than a second"))
+				}
+			}
+		}
+	}
+	return allErrs
+}
+
+func validateKubeProxy(kp *core.KubeProxyConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if kp != nil {
+		if kp.Mode == nil {
+			allErrs = append(allErrs, field.Required(fldPath.Child("mode"), "must be set when .spec.kubernetes.kubeProxy is set"))
+		} else if mode := *kp.Mode; !availableProxyMode.Has(string(mode)) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("mode"), mode, availableProxyMode.List()))
+		}
+	}
+	return allErrs
+}
+
+func validateMonitoring(monitoring *core.Monitoring, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if monitoring != nil && monitoring.Alerting != nil {
+		allErrs = append(allErrs, validateAlerting(monitoring.Alerting, fldPath.Child("alerting"))...)
+	}
+	return allErrs
+}
+
+func validateAlerting(alerting *core.Alerting, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	emails := make(map[string]struct{})
+	for i, email := range alerting.EmailReceivers {
+		if !utils.TestEmail(email) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("emailReceivers").Index(i), email, "must provide a valid email"))
+		}
+
+		if _, duplicate := emails[email]; duplicate {
+			allErrs = append(allErrs, field.Duplicate(fldPath.Child("emailReceivers").Index(i), email))
+		} else {
+			emails[email] = struct{}{}
+		}
+	}
+	return allErrs
+}
+
+func validateMaintenance(maintenance *core.Maintenance, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if maintenance == nil {
+		allErrs = append(allErrs, field.Required(fldPath, "maintenance information is required"))
+		return allErrs
+	}
+
+	if maintenance.AutoUpdate == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("autoUpdate"), "auto update information is required"))
+	}
+
+	if maintenance.TimeWindow == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("timeWindow"), "time window information is required"))
+	} else {
+		maintenanceTimeWindow, err := utils.ParseMaintenanceTimeWindow(maintenance.TimeWindow.Begin, maintenance.TimeWindow.End)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("timeWindow", "begin/end"), maintenance.TimeWindow, err.Error()))
+		}
+
+		if err == nil {
+			duration := maintenanceTimeWindow.Duration()
+			if duration > 6*time.Hour {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("timeWindow"), "time window must not be greater than 6 hours"))
+				return allErrs
+			}
+			if duration < 30*time.Minute {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("timeWindow"), "time window must not be smaller than 30 minutes"))
+				return allErrs
+			}
+		}
+	}
+
+	return allErrs
+}
+
+func validateProvider(provider core.Provider, kubernetes core.Kubernetes, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(provider.Type) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "must specify a provider type"))
+	}
+
+	var maxPod int32
+	if kubernetes.Kubelet != nil && kubernetes.Kubelet.MaxPods != nil {
+		maxPod = *kubernetes.Kubelet.MaxPods
+	}
+
+	for i, worker := range provider.Workers {
+		allErrs = append(allErrs, ValidateWorker(worker, fldPath.Child("workers").Index(i))...)
+
+		if worker.Kubernetes != nil && worker.Kubernetes.Kubelet != nil && worker.Kubernetes.Kubelet.MaxPods != nil && *worker.Kubernetes.Kubelet.MaxPods > maxPod {
+			maxPod = *worker.Kubernetes.Kubelet.MaxPods
+		}
+	}
+
+	allErrs = append(allErrs, ValidateWorkers(provider.Workers, fldPath.Child("workers"))...)
+
+	if kubernetes.KubeControllerManager != nil && kubernetes.KubeControllerManager.NodeCIDRMaskSize != nil {
+		if maxPod == 0 {
+			// default maxPod setting on kubelet
+			maxPod = 110
+		}
+		allErrs = append(allErrs, ValidateNodeCIDRMaskWithMaxPod(maxPod, *kubernetes.KubeControllerManager.NodeCIDRMaskSize)...)
+	}
+
+	return allErrs
+}
+
+// ValidateWorker validates the worker object.
+func ValidateWorker(worker core.Worker, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, validateDNS1123Label(worker.Name, fldPath.Child("name"))...)
+	maxWorkerNameLength := 15
+	if len(worker.Name) > maxWorkerNameLength {
+		allErrs = append(allErrs, field.TooLong(fldPath.Child("name"), worker.Name, maxWorkerNameLength))
+	}
+	if len(worker.Machine.Type) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("machine", "type"), "must specify a machine type"))
+	}
+	if worker.Minimum < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("minimum"), worker.Minimum, "minimum value must not be negative"))
+	}
+	if worker.Maximum < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("maximum"), worker.Maximum, "maximum value must not be negative"))
+	}
+	if worker.Maximum < worker.Minimum {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("maximum"), "maximum value must not be less or equal than minimum value"))
+	}
+	if worker.Maximum != 0 && worker.Minimum == 0 {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("minimum"), "minimum value must be >= 1 if maximum value > 0 (cluster-autoscaler cannot handle min=0)"))
+	}
+
+	allErrs = append(allErrs, ValidatePositiveIntOrPercent(worker.MaxSurge, fldPath.Child("maxSurge"))...)
+	allErrs = append(allErrs, ValidatePositiveIntOrPercent(worker.MaxUnavailable, fldPath.Child("maxUnavailable"))...)
+	allErrs = append(allErrs, IsNotMoreThan100Percent(worker.MaxUnavailable, fldPath.Child("maxUnavailable"))...)
+
+	if (worker.MaxUnavailable == nil && worker.MaxSurge == nil) || (getIntOrPercentValue(*worker.MaxUnavailable) == 0 && getIntOrPercentValue(*worker.MaxSurge) == 0) {
+		// Both MaxSurge and MaxUnavailable cannot be zero.
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("maxUnavailable"), worker.MaxUnavailable, "may not be 0 when `maxSurge` is 0"))
+	}
+
+	allErrs = append(allErrs, metav1validation.ValidateLabels(worker.Labels, fldPath.Child("labels"))...)
+	allErrs = append(allErrs, apivalidation.ValidateAnnotations(worker.Annotations, fldPath.Child("annotations"))...)
+	if len(worker.Taints) > 0 {
+		allErrs = append(allErrs, validateTaints(worker.Taints, fldPath.Child("taints"))...)
+	}
+	if worker.Kubernetes != nil && worker.Kubernetes.Kubelet != nil {
+		allErrs = append(allErrs, ValidateKubeletConfig(*worker.Kubernetes.Kubelet, fldPath.Child("kubernetes", "kubelet"))...)
+	}
+
+	if worker.CABundle != nil {
+		if _, err := utils.DecodeCertificate([]byte(*worker.CABundle)); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("caBundle"), *(worker.CABundle), "caBundle is not a valid PEM-encoded certificate"))
+		}
+	}
+
+	if worker.Volume != nil {
+		volumeSizeRegex, _ := regexp.Compile(`^(\d)+Gi$`)
+		if !volumeSizeRegex.MatchString(worker.Volume.Size) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("volume", "size"), worker.Volume.Size, fmt.Sprintf("volume size must match the regex %s", volumeSizeRegex)))
+		}
+	}
+
+	return allErrs
+}
+
+// ValidateKubeletConfig validates the KubeletConfig object.
+func ValidateKubeletConfig(kubeletConfig core.KubeletConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if kubeletConfig.MaxPods != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*kubeletConfig.MaxPods), fldPath.Child("maxPods"))...)
+	}
+
+	if kubeletConfig.EvictionPressureTransitionPeriod != nil {
+		allErrs = append(allErrs, ValidatePositiveDuration(kubeletConfig.EvictionPressureTransitionPeriod, fldPath.Child("evictionPressureTransitionPeriod"))...)
+	}
+
+	if kubeletConfig.EvictionMaxPodGracePeriod != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*kubeletConfig.EvictionMaxPodGracePeriod), fldPath.Child("evictionMaxPodGracePeriod"))...)
+	}
+
+	if kubeletConfig.EvictionHard != nil {
+		allErrs = append(allErrs, validateKubeletConfigEviction(kubeletConfig.EvictionHard, fldPath.Child("evictionHard"))...)
+	}
+	if kubeletConfig.EvictionSoft != nil {
+		allErrs = append(allErrs, validateKubeletConfigEviction(kubeletConfig.EvictionSoft, fldPath.Child("evictionSoft"))...)
+	}
+	if kubeletConfig.EvictionMinimumReclaim != nil {
+		allErrs = append(allErrs, validateKubeletConfigEvictionMinimumReclaim(kubeletConfig.EvictionMinimumReclaim, fldPath.Child("evictionMinimumReclaim"))...)
+	}
+	if kubeletConfig.EvictionSoftGracePeriod != nil {
+		allErrs = append(allErrs, validateKubeletConfigEvictionSoftGracePeriod(kubeletConfig.EvictionSoftGracePeriod, fldPath.Child("evictionSoftGracePeriod"))...)
+	}
+	return allErrs
+}
+
+func validateKubeletConfigEviction(eviction *core.KubeletConfigEviction, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, ValidateResourceQuantityOrPercent(eviction.MemoryAvailable, fldPath, "memoryAvailable")...)
+	allErrs = append(allErrs, ValidateResourceQuantityOrPercent(eviction.ImageFSAvailable, fldPath, "imagefsAvailable")...)
+	allErrs = append(allErrs, ValidateResourceQuantityOrPercent(eviction.ImageFSInodesFree, fldPath, "imagefsInodesFree")...)
+	allErrs = append(allErrs, ValidateResourceQuantityOrPercent(eviction.NodeFSAvailable, fldPath, "nodefsAvailable")...)
+	allErrs = append(allErrs, ValidateResourceQuantityOrPercent(eviction.ImageFSInodesFree, fldPath, "imagefsInodesFree")...)
+	return allErrs
+}
+
+func validateKubeletConfigEvictionMinimumReclaim(eviction *core.KubeletConfigEvictionMinimumReclaim, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if eviction.MemoryAvailable != nil {
+		allErrs = append(allErrs, validateResourceQuantityValue("memoryAvailable", *eviction.MemoryAvailable, fldPath.Child("memoryAvailable"))...)
+	}
+	if eviction.ImageFSAvailable != nil {
+		allErrs = append(allErrs, validateResourceQuantityValue("imagefsAvailable", *eviction.ImageFSAvailable, fldPath.Child("imagefsAvailable"))...)
+	}
+	if eviction.ImageFSInodesFree != nil {
+		allErrs = append(allErrs, validateResourceQuantityValue("imagefsInodesFree", *eviction.ImageFSInodesFree, fldPath.Child("imagefsInodesFree"))...)
+	}
+	if eviction.NodeFSAvailable != nil {
+		allErrs = append(allErrs, validateResourceQuantityValue("nodefsAvailable", *eviction.NodeFSAvailable, fldPath.Child("nodefsAvailable"))...)
+	}
+	if eviction.ImageFSInodesFree != nil {
+		allErrs = append(allErrs, validateResourceQuantityValue("imagefsInodesFree", *eviction.ImageFSInodesFree, fldPath.Child("imagefsInodesFree"))...)
+	}
+	return allErrs
+}
+
+func validateKubeletConfigEvictionSoftGracePeriod(eviction *core.KubeletConfigEvictionSoftGracePeriod, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, ValidatePositiveDuration(eviction.MemoryAvailable, fldPath.Child("memoryAvailable"))...)
+	allErrs = append(allErrs, ValidatePositiveDuration(eviction.ImageFSAvailable, fldPath.Child("imagefsAvailable"))...)
+	allErrs = append(allErrs, ValidatePositiveDuration(eviction.ImageFSInodesFree, fldPath.Child("imagefsInodesFree"))...)
+	allErrs = append(allErrs, ValidatePositiveDuration(eviction.NodeFSAvailable, fldPath.Child("nodefsAvailable"))...)
+	allErrs = append(allErrs, ValidatePositiveDuration(eviction.ImageFSInodesFree, fldPath.Child("imagefsInodesFree"))...)
+	return allErrs
+}
+
+// https://github.com/kubernetes/kubernetes/blob/ee9079f8ec39914ff8975b5390749771b9303ea4/pkg/apis/core/validation/validation.go#L4057-L4089
+func validateTaints(taints []corev1.Taint, fldPath *field.Path) field.ErrorList {
+	allErrors := field.ErrorList{}
+
+	uniqueTaints := map[corev1.TaintEffect]sets.String{}
+
+	for i, taint := range taints {
+		idxPath := fldPath.Index(i)
+		// validate the taint key
+		allErrors = append(allErrors, metav1validation.ValidateLabelName(taint.Key, idxPath.Child("key"))...)
+		// validate the taint value
+		if errs := validation.IsValidLabelValue(taint.Value); len(errs) != 0 {
+			allErrors = append(allErrors, field.Invalid(idxPath.Child("value"), taint.Value, strings.Join(errs, ";")))
+		}
+		// validate the taint effect
+		allErrors = append(allErrors, validateTaintEffect(&taint.Effect, false, idxPath.Child("effect"))...)
+
+		// validate if taint is unique by <key, effect>
+		if len(uniqueTaints[taint.Effect]) > 0 && uniqueTaints[taint.Effect].Has(taint.Key) {
+			duplicatedError := field.Duplicate(idxPath, taint)
+			duplicatedError.Detail = "taints must be unique by key and effect pair"
+			allErrors = append(allErrors, duplicatedError)
+			continue
+		}
+
+		// add taint to existingTaints for uniqueness check
+		if len(uniqueTaints[taint.Effect]) == 0 {
+			uniqueTaints[taint.Effect] = sets.String{}
+		}
+		uniqueTaints[taint.Effect].Insert(taint.Key)
+	}
+	return allErrors
+}
+
+// https://github.com/kubernetes/kubernetes/blob/ee9079f8ec39914ff8975b5390749771b9303ea4/pkg/apis/core/validation/validation.go#L2774-L2795
+func validateTaintEffect(effect *corev1.TaintEffect, allowEmpty bool, fldPath *field.Path) field.ErrorList {
+	if !allowEmpty && len(*effect) == 0 {
+		return field.ErrorList{field.Required(fldPath, "")}
+	}
+
+	allErrors := field.ErrorList{}
+	switch *effect {
+	case corev1.TaintEffectNoSchedule, corev1.TaintEffectPreferNoSchedule, corev1.TaintEffectNoExecute:
+	default:
+		validValues := []string{
+			string(corev1.TaintEffectNoSchedule),
+			string(corev1.TaintEffectPreferNoSchedule),
+			string(corev1.TaintEffectNoExecute),
+		}
+		allErrors = append(allErrors, field.NotSupported(fldPath, *effect, validValues))
+	}
+	return allErrors
+}
+
+// ValidateWorkers validates worker objects.
+func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	workerNames := make(map[string]bool)
+	atLeastOneActivePool := false
+
+	for i, worker := range workers {
+		if worker.Minimum != 0 && worker.Maximum != 0 {
+			atLeastOneActivePool = true
+		}
+
+		if workerNames[worker.Name] {
+			allErrs = append(allErrs, field.Duplicate(fldPath.Index(i).Child("name"), worker.Name))
+		}
+		workerNames[worker.Name] = true
+	}
+
+	if !atLeastOneActivePool {
+		allErrs = append(allErrs, field.Forbidden(fldPath, "at least one worker pool with min>0 and max> 0 needed"))
+	}
+
+	return allErrs
+}
+
+// ValidateHibernation validates a Hibernation object.
+func ValidateHibernation(hibernation *core.Hibernation, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if hibernation == nil {
+		return allErrs
+	}
+
+	allErrs = append(allErrs, ValidateHibernationSchedules(hibernation.Schedules, fldPath.Child("schedules"))...)
+
+	return allErrs
+}
+
+// ValidateHibernationSchedules validates a list of hibernation schedules.
+func ValidateHibernationSchedules(schedules []core.HibernationSchedule, fldPath *field.Path) field.ErrorList {
+	var (
+		allErrs = field.ErrorList{}
+		seen    = sets.NewString()
+	)
+
+	for i, schedule := range schedules {
+		allErrs = append(allErrs, ValidateHibernationSchedule(seen, &schedule, fldPath.Index(i))...)
+	}
+
+	return allErrs
+}
+
+// ValidateHibernationCronSpec validates a cron specification of a hibernation schedule.
+func ValidateHibernationCronSpec(seenSpecs sets.String, spec string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	_, err := cron.ParseStandard(spec)
+	switch {
+	case err != nil:
+		allErrs = append(allErrs, field.Invalid(fldPath, spec, fmt.Sprintf("not a valid cron spec: %v", err)))
+	case seenSpecs.Has(spec):
+		allErrs = append(allErrs, field.Duplicate(fldPath, spec))
+	default:
+		seenSpecs.Insert(spec)
+	}
+
+	return allErrs
+}
+
+// ValidateHibernationScheduleLocation validates that the location of a HibernationSchedule is correct.
+func ValidateHibernationScheduleLocation(location string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if _, err := time.LoadLocation(location); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, location, fmt.Sprintf("not a valid location: %v", err)))
+	}
+
+	return allErrs
+}
+
+// ValidateHibernationSchedule validates the correctness of a HibernationSchedule.
+// It checks whether the set start and end time are valid cron specs.
+func ValidateHibernationSchedule(seenSpecs sets.String, schedule *core.HibernationSchedule, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if schedule.Start == nil && schedule.End == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("start/end"), "either start or end has to be provided"))
+	}
+	if schedule.Start != nil {
+		allErrs = append(allErrs, ValidateHibernationCronSpec(seenSpecs, *schedule.Start, fldPath.Child("start"))...)
+	}
+	if schedule.End != nil {
+		allErrs = append(allErrs, ValidateHibernationCronSpec(seenSpecs, *schedule.End, fldPath.Child("end"))...)
+	}
+	if schedule.Location != nil {
+		allErrs = append(allErrs, ValidateHibernationScheduleLocation(*schedule.Location, fldPath.Child("location"))...)
+	}
+
+	return allErrs
+}
+
+// ValidatePositiveDuration validates that a duration is positive.
+func ValidatePositiveDuration(duration *metav1.Duration, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if duration == nil {
+		return allErrs
+	}
+	if duration.Seconds() < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath, duration.Duration.String(), "must be non-negative"))
+	}
+	return allErrs
+}
+
+// ValidateResourceQuantityOrPercent checks if a value can be parsed to either a resource.quantity, a positive int or percent.
+func ValidateResourceQuantityOrPercent(valuePtr *string, fldPath *field.Path, key string) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if valuePtr == nil {
+		return allErrs
+	}
+	value := *valuePtr
+	// check for resource quantity
+	if quantity, err := resource.ParseQuantity(value); err == nil {
+		if len(validateResourceQuantityValue(key, quantity, fldPath)) == 0 {
+			return allErrs
+		}
+	}
+
+	if validation.IsValidPercent(value) != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child(key), value, "field must be either a valid resource quantity (e.g 200Mi) or a percentage (e.g '5%')"))
+		return allErrs
+	}
+
+	percentValue, _ := strconv.Atoi(value[:len(value)-1])
+	if percentValue > 100 || percentValue < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child(key), value, "must not be greater than 100% and not smaller than 0%"))
+	}
+	return allErrs
+}
+
+// ValidatePositiveIntOrPercent validates a int or string object and ensures it is positive.
+func ValidatePositiveIntOrPercent(intOrPercent *intstr.IntOrString, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if intOrPercent == nil {
+		return allErrs
+	}
+
+	if intOrPercent.Type == intstr.String {
+		if validation.IsValidPercent(intOrPercent.StrVal) != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath, intOrPercent, "must be an integer or percentage (e.g '5%')"))
+		}
+	} else if intOrPercent.Type == intstr.Int {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(intOrPercent.IntValue()), fldPath)...)
+	}
+
+	return allErrs
+}
+
+// IsNotMoreThan100Percent validates an int or string object and ensures it is not more than 100%.
+func IsNotMoreThan100Percent(intOrStringValue *intstr.IntOrString, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if intOrStringValue == nil {
+		return allErrs
+	}
+
+	value, isPercent := getPercentValue(*intOrStringValue)
+	if !isPercent || value <= 100 {
+		return nil
+	}
+	allErrs = append(allErrs, field.Invalid(fldPath, intOrStringValue, "must not be greater than 100%"))
+
+	return allErrs
+}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/shootstate.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/shootstate.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core"
+
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateShootState validates a ShootState object
+func ValidateShootState(shootState *core.ShootState) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&shootState.ObjectMeta, true, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateShootStateSpec(&shootState.Spec, field.NewPath("spec"))...)
+
+	return allErrs
+}
+
+// ValidateShootStateUpdate validates an update to a ShootState object
+func ValidateShootStateUpdate(newShootState, oldShootState *core.ShootState) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newShootState.ObjectMeta, &oldShootState.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateShootStateSpecUpdate(&newShootState.Spec, &oldShootState.Spec)...)
+	allErrs = append(allErrs, ValidateShootState(newShootState)...)
+
+	return allErrs
+}
+
+// ValidateShootStateSpec validates the spec field of a ShootState object.
+func ValidateShootStateSpec(shootStateSpec *core.ShootStateSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for i, data := range shootStateSpec.Gardener {
+		idxPath := fldPath.Child("gardener").Index(i)
+		namePath := idxPath.Child("name")
+
+		if len(data.Name) == 0 {
+			allErrs = append(allErrs, field.Invalid(namePath, data.Name, "name of data required to generate resources cannot be empty"))
+		}
+	}
+
+	for i, extensionResources := range shootStateSpec.Extensions {
+		idxPath := fldPath.Child("extensions").Index(i)
+		kindPath := idxPath.Child("kind")
+		purposePath := idxPath.Child("purpose")
+
+		if len(extensionResources.Kind) == 0 {
+			allErrs = append(allErrs, field.Invalid(kindPath, extensionResources.Kind, "extension resource kind cannot be empty"))
+		}
+
+		if extensionResources.Purpose != nil && len(*extensionResources.Purpose) == 0 {
+			allErrs = append(allErrs, field.Invalid(purposePath, extensionResources.Purpose, "extension resource purpose cannot be empty"))
+		}
+	}
+
+	return allErrs
+}
+
+// ValidateShootStateSpecUpdate validates the update to the specification of a ShootState
+func ValidateShootStateSpecUpdate(newShootState, oldShootState *core.ShootStateSpec) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	return allErrs
+}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/utils.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/utils.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateName is a helper function for validating that a name is a DNS sub domain.
+func ValidateName(name string, prefix bool) []string {
+	return apivalidation.NameIsDNSSubdomain(name, prefix)
+}
+
+func validateSecretReference(ref corev1.SecretReference, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(ref.Name) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "must provide a name"))
+	}
+	if len(ref.Namespace) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("namespace"), "must provide a namespace"))
+	}
+
+	return allErrs
+}
+
+func validateNameConsecutiveHyphens(name string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if strings.Contains(name, "--") {
+		allErrs = append(allErrs, field.Invalid(fldPath, name, "name may not contain two consecutive hyphens"))
+	}
+
+	return allErrs
+}
+
+// validateDNS1123Subdomain validates that a name is a proper DNS subdomain.
+func validateDNS1123Subdomain(value string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for _, msg := range validation.IsDNS1123Subdomain(value) {
+		allErrs = append(allErrs, field.Invalid(fldPath, value, msg))
+	}
+
+	return allErrs
+}
+
+// validateDNS1123Label valides a name is a proper RFC1123 DNS label.
+func validateDNS1123Label(value string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for _, msg := range validation.IsDNS1123Label(value) {
+		allErrs = append(allErrs, field.Invalid(fldPath, value, msg))
+	}
+
+	return allErrs
+}
+
+func getIntOrPercentValue(intOrStringValue intstr.IntOrString) int {
+	value, isPercent := getPercentValue(intOrStringValue)
+	if isPercent {
+		return value
+	}
+	return intOrStringValue.IntValue()
+}
+
+func getPercentValue(intOrStringValue intstr.IntOrString) (int, bool) {
+	if intOrStringValue.Type != intstr.String {
+		return 0, false
+	}
+	if len(validation.IsValidPercent(intOrStringValue.StrVal)) != 0 {
+		return 0, false
+	}
+	value, _ := strconv.Atoi(intOrStringValue.StrVal[:len(intOrStringValue.StrVal)-1])
+	return value, true
+}
+
+// ShouldEnforceImmutability compares the given slices and returns if a immutability should be enforced.
+// It mainly checks if the order of the same elements in `new` and `old` is the same, i.e. only an addition
+// of elements to `new` is allowed.
+func ShouldEnforceImmutability(new, old []string) bool {
+	sizeDelta := len(new) - len(old)
+	if sizeDelta > 0 {
+		newA := new[:len(new)-sizeDelta]
+		if equal(newA, old) {
+			return false
+		}
+		return ShouldEnforceImmutability(newA, old)
+	}
+	return sizeDelta < 0 || sizeDelta == 0
+}
+
+func equal(new, old []string) bool {
+	for i := range new {
+		if new[i] != old[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/robfig/cron/.gitignore
+++ b/vendor/github.com/robfig/cron/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/vendor/github.com/robfig/cron/.travis.yml
+++ b/vendor/github.com/robfig/cron/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/vendor/github.com/robfig/cron/LICENSE
+++ b/vendor/github.com/robfig/cron/LICENSE
@@ -1,0 +1,21 @@
+Copyright (C) 2012 Rob Figueiredo
+All Rights Reserved.
+
+MIT LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/robfig/cron/README.md
+++ b/vendor/github.com/robfig/cron/README.md
@@ -1,0 +1,6 @@
+[![GoDoc](http://godoc.org/github.com/robfig/cron?status.png)](http://godoc.org/github.com/robfig/cron) 
+[![Build Status](https://travis-ci.org/robfig/cron.svg?branch=master)](https://travis-ci.org/robfig/cron)
+
+# cron
+
+Documentation here: https://godoc.org/github.com/robfig/cron

--- a/vendor/github.com/robfig/cron/constantdelay.go
+++ b/vendor/github.com/robfig/cron/constantdelay.go
@@ -1,0 +1,27 @@
+package cron
+
+import "time"
+
+// ConstantDelaySchedule represents a simple recurring duty cycle, e.g. "Every 5 minutes".
+// It does not support jobs more frequent than once a second.
+type ConstantDelaySchedule struct {
+	Delay time.Duration
+}
+
+// Every returns a crontab Schedule that activates once every duration.
+// Delays of less than a second are not supported (will round up to 1 second).
+// Any fields less than a Second are truncated.
+func Every(duration time.Duration) ConstantDelaySchedule {
+	if duration < time.Second {
+		duration = time.Second
+	}
+	return ConstantDelaySchedule{
+		Delay: duration - time.Duration(duration.Nanoseconds())%time.Second,
+	}
+}
+
+// Next returns the next time this should be run.
+// This rounds so that the next activation time will be on the second.
+func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
+	return t.Add(schedule.Delay - time.Duration(t.Nanosecond())*time.Nanosecond)
+}

--- a/vendor/github.com/robfig/cron/cron.go
+++ b/vendor/github.com/robfig/cron/cron.go
@@ -1,0 +1,259 @@
+package cron
+
+import (
+	"log"
+	"runtime"
+	"sort"
+	"time"
+)
+
+// Cron keeps track of any number of entries, invoking the associated func as
+// specified by the schedule. It may be started, stopped, and the entries may
+// be inspected while running.
+type Cron struct {
+	entries  []*Entry
+	stop     chan struct{}
+	add      chan *Entry
+	snapshot chan []*Entry
+	running  bool
+	ErrorLog *log.Logger
+	location *time.Location
+}
+
+// Job is an interface for submitted cron jobs.
+type Job interface {
+	Run()
+}
+
+// The Schedule describes a job's duty cycle.
+type Schedule interface {
+	// Return the next activation time, later than the given time.
+	// Next is invoked initially, and then each time the job is run.
+	Next(time.Time) time.Time
+}
+
+// Entry consists of a schedule and the func to execute on that schedule.
+type Entry struct {
+	// The schedule on which this job should be run.
+	Schedule Schedule
+
+	// The next time the job will run. This is the zero time if Cron has not been
+	// started or this entry's schedule is unsatisfiable
+	Next time.Time
+
+	// The last time this job was run. This is the zero time if the job has never
+	// been run.
+	Prev time.Time
+
+	// The Job to run.
+	Job Job
+}
+
+// byTime is a wrapper for sorting the entry array by time
+// (with zero time at the end).
+type byTime []*Entry
+
+func (s byTime) Len() int      { return len(s) }
+func (s byTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s byTime) Less(i, j int) bool {
+	// Two zero times should return false.
+	// Otherwise, zero is "greater" than any other time.
+	// (To sort it at the end of the list.)
+	if s[i].Next.IsZero() {
+		return false
+	}
+	if s[j].Next.IsZero() {
+		return true
+	}
+	return s[i].Next.Before(s[j].Next)
+}
+
+// New returns a new Cron job runner, in the Local time zone.
+func New() *Cron {
+	return NewWithLocation(time.Now().Location())
+}
+
+// NewWithLocation returns a new Cron job runner.
+func NewWithLocation(location *time.Location) *Cron {
+	return &Cron{
+		entries:  nil,
+		add:      make(chan *Entry),
+		stop:     make(chan struct{}),
+		snapshot: make(chan []*Entry),
+		running:  false,
+		ErrorLog: nil,
+		location: location,
+	}
+}
+
+// A wrapper that turns a func() into a cron.Job
+type FuncJob func()
+
+func (f FuncJob) Run() { f() }
+
+// AddFunc adds a func to the Cron to be run on the given schedule.
+func (c *Cron) AddFunc(spec string, cmd func()) error {
+	return c.AddJob(spec, FuncJob(cmd))
+}
+
+// AddJob adds a Job to the Cron to be run on the given schedule.
+func (c *Cron) AddJob(spec string, cmd Job) error {
+	schedule, err := Parse(spec)
+	if err != nil {
+		return err
+	}
+	c.Schedule(schedule, cmd)
+	return nil
+}
+
+// Schedule adds a Job to the Cron to be run on the given schedule.
+func (c *Cron) Schedule(schedule Schedule, cmd Job) {
+	entry := &Entry{
+		Schedule: schedule,
+		Job:      cmd,
+	}
+	if !c.running {
+		c.entries = append(c.entries, entry)
+		return
+	}
+
+	c.add <- entry
+}
+
+// Entries returns a snapshot of the cron entries.
+func (c *Cron) Entries() []*Entry {
+	if c.running {
+		c.snapshot <- nil
+		x := <-c.snapshot
+		return x
+	}
+	return c.entrySnapshot()
+}
+
+// Location gets the time zone location
+func (c *Cron) Location() *time.Location {
+	return c.location
+}
+
+// Start the cron scheduler in its own go-routine, or no-op if already started.
+func (c *Cron) Start() {
+	if c.running {
+		return
+	}
+	c.running = true
+	go c.run()
+}
+
+// Run the cron scheduler, or no-op if already running.
+func (c *Cron) Run() {
+	if c.running {
+		return
+	}
+	c.running = true
+	c.run()
+}
+
+func (c *Cron) runWithRecovery(j Job) {
+	defer func() {
+		if r := recover(); r != nil {
+			const size = 64 << 10
+			buf := make([]byte, size)
+			buf = buf[:runtime.Stack(buf, false)]
+			c.logf("cron: panic running job: %v\n%s", r, buf)
+		}
+	}()
+	j.Run()
+}
+
+// Run the scheduler. this is private just due to the need to synchronize
+// access to the 'running' state variable.
+func (c *Cron) run() {
+	// Figure out the next activation times for each entry.
+	now := c.now()
+	for _, entry := range c.entries {
+		entry.Next = entry.Schedule.Next(now)
+	}
+
+	for {
+		// Determine the next entry to run.
+		sort.Sort(byTime(c.entries))
+
+		var timer *time.Timer
+		if len(c.entries) == 0 || c.entries[0].Next.IsZero() {
+			// If there are no entries yet, just sleep - it still handles new entries
+			// and stop requests.
+			timer = time.NewTimer(100000 * time.Hour)
+		} else {
+			timer = time.NewTimer(c.entries[0].Next.Sub(now))
+		}
+
+		for {
+			select {
+			case now = <-timer.C:
+				now = now.In(c.location)
+				// Run every entry whose next time was less than now
+				for _, e := range c.entries {
+					if e.Next.After(now) || e.Next.IsZero() {
+						break
+					}
+					go c.runWithRecovery(e.Job)
+					e.Prev = e.Next
+					e.Next = e.Schedule.Next(now)
+				}
+
+			case newEntry := <-c.add:
+				timer.Stop()
+				now = c.now()
+				newEntry.Next = newEntry.Schedule.Next(now)
+				c.entries = append(c.entries, newEntry)
+
+			case <-c.snapshot:
+				c.snapshot <- c.entrySnapshot()
+				continue
+
+			case <-c.stop:
+				timer.Stop()
+				return
+			}
+
+			break
+		}
+	}
+}
+
+// Logs an error to stderr or to the configured error log
+func (c *Cron) logf(format string, args ...interface{}) {
+	if c.ErrorLog != nil {
+		c.ErrorLog.Printf(format, args...)
+	} else {
+		log.Printf(format, args...)
+	}
+}
+
+// Stop stops the cron scheduler if it is running; otherwise it does nothing.
+func (c *Cron) Stop() {
+	if !c.running {
+		return
+	}
+	c.stop <- struct{}{}
+	c.running = false
+}
+
+// entrySnapshot returns a copy of the current cron entry list.
+func (c *Cron) entrySnapshot() []*Entry {
+	entries := []*Entry{}
+	for _, e := range c.entries {
+		entries = append(entries, &Entry{
+			Schedule: e.Schedule,
+			Next:     e.Next,
+			Prev:     e.Prev,
+			Job:      e.Job,
+		})
+	}
+	return entries
+}
+
+// now returns current time in c location
+func (c *Cron) now() time.Time {
+	return time.Now().In(c.location)
+}

--- a/vendor/github.com/robfig/cron/doc.go
+++ b/vendor/github.com/robfig/cron/doc.go
@@ -1,0 +1,129 @@
+/*
+Package cron implements a cron spec parser and job runner.
+
+Usage
+
+Callers may register Funcs to be invoked on a given schedule.  Cron will run
+them in their own goroutines.
+
+	c := cron.New()
+	c.AddFunc("0 30 * * * *", func() { fmt.Println("Every hour on the half hour") })
+	c.AddFunc("@hourly",      func() { fmt.Println("Every hour") })
+	c.AddFunc("@every 1h30m", func() { fmt.Println("Every hour thirty") })
+	c.Start()
+	..
+	// Funcs are invoked in their own goroutine, asynchronously.
+	...
+	// Funcs may also be added to a running Cron
+	c.AddFunc("@daily", func() { fmt.Println("Every day") })
+	..
+	// Inspect the cron job entries' next and previous run times.
+	inspect(c.Entries())
+	..
+	c.Stop()  // Stop the scheduler (does not stop any jobs already running).
+
+CRON Expression Format
+
+A cron expression represents a set of times, using 6 space-separated fields.
+
+	Field name   | Mandatory? | Allowed values  | Allowed special characters
+	----------   | ---------- | --------------  | --------------------------
+	Seconds      | Yes        | 0-59            | * / , -
+	Minutes      | Yes        | 0-59            | * / , -
+	Hours        | Yes        | 0-23            | * / , -
+	Day of month | Yes        | 1-31            | * / , - ?
+	Month        | Yes        | 1-12 or JAN-DEC | * / , -
+	Day of week  | Yes        | 0-6 or SUN-SAT  | * / , - ?
+
+Note: Month and Day-of-week field values are case insensitive.  "SUN", "Sun",
+and "sun" are equally accepted.
+
+Special Characters
+
+Asterisk ( * )
+
+The asterisk indicates that the cron expression will match for all values of the
+field; e.g., using an asterisk in the 5th field (month) would indicate every
+month.
+
+Slash ( / )
+
+Slashes are used to describe increments of ranges. For example 3-59/15 in the
+1st field (minutes) would indicate the 3rd minute of the hour and every 15
+minutes thereafter. The form "*\/..." is equivalent to the form "first-last/...",
+that is, an increment over the largest possible range of the field.  The form
+"N/..." is accepted as meaning "N-MAX/...", that is, starting at N, use the
+increment until the end of that specific range.  It does not wrap around.
+
+Comma ( , )
+
+Commas are used to separate items of a list. For example, using "MON,WED,FRI" in
+the 5th field (day of week) would mean Mondays, Wednesdays and Fridays.
+
+Hyphen ( - )
+
+Hyphens are used to define ranges. For example, 9-17 would indicate every
+hour between 9am and 5pm inclusive.
+
+Question mark ( ? )
+
+Question mark may be used instead of '*' for leaving either day-of-month or
+day-of-week blank.
+
+Predefined schedules
+
+You may use one of several pre-defined schedules in place of a cron expression.
+
+	Entry                  | Description                                | Equivalent To
+	-----                  | -----------                                | -------------
+	@yearly (or @annually) | Run once a year, midnight, Jan. 1st        | 0 0 0 1 1 *
+	@monthly               | Run once a month, midnight, first of month | 0 0 0 1 * *
+	@weekly                | Run once a week, midnight between Sat/Sun  | 0 0 0 * * 0
+	@daily (or @midnight)  | Run once a day, midnight                   | 0 0 0 * * *
+	@hourly                | Run once an hour, beginning of hour        | 0 0 * * * *
+
+Intervals
+
+You may also schedule a job to execute at fixed intervals, starting at the time it's added 
+or cron is run. This is supported by formatting the cron spec like this:
+
+    @every <duration>
+
+where "duration" is a string accepted by time.ParseDuration
+(http://golang.org/pkg/time/#ParseDuration).
+
+For example, "@every 1h30m10s" would indicate a schedule that activates after
+1 hour, 30 minutes, 10 seconds, and then every interval after that.
+
+Note: The interval does not take the job runtime into account.  For example,
+if a job takes 3 minutes to run, and it is scheduled to run every 5 minutes,
+it will have only 2 minutes of idle time between each run.
+
+Time zones
+
+All interpretation and scheduling is done in the machine's local time zone (as
+provided by the Go time package (http://www.golang.org/pkg/time).
+
+Be aware that jobs scheduled during daylight-savings leap-ahead transitions will
+not be run!
+
+Thread safety
+
+Since the Cron service runs concurrently with the calling code, some amount of
+care must be taken to ensure proper synchronization.
+
+All cron methods are designed to be correctly synchronized as long as the caller
+ensures that invocations have a clear happens-before ordering between them.
+
+Implementation
+
+Cron entries are stored in an array, sorted by their next activation time.  Cron
+sleeps until the next job is due to be run.
+
+Upon waking:
+ - it runs each entry that is active on that second
+ - it calculates the next run times for the jobs that were run
+ - it re-sorts the array of entries by next activation time.
+ - it goes to sleep until the soonest job.
+*/
+package cron

--- a/vendor/github.com/robfig/cron/parser.go
+++ b/vendor/github.com/robfig/cron/parser.go
@@ -1,0 +1,380 @@
+package cron
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Configuration options for creating a parser. Most options specify which
+// fields should be included, while others enable features. If a field is not
+// included the parser will assume a default value. These options do not change
+// the order fields are parse in.
+type ParseOption int
+
+const (
+	Second      ParseOption = 1 << iota // Seconds field, default 0
+	Minute                              // Minutes field, default 0
+	Hour                                // Hours field, default 0
+	Dom                                 // Day of month field, default *
+	Month                               // Month field, default *
+	Dow                                 // Day of week field, default *
+	DowOptional                         // Optional day of week field, default *
+	Descriptor                          // Allow descriptors such as @monthly, @weekly, etc.
+)
+
+var places = []ParseOption{
+	Second,
+	Minute,
+	Hour,
+	Dom,
+	Month,
+	Dow,
+}
+
+var defaults = []string{
+	"0",
+	"0",
+	"0",
+	"*",
+	"*",
+	"*",
+}
+
+// A custom Parser that can be configured.
+type Parser struct {
+	options   ParseOption
+	optionals int
+}
+
+// Creates a custom Parser with custom options.
+//
+//  // Standard parser without descriptors
+//  specParser := NewParser(Minute | Hour | Dom | Month | Dow)
+//  sched, err := specParser.Parse("0 0 15 */3 *")
+//
+//  // Same as above, just excludes time fields
+//  subsParser := NewParser(Dom | Month | Dow)
+//  sched, err := specParser.Parse("15 */3 *")
+//
+//  // Same as above, just makes Dow optional
+//  subsParser := NewParser(Dom | Month | DowOptional)
+//  sched, err := specParser.Parse("15 */3")
+//
+func NewParser(options ParseOption) Parser {
+	optionals := 0
+	if options&DowOptional > 0 {
+		options |= Dow
+		optionals++
+	}
+	return Parser{options, optionals}
+}
+
+// Parse returns a new crontab schedule representing the given spec.
+// It returns a descriptive error if the spec is not valid.
+// It accepts crontab specs and features configured by NewParser.
+func (p Parser) Parse(spec string) (Schedule, error) {
+	if len(spec) == 0 {
+		return nil, fmt.Errorf("Empty spec string")
+	}
+	if spec[0] == '@' && p.options&Descriptor > 0 {
+		return parseDescriptor(spec)
+	}
+
+	// Figure out how many fields we need
+	max := 0
+	for _, place := range places {
+		if p.options&place > 0 {
+			max++
+		}
+	}
+	min := max - p.optionals
+
+	// Split fields on whitespace
+	fields := strings.Fields(spec)
+
+	// Validate number of fields
+	if count := len(fields); count < min || count > max {
+		if min == max {
+			return nil, fmt.Errorf("Expected exactly %d fields, found %d: %s", min, count, spec)
+		}
+		return nil, fmt.Errorf("Expected %d to %d fields, found %d: %s", min, max, count, spec)
+	}
+
+	// Fill in missing fields
+	fields = expandFields(fields, p.options)
+
+	var err error
+	field := func(field string, r bounds) uint64 {
+		if err != nil {
+			return 0
+		}
+		var bits uint64
+		bits, err = getField(field, r)
+		return bits
+	}
+
+	var (
+		second     = field(fields[0], seconds)
+		minute     = field(fields[1], minutes)
+		hour       = field(fields[2], hours)
+		dayofmonth = field(fields[3], dom)
+		month      = field(fields[4], months)
+		dayofweek  = field(fields[5], dow)
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SpecSchedule{
+		Second: second,
+		Minute: minute,
+		Hour:   hour,
+		Dom:    dayofmonth,
+		Month:  month,
+		Dow:    dayofweek,
+	}, nil
+}
+
+func expandFields(fields []string, options ParseOption) []string {
+	n := 0
+	count := len(fields)
+	expFields := make([]string, len(places))
+	copy(expFields, defaults)
+	for i, place := range places {
+		if options&place > 0 {
+			expFields[i] = fields[n]
+			n++
+		}
+		if n == count {
+			break
+		}
+	}
+	return expFields
+}
+
+var standardParser = NewParser(
+	Minute | Hour | Dom | Month | Dow | Descriptor,
+)
+
+// ParseStandard returns a new crontab schedule representing the given standardSpec
+// (https://en.wikipedia.org/wiki/Cron). It differs from Parse requiring to always
+// pass 5 entries representing: minute, hour, day of month, month and day of week,
+// in that order. It returns a descriptive error if the spec is not valid.
+//
+// It accepts
+//   - Standard crontab specs, e.g. "* * * * ?"
+//   - Descriptors, e.g. "@midnight", "@every 1h30m"
+func ParseStandard(standardSpec string) (Schedule, error) {
+	return standardParser.Parse(standardSpec)
+}
+
+var defaultParser = NewParser(
+	Second | Minute | Hour | Dom | Month | DowOptional | Descriptor,
+)
+
+// Parse returns a new crontab schedule representing the given spec.
+// It returns a descriptive error if the spec is not valid.
+//
+// It accepts
+//   - Full crontab specs, e.g. "* * * * * ?"
+//   - Descriptors, e.g. "@midnight", "@every 1h30m"
+func Parse(spec string) (Schedule, error) {
+	return defaultParser.Parse(spec)
+}
+
+// getField returns an Int with the bits set representing all of the times that
+// the field represents or error parsing field value.  A "field" is a comma-separated
+// list of "ranges".
+func getField(field string, r bounds) (uint64, error) {
+	var bits uint64
+	ranges := strings.FieldsFunc(field, func(r rune) bool { return r == ',' })
+	for _, expr := range ranges {
+		bit, err := getRange(expr, r)
+		if err != nil {
+			return bits, err
+		}
+		bits |= bit
+	}
+	return bits, nil
+}
+
+// getRange returns the bits indicated by the given expression:
+//   number | number "-" number [ "/" number ]
+// or error parsing range.
+func getRange(expr string, r bounds) (uint64, error) {
+	var (
+		start, end, step uint
+		rangeAndStep     = strings.Split(expr, "/")
+		lowAndHigh       = strings.Split(rangeAndStep[0], "-")
+		singleDigit      = len(lowAndHigh) == 1
+		err              error
+	)
+
+	var extra uint64
+	if lowAndHigh[0] == "*" || lowAndHigh[0] == "?" {
+		start = r.min
+		end = r.max
+		extra = starBit
+	} else {
+		start, err = parseIntOrName(lowAndHigh[0], r.names)
+		if err != nil {
+			return 0, err
+		}
+		switch len(lowAndHigh) {
+		case 1:
+			end = start
+		case 2:
+			end, err = parseIntOrName(lowAndHigh[1], r.names)
+			if err != nil {
+				return 0, err
+			}
+		default:
+			return 0, fmt.Errorf("Too many hyphens: %s", expr)
+		}
+	}
+
+	switch len(rangeAndStep) {
+	case 1:
+		step = 1
+	case 2:
+		step, err = mustParseInt(rangeAndStep[1])
+		if err != nil {
+			return 0, err
+		}
+
+		// Special handling: "N/step" means "N-max/step".
+		if singleDigit {
+			end = r.max
+		}
+	default:
+		return 0, fmt.Errorf("Too many slashes: %s", expr)
+	}
+
+	if start < r.min {
+		return 0, fmt.Errorf("Beginning of range (%d) below minimum (%d): %s", start, r.min, expr)
+	}
+	if end > r.max {
+		return 0, fmt.Errorf("End of range (%d) above maximum (%d): %s", end, r.max, expr)
+	}
+	if start > end {
+		return 0, fmt.Errorf("Beginning of range (%d) beyond end of range (%d): %s", start, end, expr)
+	}
+	if step == 0 {
+		return 0, fmt.Errorf("Step of range should be a positive number: %s", expr)
+	}
+
+	return getBits(start, end, step) | extra, nil
+}
+
+// parseIntOrName returns the (possibly-named) integer contained in expr.
+func parseIntOrName(expr string, names map[string]uint) (uint, error) {
+	if names != nil {
+		if namedInt, ok := names[strings.ToLower(expr)]; ok {
+			return namedInt, nil
+		}
+	}
+	return mustParseInt(expr)
+}
+
+// mustParseInt parses the given expression as an int or returns an error.
+func mustParseInt(expr string) (uint, error) {
+	num, err := strconv.Atoi(expr)
+	if err != nil {
+		return 0, fmt.Errorf("Failed to parse int from %s: %s", expr, err)
+	}
+	if num < 0 {
+		return 0, fmt.Errorf("Negative number (%d) not allowed: %s", num, expr)
+	}
+
+	return uint(num), nil
+}
+
+// getBits sets all bits in the range [min, max], modulo the given step size.
+func getBits(min, max, step uint) uint64 {
+	var bits uint64
+
+	// If step is 1, use shifts.
+	if step == 1 {
+		return ^(math.MaxUint64 << (max + 1)) & (math.MaxUint64 << min)
+	}
+
+	// Else, use a simple loop.
+	for i := min; i <= max; i += step {
+		bits |= 1 << i
+	}
+	return bits
+}
+
+// all returns all bits within the given bounds.  (plus the star bit)
+func all(r bounds) uint64 {
+	return getBits(r.min, r.max, 1) | starBit
+}
+
+// parseDescriptor returns a predefined schedule for the expression, or error if none matches.
+func parseDescriptor(descriptor string) (Schedule, error) {
+	switch descriptor {
+	case "@yearly", "@annually":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    1 << dom.min,
+			Month:  1 << months.min,
+			Dow:    all(dow),
+		}, nil
+
+	case "@monthly":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    1 << dom.min,
+			Month:  all(months),
+			Dow:    all(dow),
+		}, nil
+
+	case "@weekly":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    all(dom),
+			Month:  all(months),
+			Dow:    1 << dow.min,
+		}, nil
+
+	case "@daily", "@midnight":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   1 << hours.min,
+			Dom:    all(dom),
+			Month:  all(months),
+			Dow:    all(dow),
+		}, nil
+
+	case "@hourly":
+		return &SpecSchedule{
+			Second: 1 << seconds.min,
+			Minute: 1 << minutes.min,
+			Hour:   all(hours),
+			Dom:    all(dom),
+			Month:  all(months),
+			Dow:    all(dow),
+		}, nil
+	}
+
+	const every = "@every "
+	if strings.HasPrefix(descriptor, every) {
+		duration, err := time.ParseDuration(descriptor[len(every):])
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse duration %s: %s", descriptor, err)
+		}
+		return Every(duration), nil
+	}
+
+	return nil, fmt.Errorf("Unrecognized descriptor: %s", descriptor)
+}

--- a/vendor/github.com/robfig/cron/spec.go
+++ b/vendor/github.com/robfig/cron/spec.go
@@ -1,0 +1,158 @@
+package cron
+
+import "time"
+
+// SpecSchedule specifies a duty cycle (to the second granularity), based on a
+// traditional crontab specification. It is computed initially and stored as bit sets.
+type SpecSchedule struct {
+	Second, Minute, Hour, Dom, Month, Dow uint64
+}
+
+// bounds provides a range of acceptable values (plus a map of name to value).
+type bounds struct {
+	min, max uint
+	names    map[string]uint
+}
+
+// The bounds for each field.
+var (
+	seconds = bounds{0, 59, nil}
+	minutes = bounds{0, 59, nil}
+	hours   = bounds{0, 23, nil}
+	dom     = bounds{1, 31, nil}
+	months  = bounds{1, 12, map[string]uint{
+		"jan": 1,
+		"feb": 2,
+		"mar": 3,
+		"apr": 4,
+		"may": 5,
+		"jun": 6,
+		"jul": 7,
+		"aug": 8,
+		"sep": 9,
+		"oct": 10,
+		"nov": 11,
+		"dec": 12,
+	}}
+	dow = bounds{0, 6, map[string]uint{
+		"sun": 0,
+		"mon": 1,
+		"tue": 2,
+		"wed": 3,
+		"thu": 4,
+		"fri": 5,
+		"sat": 6,
+	}}
+)
+
+const (
+	// Set the top bit if a star was included in the expression.
+	starBit = 1 << 63
+)
+
+// Next returns the next time this schedule is activated, greater than the given
+// time.  If no time can be found to satisfy the schedule, return the zero time.
+func (s *SpecSchedule) Next(t time.Time) time.Time {
+	// General approach:
+	// For Month, Day, Hour, Minute, Second:
+	// Check if the time value matches.  If yes, continue to the next field.
+	// If the field doesn't match the schedule, then increment the field until it matches.
+	// While incrementing the field, a wrap-around brings it back to the beginning
+	// of the field list (since it is necessary to re-verify previous field
+	// values)
+
+	// Start at the earliest possible time (the upcoming second).
+	t = t.Add(1*time.Second - time.Duration(t.Nanosecond())*time.Nanosecond)
+
+	// This flag indicates whether a field has been incremented.
+	added := false
+
+	// If no time is found within five years, return zero.
+	yearLimit := t.Year() + 5
+
+WRAP:
+	if t.Year() > yearLimit {
+		return time.Time{}
+	}
+
+	// Find the first applicable month.
+	// If it's this month, then do nothing.
+	for 1<<uint(t.Month())&s.Month == 0 {
+		// If we have to add a month, reset the other parts to 0.
+		if !added {
+			added = true
+			// Otherwise, set the date at the beginning (since the current time is irrelevant).
+			t = time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, t.Location())
+		}
+		t = t.AddDate(0, 1, 0)
+
+		// Wrapped around.
+		if t.Month() == time.January {
+			goto WRAP
+		}
+	}
+
+	// Now get a day in that month.
+	for !dayMatches(s, t) {
+		if !added {
+			added = true
+			t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+		}
+		t = t.AddDate(0, 0, 1)
+
+		if t.Day() == 1 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Hour())&s.Hour == 0 {
+		if !added {
+			added = true
+			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, t.Location())
+		}
+		t = t.Add(1 * time.Hour)
+
+		if t.Hour() == 0 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Minute())&s.Minute == 0 {
+		if !added {
+			added = true
+			t = t.Truncate(time.Minute)
+		}
+		t = t.Add(1 * time.Minute)
+
+		if t.Minute() == 0 {
+			goto WRAP
+		}
+	}
+
+	for 1<<uint(t.Second())&s.Second == 0 {
+		if !added {
+			added = true
+			t = t.Truncate(time.Second)
+		}
+		t = t.Add(1 * time.Second)
+
+		if t.Second() == 0 {
+			goto WRAP
+		}
+	}
+
+	return t
+}
+
+// dayMatches returns true if the schedule's day-of-week and day-of-month
+// restrictions are satisfied by the given time.
+func dayMatches(s *SpecSchedule, t time.Time) bool {
+	var (
+		domMatch bool = 1<<uint(t.Day())&s.Dom > 0
+		dowMatch bool = 1<<uint(t.Weekday())&s.Dow > 0
+	)
+	if s.Dom&starBit > 0 || s.Dow&starBit > 0 {
+		return domMatch && dowMatch
+	}
+	return domMatch || dowMatch
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -98,12 +98,14 @@ github.com/gardener/external-dns-management/pkg/client/dns/clientset/versioned/s
 # github.com/gardener/gardener v1.0.1
 github.com/gardener/gardener/pkg/api/extensions
 github.com/gardener/gardener/pkg/apis/core
+github.com/gardener/gardener/pkg/apis/core/helper
 github.com/gardener/gardener/pkg/apis/core/install
 github.com/gardener/gardener/pkg/apis/core/v1alpha1
 github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants
 github.com/gardener/gardener/pkg/apis/core/v1beta1
 github.com/gardener/gardener/pkg/apis/core/v1beta1/constants
 github.com/gardener/gardener/pkg/apis/core/v1beta1/helper
+github.com/gardener/gardener/pkg/apis/core/validation
 github.com/gardener/gardener/pkg/apis/extensions
 github.com/gardener/gardener/pkg/apis/extensions/v1alpha1
 github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper
@@ -415,6 +417,8 @@ github.com/prometheus/common/model
 # github.com/prometheus/procfs v0.0.3
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
+# github.com/robfig/cron v1.2.0
+github.com/robfig/cron
 # github.com/rogpeppe/go-internal v1.3.0
 github.com/rogpeppe/go-internal/modfile
 github.com/rogpeppe/go-internal/module


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR forces a zone order immutability for updates on the infrastructure and worker portions of a shoot. Since the AWS provider uses the zone index to create networks via Terraform as well as `MachineDeployments`, the index should be kept stable.

**Special notes for your reviewer**:
/cc @rfranzke - thanks for noticing!

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The AWS validator now checks that zone orders in a shoot resources is retained (only additions are allowed).
```
