### PR TITLE
Set minAllowed memory for csi containers

### DIFF
--- a/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser-vpa.yaml
+++ b/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser-vpa.yaml
@@ -1,12 +1,12 @@
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
-    name: aws-lb-readvertiser-vpa
-    namespace: {{ .Release.Namespace }}
+  name: aws-lb-readvertiser-vpa
+  namespace: {{ .Release.Namespace }}
 spec:
-    targetRef:
-        apiVersion: {{ include "deploymentversion" . }}
-        kind: Deployment
-        name: aws-lb-readvertiser
-    updatePolicy:
-        updateMode: "Auto"
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: aws-lb-readvertiser
+  updatePolicy:
+    updateMode: "Auto"

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/vpa.yaml
@@ -5,6 +5,11 @@ metadata:
   name: csi-driver-controller-vpa
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        memory: 25Mi
   targetRef:
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently VPA can update the container memory request to be < 4MB which is not allowed by docker (ref https://docs.docker.com/config/containers/resource_constraints/)

```yaml
    name: csi-attacher
    resources:
      limits:
        cpu: 30m
        memory: 3200Ki
      requests:
        cpu: 10m
        memory: "2097152"
```

Similar container fails with:
```
$ k -n shoot--foo--bar get po | grep CreateContainerError
csi-driver-controller-7454d974c8-mvdx9        5/6     CreateContainerError   0          25m

$ k -n shoot--foo--bar describe po csi-driver-controller-7454d974c8-mvdx9


  Warning  Failed     23m (x2 over 24m)    kubelet, ip-10-242-31-64.eu-west-1.compute.internal  Error: Error response from daemon: Minimum memory limit allowed is 4MB
```

There is also https://github.com/gardener/gardener/pull/2164. Hence, this PR prevents `csi-driver-controller` containers to be less than 25Mi.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue preventing `csi-driver-controller` container to start because of too low memory recommendation by VPA is now fixed.
```
