### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:v0.26.2->v0.26.3]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -15,7 +15,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.26.2"
+  tag: "v0.26.3"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/machine-controller-manager #409 @prashanth26
Set deleteOnTermination flag to true while deleting the VMs in AWS.
```