### PR TITLE
Allow defining zones multiple times in infraConfig

### DIFF
--- a/pkg/apis/aws/validation/infrastructure.go
+++ b/pkg/apis/aws/validation/infrastructure.go
@@ -101,12 +101,8 @@ func ValidateInfrastructureConfig(infra *apisaws.InfrastructureConfig, nodesCIDR
 		workerCIDRs = make([]cidrvalidation.CIDR, 0, len(infra.Networks.Zones))
 	)
 
-	validatedZones := sets.NewString()
 	for i, zone := range infra.Networks.Zones {
 		zonePath := networksPath.Child("zones").Index(i)
-		if validatedZones.Has(zone.Name) {
-			allErrs = append(allErrs, field.Invalid(zonePath.Child("name"), zone.Name, "each zone may only be specified once"))
-		}
 
 		internalPath := zonePath.Child("internal")
 		cidrs = append(cidrs, cidrvalidation.NewCIDR(zone.Internal, internalPath))
@@ -120,8 +116,6 @@ func ValidateInfrastructureConfig(infra *apisaws.InfrastructureConfig, nodesCIDR
 		cidrs = append(cidrs, cidrvalidation.NewCIDR(zone.Workers, workerPath))
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(workerPath, zone.Workers)...)
 		workerCIDRs = append(workerCIDRs, cidrvalidation.NewCIDR(zone.Workers, workerPath))
-
-		validatedZones.Insert(zone.Name)
 	}
 
 	allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(cidrs...)...)

--- a/pkg/apis/aws/validation/infrastructure_test.go
+++ b/pkg/apis/aws/validation/infrastructure_test.go
@@ -142,17 +142,13 @@ var _ = Describe("InfrastructureConfig validation", func() {
 
 			})
 
-			It("should forbid adding a zone", func() {
+			It("should allow adding the same zone", func() {
 				infrastructureConfig.Networks.Zones = append(infrastructureConfig.Networks.Zones, awsZone2)
 				infrastructureConfig.Networks.Zones[1].Name = zone
 
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
 
-				Expect(errorList).To(ConsistOfFields(Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("networks.zones[1].name"),
-					"Detail": Equal("each zone may only be specified once"),
-				}))
+				Expect(errorList).To(BeEmpty())
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow defining zones multiple times in infraConfig.

**Special notes for your reviewer**:
/cc @rfranzke @hoeltcl 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The AWS validator now allows a zone being specified multiple times in the `InfrastructureConfig`.
```
