### PR TITLE
mtu customizer should use default network interface instead of eth0

### DIFF
--- a/pkg/webhook/controlplane/scripts/mtu-customizer.sh
+++ b/pkg/webhook/controlplane/scripts/mtu-customizer.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -eu
+
+MTU=1460
+DEFAULT_NETWORK_INTERFACE=$(ip route list | grep default | grep -E  'dev (\w+)' -o | awk '{print $2}')
+
+ip link set dev $DEFAULT_NETWORK_INTERFACE mtu 1460
+
+if [ $? -eq 0 ]
+then
+  echo "Successfully set MTU to $MTU for default network interface $DEFAULT_NETWORK_INTERFACE"
+else
+  echo "Failed to set MTU of $MTU to default network interface $DEFAULT_NETWORK_INTERFACE"
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

See attached issue.


**Which issue(s) this PR fixes**:
Fixes #52 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
