### PR TITLE
remove blocked-network cidr from kcm

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -198,16 +198,17 @@ func ensureKubeSchedulerCommandLineArgs(c *corev1.Container, csiEnabled, csiMigr
 }
 
 func ensureKubeControllerManagerLabels(t *corev1.PodTemplateSpec, csiEnabled, csiMigrationComplete bool) {
+	// make sure to always remove this label
+	delete(t.Labels, v1beta1constants.LabelNetworkPolicyToBlockedCIDRs)
+
 	if csiEnabled && csiMigrationComplete {
 		delete(t.Labels, v1beta1constants.LabelNetworkPolicyToPublicNetworks)
 		delete(t.Labels, v1beta1constants.LabelNetworkPolicyToPrivateNetworks)
-		delete(t.Labels, v1beta1constants.LabelNetworkPolicyToBlockedCIDRs)
 		return
 	}
 
 	t.Labels = extensionswebhook.EnsureAnnotationOrLabel(t.Labels, v1beta1constants.LabelNetworkPolicyToPublicNetworks, v1beta1constants.LabelNetworkPolicyAllowed)
 	t.Labels = extensionswebhook.EnsureAnnotationOrLabel(t.Labels, v1beta1constants.LabelNetworkPolicyToPrivateNetworks, v1beta1constants.LabelNetworkPolicyAllowed)
-	t.Labels = extensionswebhook.EnsureAnnotationOrLabel(t.Labels, v1beta1constants.LabelNetworkPolicyToBlockedCIDRs, v1beta1constants.LabelNetworkPolicyAllowed)
 }
 
 var (

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -127,7 +127,6 @@ var _ = Describe("Ensurer", func() {
 		kubeControllerManagerLabels = map[string]string{
 			v1beta1constants.LabelNetworkPolicyToPublicNetworks:  v1beta1constants.LabelNetworkPolicyAllowed,
 			v1beta1constants.LabelNetworkPolicyToPrivateNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
-			v1beta1constants.LabelNetworkPolicyToBlockedCIDRs:    v1beta1constants.LabelNetworkPolicyAllowed,
 		}
 	)
 
@@ -259,6 +258,11 @@ var _ = Describe("Ensurer", func() {
 				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeControllerManager},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								v1beta1constants.LabelNetworkPolicyToBlockedCIDRs: v1beta1constants.LabelNetworkPolicyAllowed,
+							},
+						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
@@ -319,6 +323,11 @@ var _ = Describe("Ensurer", func() {
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeControllerManager},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									v1beta1constants.LabelNetworkPolicyToBlockedCIDRs: v1beta1constants.LabelNetworkPolicyAllowed,
+								},
+							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
 									{
@@ -778,7 +787,7 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, l
 		Expect(c.Command).NotTo(ContainElement("--external-cloud-volume-plugin=aws"))
 		Expect(c.Env).NotTo(ContainElement(accessKeyIDEnvVar))
 		Expect(c.Env).NotTo(ContainElement(secretAccessKeyEnvVar))
-		Expect(dep.Spec.Template.Labels).To(BeNil())
+		Expect(dep.Spec.Template.Labels).To(BeEmpty())
 		Expect(dep.Spec.Template.Spec.Volumes).To(BeNil())
 		Expect(c.VolumeMounts).NotTo(ContainElement(cloudProviderConfigVolumeMount))
 		Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(cloudProviderConfigVolume))


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes access to blocked networks from `kube-controller-manager`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`kube-controller-manageer` no longer has access to blocked CIDRs.
```
