### PR TITLE
Prevent errors to be logged multiple times

### DIFF
--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -39,7 +38,7 @@ import (
 )
 
 func (a *actuator) Reconcile(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, _ *extensionscontroller.Cluster) error {
-	infrastructureStatus, state, err := Reconcile(ctx, a.logger, a.RESTConfig(), a.Client(), a.Decoder(), a.ChartRenderer(), infrastructure, terraformer.StateConfigMapInitializerFunc(terraformer.CreateState))
+	infrastructureStatus, state, err := Reconcile(ctx, a.RESTConfig(), a.Client(), a.Decoder(), a.ChartRenderer(), infrastructure, terraformer.StateConfigMapInitializerFunc(terraformer.CreateState))
 	if err != nil {
 		return err
 	}
@@ -49,7 +48,6 @@ func (a *actuator) Reconcile(ctx context.Context, infrastructure *extensionsv1al
 // Reconcile reconciles the given Infrastructure object. It returns the provider specific status and the Terraform state.
 func Reconcile(
 	ctx context.Context,
-	logger logr.Logger,
 	restConfig *rest.Config,
 	c client.Client,
 	decoder runtime.Decoder,
@@ -97,8 +95,7 @@ func Reconcile(
 		)).
 		Apply(); err != nil {
 
-		logger.Error(err, "failed to apply the terraform config", "infrastructure", infrastructure.Name)
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to apply the terraform config: %+v", err)
 	}
 
 	return computeProviderStatus(ctx, tf, infrastructureConfig)

--- a/pkg/controller/infrastructure/actuator_restore.go
+++ b/pkg/controller/infrastructure/actuator_restore.go
@@ -29,7 +29,7 @@ func (a *actuator) Restore(ctx context.Context, infrastructure *extensionsv1alph
 		return err
 	}
 
-	infrastructureStatus, state, err := Reconcile(ctx, a.logger, a.RESTConfig(), a.Client(), a.Decoder(), a.ChartRenderer(), infrastructure, terraformer.CreateOrUpdateState{State: &terraformState.Data})
+	infrastructureStatus, state, err := Reconcile(ctx, a.RESTConfig(), a.Client(), a.Decoder(), a.ChartRenderer(), infrastructure, terraformer.CreateOrUpdateState{State: &terraformState.Data})
 	if err != nil {
 		return err
 	}

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -261,7 +261,7 @@ var _ = Describe("Infrastructure tests", func() {
 			}()
 
 			By("reconcile infrastructure")
-			infraStatus, _, err := infrastructure.Reconcile(ctx, logger, restConfig, c, decoder, chartRenderer, infra, terraformer.StateConfigMapInitializerFunc(terraformer.CreateState))
+			infraStatus, _, err := infrastructure.Reconcile(ctx, restConfig, c, decoder, chartRenderer, infra, terraformer.StateConfigMapInitializerFunc(terraformer.CreateState))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("test infrastructure reconciliation")


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent errors to be logged multiple times.

**Which issue(s) this PR fixes**:
Ref gardener/gardener#2325

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
