### PR TITLE
Enforce workerConfig for io1 volumes

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -979,6 +979,11 @@ it is not used in requests to create gp2, st1, sc1, or standard volumes.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="aws.provider.extensions.gardener.cloud/v1alpha1.VolumeType">VolumeType
+(<code>string</code> alias)</p></h3>
+<p>
+<p>VolumeType is a constant for volume types.</p>
+</p>
 <h3 id="aws.provider.extensions.gardener.cloud/v1alpha1.Zone">Zone
 </h3>
 <p>

--- a/pkg/apis/aws/types_worker.go
+++ b/pkg/apis/aws/types_worker.go
@@ -70,3 +70,13 @@ type MachineImage struct {
 	// AMI is the AMI for the machine image.
 	AMI string
 }
+
+// VolumeType is a constant for volume types.
+type VolumeType string
+
+const (
+	// VolumeTypeIO1 is a constant for the io1 volume type.
+	VolumeTypeIO1 VolumeType = "io1"
+	// VolumeTypeGP2 is a constant for the gp2 volume type.
+	VolumeTypeGP2 VolumeType = "gp2"
+)

--- a/pkg/apis/aws/v1alpha1/types_worker.go
+++ b/pkg/apis/aws/v1alpha1/types_worker.go
@@ -74,3 +74,13 @@ type MachineImage struct {
 	// AMI is the AMI for the machine image.
 	AMI string `json:"ami"`
 }
+
+// VolumeType is a constant for volume types.
+type VolumeType string
+
+const (
+	// VolumeTypeIO1 is a constant for the io1 volume type.
+	VolumeTypeIO1 VolumeType = "io1"
+	// VolumeTypeGP2 is a constant for the gp2 volume type.
+	VolumeTypeGP2 VolumeType = "gp2"
+)

--- a/pkg/apis/aws/validation/shoot.go
+++ b/pkg/apis/aws/validation/shoot.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
-
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -52,6 +51,10 @@ func ValidateWorkers(workers []core.Worker, zones []apisaws.Zone, fldPath *field
 			allErrs = append(allErrs, field.Required(fldPath.Index(i).Child("volume"), "must not be nil"))
 		} else {
 			allErrs = append(allErrs, validateVolume(worker.Volume, fldPath.Index(i).Child("volume"))...)
+
+			if worker.Volume.Type != nil && *worker.Volume.Type == string(apisaws.VolumeTypeIO1) && worker.ProviderConfig == nil {
+				allErrs = append(allErrs, field.Required(fldPath.Index(i).Child("providerConfig"), fmt.Sprintf("WorkerConfig must be set if volume type is %s", apisaws.VolumeTypeIO1)))
+			}
 		}
 
 		if len(worker.Zones) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
If no `iops` are set when `io1` volumes are used then we should return an error in the validation of the `Shoot`, otherwise the `Worker` controller will fail, eventually, because MCM will complain:

```
E0423 11:13:31.849445       1 awsmachineclass.go:126] Validation of AWSMachineClass failed spec.blockDevices[0].ebs.iops: Required value: Please mention a valid ebs volume iops
```

/kind bug

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
When worker pools with the `io1` volume type are used then the validation does now enforce that the `.spec.provider.workers[].providerConfig` does contain a proper AWS `WorkerConfig` (that states the iops).
```
