### PR TITLE
allow modifying gateway endpoints inside vpc after shoot creation

### DIFF
--- a/pkg/apis/aws/validation/infrastructure.go
+++ b/pkg/apis/aws/validation/infrastructure.go
@@ -147,7 +147,11 @@ func ValidateInfrastructureConfig(infra *apisaws.InfrastructureConfig, nodesCIDR
 func ValidateInfrastructureConfigUpdate(oldConfig, newConfig *apisaws.InfrastructureConfig) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newConfig.Networks.VPC, oldConfig.Networks.VPC, field.NewPath("networks.vpc"))...)
+	vpcPath := field.NewPath("networks.vpc")
+	oldVPC := oldConfig.Networks.VPC
+	newVPC := newConfig.Networks.VPC
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newVPC.ID, oldVPC.ID, vpcPath.Child("id"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newVPC.CIDR, oldVPC.CIDR, vpcPath.Child("cidr"))...)
 
 	var (
 		oldZones = oldConfig.Networks.Zones

--- a/pkg/apis/aws/validation/infrastructure_test.go
+++ b/pkg/apis/aws/validation/infrastructure_test.go
@@ -365,7 +365,26 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should forbid changing the VPC", func() {
+		It("should allow changing gateway endpoints inside vpc", func() {
+			newInfraConfig := infrastructureConfig.DeepCopy()
+			newInfraConfig.Networks.VPC.GatewayEndpoints = []string{"myep"}
+			Expect(ValidateInfrastructureConfigUpdate(infrastructureConfig, newInfraConfig)).To(BeEmpty())
+		})
+
+		It("should forbid changing the VPC ID", func() {
+			newInfrastructureConfig := infrastructureConfig.DeepCopy()
+			newid := "the-new-id"
+			newInfrastructureConfig.Networks.VPC.ID = &newid
+
+			errorList := ValidateInfrastructureConfigUpdate(infrastructureConfig, newInfrastructureConfig)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("networks.vpc.id"),
+			}))))
+		})
+
+		It("should forbid changing the VPC CIDR", func() {
 			newInfrastructureConfig := infrastructureConfig.DeepCopy()
 			newCIDR := "1.2.3.4/5"
 			newInfrastructureConfig.Networks.VPC.CIDR = &newCIDR
@@ -374,7 +393,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("networks.vpc"),
+				"Field": Equal("networks.vpc.cidr"),
 			}))))
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Continues https://github.com/gardener/gardener-extension-provider-aws/pull/17

Currently the whole VPC section is immutable although gateway endpoints should be mutable. The change makes the immutable check more specific to `vpc.id` and `vpc.cidr`, and leaves `gatewayEndpoints` as a mutable field.

**Release note**:
```improvement operator
Now it is possible to modify the gateway endpoints list `networks.vpc.gatewayEndpoints` after the shoot is created.
```
