### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:v0.29.0->v0.30.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -21,7 +21,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.29.0"
+  tag: "v0.30.0"
 - name: aws-lb-readvertiser
   sourceRepository: github.com/gardener/aws-lb-readvertiser
   repository: eu.gcr.io/gardener-project/gardener/aws-lb-readvertiser


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/machine-controller-manager #464 @hardikdr
Enable support of snapshot-based volumes for machines in AWS.
```

``` noteworthy developer github.com/gardener/machine-controller-manager #460 @prashanth26
Support for external / OOT (Out Of Tree) machine controller. A new provider can be maintained out of the core MCM repository.
```