### PR TITLE
Increase create timeout for aws_route.private_utility_zX_nat

### DIFF
--- a/charts/internal/aws-infra/templates/main.tf
+++ b/charts/internal/aws-infra/templates/main.tf
@@ -211,6 +211,10 @@ resource "aws_route" "private_utility_z{{ $index }}_nat" {
   route_table_id         = "${aws_route_table.routetable_private_utility_z{{ $index }}.id}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${aws_nat_gateway.natgw_z{{ $index }}.id}"
+
+  timeouts {
+    create = "5m"
+  }
 }
 
 resource "aws_route_table_association" "routetable_private_utility_z{{ $index }}_association_private_utility_z{{ $index }}" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase create timeout for aws_route.private_utility_zX_nat.

**Which issue(s) this PR fixes**:
Ref https://github.com/gardener/gardener-extension-provider-aws/issues/5

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The create timeout for `aws_route.private_utility_zX_nat` is now increased to `5m`.
```
