### PR TITLE
[ci:component:github.com/gardener/cloud-provider-aws:v1.17.4->v1.18.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -11,7 +11,12 @@ images:
   sourceRepository: github.com/gardener/cloud-provider-aws
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
   tag: "v1.17.4"
-  targetVersion: ">= 1.17"
+  targetVersion: "1.17.x"
+- name: cloud-controller-manager
+  sourceRepository: github.com/gardener/cloud-provider-aws
+  repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
+  tag: "v1.18.0"
+  targetVersion: ">= 1.18"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager


### PR DESCRIPTION
*Release Notes*:
```improvement operator github.com/gardener/cloud-provider-aws $87ca4e44cdf0d71377d4ce93d87241d509980e33
`k8s.io/legacy-cloud-providers` is now updated to `v1.18.0`.
```
