### PR TITLE
Use Terraform resource timeouts and workqueue backoff

### DIFF
--- a/charts/internal/aws-infra/templates/main.tf
+++ b/charts/internal/aws-infra/templates/main.tf
@@ -59,12 +59,21 @@ resource "aws_route" "public" {
   route_table_id         = "${aws_route_table.routetable_main.id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "{{ required "vpc.internetGatewayID is required" .Values.vpc.internetGatewayID }}"
+
+  timeouts {
+    create = "5m"
+  }
 }
 
 resource "aws_security_group" "nodes" {
   name        = "{{ required "clusterName is required" .Values.clusterName }}-nodes"
   description = "Security group for nodes"
   vpc_id      = "{{ required "vpc.id is required" .Values.vpc.id }}"
+
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
 
 {{ include "aws-infra.tags-with-suffix" (set $.Values "suffix" "nodes") | indent 2 }}
 }
@@ -111,6 +120,11 @@ resource "aws_subnet" "nodes_z{{ $index }}" {
   cidr_block        = "{{ required "zone.worker is required" $zone.worker }}"
   availability_zone = "{{ required "zone.name is required" $zone.name }}"
 
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
+
 {{ include "aws-infra.tags-with-suffix" (set $.Values "suffix" (print "nodes-z" $index)) | indent 2 }}
 }
 
@@ -122,6 +136,11 @@ resource "aws_subnet" "private_utility_z{{ $index }}" {
   vpc_id            = "{{ required "vpc.id is required" $.Values.vpc.id }}"
   cidr_block        = "{{ required "zone.internal is required" $zone.internal }}"
   availability_zone = "{{ required "zone.name is required" $zone.name }}"
+
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
 
   tags = {
     Name = "{{ required "clusterName is required" $.Values.clusterName }}-private-utility-z{{ $index }}"
@@ -152,6 +171,11 @@ resource "aws_subnet" "public_utility_z{{ $index }}" {
   vpc_id            = "{{ required "vpc.id is required" $.Values.vpc.id }}"
   cidr_block        = "{{ required "zone.public is required" $zone.public }}"
   availability_zone = "{{ required "zone.name is required" $zone.name }}"
+
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
 
   tags = {
     Name = "{{ required "clusterName is required" $.Values.clusterName }}-public-utility-z{{ $index }}"

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -23,7 +23,6 @@ import (
 	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-	controllererrors "github.com/gardener/gardener/extensions/pkg/controller/error"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -107,10 +106,7 @@ func Delete(
 	)
 
 	if err := f.Run(flow.Opts{Context: ctx, Logger: glogger.NewFieldLogger(glogger.NewLogger("info"), "infrastructure", infrastructure.Name)}); err != nil {
-		return &controllererrors.RequeueAfterError{
-			Cause:        flow.Causes(err),
-			RequeueAfter: 30 * time.Second,
-		}
+		return flow.Causes(err)
 	}
 
 	return nil

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	awsv1alpha1 "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
@@ -28,7 +27,6 @@ import (
 	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-	controllererrors "github.com/gardener/gardener/extensions/pkg/controller/error"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
@@ -63,7 +61,6 @@ func Reconcile(
 	*terraformer.RawState,
 	error,
 ) {
-
 	credentials, err := aws.GetCredentialsFromSecretRef(ctx, c, infrastructure.Spec.SecretRef)
 	if err != nil {
 		return nil, nil, err
@@ -101,10 +98,7 @@ func Reconcile(
 		Apply(); err != nil {
 
 		logger.Error(err, "failed to apply the terraform config", "infrastructure", infrastructure.Name)
-		return nil, nil, &controllererrors.RequeueAfterError{
-			Cause:        err,
-			RequeueAfter: 30 * time.Second,
-		}
+		return nil, nil, err
 	}
 
 	return computeProviderStatus(ctx, tf, infrastructureConfig)


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we add some timeouts for those Terraform resources that are supporting it. Also, we will no longer requeue with the constant `30s` on errors but leverage the exponential backoff functionality of the underlying workqueue.

Part of gardener/gardener#2253

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
