### PR TITLE
Adapt to terrafom v0.12 language changes

### DIFF
--- a/charts/internal/aws-infra/templates/variables.tf
+++ b/charts/internal/aws-infra/templates/variables.tf
@@ -1,9 +1,9 @@
 variable "ACCESS_KEY_ID" {
   description = "AWS Access Key ID of technical user"
-  type        = "string"
+  type        = string
 }
 
 variable "SECRET_ACCESS_KEY" {
   description = "AWS Secret Access Key of technical user"
-  type        = "string"
+  type        = string
 }

--- a/charts/internal/aws-infra/values.yaml
+++ b/charts/internal/aws-infra/values.yaml
@@ -10,10 +10,10 @@ clusterName: test-namespace
 enableECRAccess: true
 
 vpc:
-  id: ${aws_vpc.vpc.id}
+  id: aws_vpc.vpc.id
   cidr: 10.10.10.10/6
   dhcpDomainName: eu-west-1.compute.internal
-  internetGatewayID: ${aws_internet_gateway.igw.id}
+  internetGatewayID: aws_internet_gateway.igw.id
   gatewayEndpoints: []
 
 zones:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/kind cleanup
/priority normal
/platform aws

**What this PR does / why we need it**:
With https://github.com/gardener-attic/gardener-extensions/pull/336 , we adapted our terraform configuration to be v0.12 compatible preserving the v0.11 compatibility.
There are major changes introduced in the terraform language with v0.12 and terraform v0.12 is backwards-compatible accepting also terraform v0.11 configuration.
Starting from `v0.12.14`, terraform is emitting deprecation warning when old form is being used:

```
Warning: Interpolation-only expressions are deprecated

  on tf/main.tf line 2, in provider "aws":
   2:   access_key = "${var.ACCESS_KEY_ID}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.

(and 35 more similar warnings elsewhere)


Warning: Quoted type constraints are deprecated

  on tf/variables.tf line 3, in variable "ACCESS_KEY_ID":
   3:   type        = "string"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "string".

(and one more similar warning elsewhere)
```

See https://github.com/hashicorp/terraform/releases/tag/v0.12.14 for a detailed explanation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Until now `provider-aws` was maintaining a Terraform configuration which is both `v0.12` and `v0.11` compatible. The Terraform configuration is now adapted to the new Terraform language which makes it Terraform `v0.11` incompatible.
```
