### PR TITLE
Support multiple EBS disks and encryption when creating machines

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -138,6 +138,31 @@ For `io1` volume type, this represents the number of IOPS that are provisioned f
 For `gp2` volume type, this represents the baseline performance of the volume and the rate at which the volume accumulates I/O credits for bursting. For more information about General Purpose SSD baseline performance, I/O credits, and bursting, see Amazon EBS Volume Types (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html) in the Amazon Elastic Compute Cloud User Guide.\
 Constraint: Range is 100-20000 IOPS for `io1` volumes and 100-10000 IOPS for `gp2` volumes.
 
+Apart from this configuration, the AWS extension supports encryption for volumes plus support for additional data volumes per machine.
+By default (if not stated otherwise), all the disks are unencrypted.
+For each data volume, you have to specify a name.
+The following YAML is a snippet of a `Shoot` resource:
+
+```yaml
+spec:
+  provider:
+    workers:
+    - name: cpu-worker
+      ...
+      volume:
+        type: gp2
+        size: 20Gi
+        encrypted: true
+      dataVolumes:
+      - name: kubelet-dir
+        type: gp2
+        size: 25Gi
+        encrypted: true
+```
+
+Please note that the IOPS you might have configured only apply to the root disk (`.spec.provider.workers[].volume`) for now.
+In the future it will be possible to configure IOPS individually per disk (i.e., also for the data volumes). 
+
 ## Example `Shoot` manifest (one availability zone)
 
 Please find below an example `Shoot` manifest for one availability zone:

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -102,5 +102,11 @@ spec:
     volume:
       type: gp2
       size: 20Gi
+  #   encrypted: false
+  # dataVolumes:
+  # - name: kubelet-dir
+  #   type: gp2
+  #   size: 21Gi
+  #   encrypted: true
     zones:
     - eu-west-1a

--- a/pkg/apis/aws/validation/shoot.go
+++ b/pkg/apis/aws/validation/shoot.go
@@ -52,6 +52,17 @@ func ValidateWorkers(workers []core.Worker, zones []apisaws.Zone, fldPath *field
 		} else {
 			allErrs = append(allErrs, validateVolume(worker.Volume, fldPath.Index(i).Child("volume"))...)
 
+			if length := len(worker.DataVolumes); length > 11 {
+				allErrs = append(allErrs, field.TooMany(fldPath.Index(i).Child("dataVolumes"), length, 11))
+			}
+			for j, volume := range worker.DataVolumes {
+				dataVolPath := fldPath.Index(i).Child("dataVolumes").Index(j)
+				if volume.Name == nil {
+					allErrs = append(allErrs, field.Required(dataVolPath.Child("name"), "must not be empty"))
+				}
+				allErrs = append(allErrs, validateVolume(volume.DeepCopy(), dataVolPath)...)
+			}
+
 			if worker.Volume.Type != nil && *worker.Volume.Type == string(apisaws.VolumeTypeIO1) && worker.ProviderConfig == nil {
 				allErrs = append(allErrs, field.Required(fldPath.Index(i).Child("providerConfig"), fmt.Sprintf("WorkerConfig must be set if volume type is %s", apisaws.VolumeTypeIO1)))
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area storage
/kind enhancement
/priority normal
/platform aws

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/1893 was merged quite some time ago, this PR now adds support for the AWS extension to handle multiple EBS disks for the worker machines. Additionally, it now supports configuring them for encryption.

**Which issue(s) this PR fixes**:
Ref https://github.com/gardener/machine-controller-manager/issues/462
Ref https://github.com/gardener/gardener/issues/2354

**Special notes for your reviewer**:
* Thanks @guydaichs for your work and contributions!
* For now, the `.volume.iops` in the `WorkerConfig` would be only applied to the root disk. In a follow-up PR I'll make it configurable per volume.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
It is now possible to configure additional data volumes for the worker machines. Additionally, it can be configured whether the disks shall be encrypted or not (default: `false`). Please consult [this documentation](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage-as-end-user.md#workerconfig) for more information.
```
