### PR TITLE
Support add custom tags on AWS EC2

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -146,6 +146,14 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			ebs["iops"] = *workerConfig.Volume.IOPS
 		}
 
+		ec2InstanceTags := map[string]string{
+			fmt.Sprintf("kubernetes.io/cluster/%s", w.worker.Namespace): "1",
+			"kubernetes.io/role/node":                                   "1",
+		}
+		for k, v := range pool.Labels {
+			ec2InstanceTags[k] = v
+		}
+
 		for zoneIndex, zone := range pool.Zones {
 			zoneIdx := int32(zoneIndex)
 
@@ -166,10 +174,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 						"securityGroupIDs": []string{nodesSecurityGroup.ID},
 					},
 				},
-				"tags": map[string]string{
-					fmt.Sprintf("kubernetes.io/cluster/%s", w.worker.Namespace): "1",
-					"kubernetes.io/role/node":                                   "1",
-				},
+				"tags": ec2InstanceTags,
 				"secret": map[string]interface{}{
 					"cloudConfig": string(pool.UserData),
 				},

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -122,6 +122,8 @@ var _ = Describe("Machines", func() {
 				zone1       string
 				zone2       string
 
+				labels map[string]string
+
 				workerPoolHash1 string
 				workerPoolHash2 string
 
@@ -173,6 +175,8 @@ var _ = Describe("Machines", func() {
 				subnetZone2 = "subnet-4321dbca"
 				zone1 = region + "a"
 				zone2 = region + "b"
+
+				labels = map[string]string{"component": "TiDB"}
 
 				shootVersionMajorMinor = "1.2"
 				shootVersion = shootVersionMajorMinor + ".3"
@@ -300,6 +304,7 @@ var _ = Describe("Machines", func() {
 									zone1,
 									zone2,
 								},
+								Labels: labels,
 							},
 							{
 								Name:           namePool2,
@@ -321,6 +326,7 @@ var _ = Describe("Machines", func() {
 									zone1,
 									zone2,
 								},
+								Labels: labels,
 							},
 						},
 					},
@@ -345,6 +351,13 @@ var _ = Describe("Machines", func() {
 				)
 
 				BeforeEach(func() {
+					ec2InstanceTags := map[string]string{
+						fmt.Sprintf("kubernetes.io/cluster/%s", namespace): "1",
+						"kubernetes.io/role/node":                          "1",
+					}
+					for k, v := range labels {
+						ec2InstanceTags[k] = v
+					}
 					defaultMachineClass = map[string]interface{}{
 						"secret": map[string]interface{}{
 							"cloudConfig": string(userData),
@@ -354,10 +367,7 @@ var _ = Describe("Machines", func() {
 						"machineType":        machineType,
 						"iamInstanceProfile": instanceProfileName,
 						"keyName":            keyName,
-						"tags": map[string]string{
-							fmt.Sprintf("kubernetes.io/cluster/%s", namespace): "1",
-							"kubernetes.io/role/node":                          "1",
-						},
+						"tags":               ec2InstanceTags,
 						"blockDevices": []map[string]interface{}{
 							{
 								"ebs": map[string]interface{}{
@@ -446,6 +456,7 @@ var _ = Describe("Machines", func() {
 							Maximum:        worker.DistributeOverZones(0, maxPool1, 2),
 							MaxSurge:       worker.DistributePositiveIntOrPercent(0, maxSurgePool1, 2, maxPool1),
 							MaxUnavailable: worker.DistributePositiveIntOrPercent(0, maxUnavailablePool1, 2, minPool1),
+							Labels:         labels,
 						},
 						{
 							Name:           machineClassNamePool1Zone2,
@@ -455,6 +466,7 @@ var _ = Describe("Machines", func() {
 							Maximum:        worker.DistributeOverZones(1, maxPool1, 2),
 							MaxSurge:       worker.DistributePositiveIntOrPercent(1, maxSurgePool1, 2, maxPool1),
 							MaxUnavailable: worker.DistributePositiveIntOrPercent(1, maxUnavailablePool1, 2, minPool1),
+							Labels:         labels,
 						},
 						{
 							Name:           machineClassNamePool2Zone1,
@@ -464,6 +476,7 @@ var _ = Describe("Machines", func() {
 							Maximum:        worker.DistributeOverZones(0, maxPool2, 2),
 							MaxSurge:       worker.DistributePositiveIntOrPercent(0, maxSurgePool2, 2, maxPool2),
 							MaxUnavailable: worker.DistributePositiveIntOrPercent(0, maxUnavailablePool2, 2, minPool2),
+							Labels:         labels,
 						},
 						{
 							Name:           machineClassNamePool2Zone2,
@@ -473,6 +486,7 @@ var _ = Describe("Machines", func() {
 							Maximum:        worker.DistributeOverZones(1, maxPool2, 2),
 							MaxSurge:       worker.DistributePositiveIntOrPercent(1, maxSurgePool2, 2, maxPool2),
 							MaxUnavailable: worker.DistributePositiveIntOrPercent(1, maxUnavailablePool2, 2, minPool2),
+							Labels:         labels,
 						},
 					}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Like PR https://github.com/gardener/gardener-extension-provider-gcp/pull/90
This PR will add worker pool labels to AWS EC2, with this feature we can add custom labels to AWS EC2

**Which issue(s) this PR fixes**:
Fixes # 
No issue is opened, but there is one GCP issue https://github.com/gardener/gardener-extension-provider-gcp/issues/82

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
WorkerPool labels will be added to  AWS EC2 as the VM tag
```
