### PR TITLE
Add zone label to machine classes

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -5,9 +5,9 @@ kind: Secret
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
-{{- if $machineClass.labels }}
+{{- if $machineClass.secret.labels }}
   labels:
-{{ toYaml $machineClass.labels | indent 4 }}
+{{ toYaml $machineClass.secret.labels | indent 4 }}
 {{- end }}
 type: Opaque
 data:
@@ -20,6 +20,10 @@ kind: AWSMachineClass
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
+{{- if $machineClass.labels }}
+  labels:
+{{ toYaml $machineClass.labels | indent 4 }}
+{{- end }}
 spec:
   ami: {{ $machineClass.ami }}
   region: {{ $machineClass.region }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -19,6 +19,8 @@ machineClasses:
     accessKeyID: ABCD
     secretAccessKey: ABCD
     cloudConfig: base64(abc)
+  # labels:
+  #   foo: bar
   blockDevices:
   - ebs:
       volumeSize: 50

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -30,6 +30,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -198,11 +199,10 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			})
 
 			machineClassSpec["name"] = className
-			machineClassSpec["labels"] = map[string]string{
-				v1beta1constants.GardenerPurpose: genericworkeractuator.GardenPurposeMachineClass,
-			}
+			machineClassSpec["labels"] = map[string]string{corev1.LabelZoneFailureDomain: zone}
 			machineClassSpec["secret"].(map[string]interface{})[aws.AccessKeyID] = string(machineClassSecretData[machinev1alpha1.AWSAccessKeyID])
 			machineClassSpec["secret"].(map[string]interface{})[aws.SecretAccessKey] = string(machineClassSecretData[machinev1alpha1.AWSSecretAccessKey])
+			machineClassSpec["secret"].(map[string]interface{})["labels"] = map[string]string{v1beta1constants.GardenerPurpose: genericworkeractuator.GardenPurposeMachineClass}
 
 			machineClasses = append(machineClasses, machineClassSpec)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the zone information label to the `AWSMachineClass` to allow the cluster-autoscaler scaling to/from zero.

**Which issue(s) this PR fixes**:
Fixes #77

**Special notes for your reviewer**:
/cc @hardikdr @prashanth26 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
NONE
```
