### PR TITLE
Prevent panic when the worker has no providerConfig

### DIFF
--- a/pkg/apis/aws/validation/shoot.go
+++ b/pkg/apis/aws/validation/shoot.go
@@ -80,7 +80,9 @@ func ValidateWorker(worker core.Worker, zones []apisaws.Zone, workerConfig *apis
 		allErrs = append(allErrs, validateZones(worker.Zones, awsZones, fldPath.Child("zones"))...)
 	}
 
-	allErrs = append(allErrs, ValidateWorkerConfig(workerConfig, worker.Volume, worker.DataVolumes, fldPath.Child("providerConfig"))...)
+	if workerConfig != nil {
+		allErrs = append(allErrs, ValidateWorkerConfig(workerConfig, worker.Volume, worker.DataVolumes, fldPath.Child("providerConfig"))...)
+	}
 
 	return allErrs
 }

--- a/pkg/apis/aws/validation/shoot_test.go
+++ b/pkg/apis/aws/validation/shoot_test.go
@@ -89,7 +89,13 @@ var _ = Describe("Shoot validation", func() {
 			}
 		})
 
-		Describe("#ValidateWorke", func() {
+		Describe("#ValidateWorker", func() {
+			It("should pass when the workerConfig is nil", func() {
+				errorList := ValidateWorker(worker, awsZones, nil, field.NewPath(""))
+
+				Expect(errorList).To(BeEmpty())
+			})
+
 			It("should pass because the worker is configured correctly", func() {
 				errorList := ValidateWorker(worker, awsZones, &apisaws.WorkerConfig{}, field.NewPath(""))
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind bug
/priority normal
/platform aws

**What this PR does / why we need it**:
Currently validator-aws panics when the worker has no providerConfig.

```
{"level":"info","ts":"2020-06-09T07:16:12.321Z","logger":"controller-runtime.certwatcher","msg":"Starting certificate watcher"}
2020/06/09 07:16:15 http: panic serving 10.40.0.177:52956: runtime error: invalid memory address or nil pointer dereference
goroutine 272 [running]:
net/http.(*conn).serve.func1(0xc0001d3720)
        /usr/local/go/src/net/http/server.go:1772 +0x139
panic(0x18ca8e0, 0x2b412a0)
        /usr/local/go/src/runtime/panic.go:975 +0x3e3
github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/validation.ValidateWorkerConfig(0x0, 0xc000884a50, 0x0, 0x0, 0x0, 0xc0008bb410, 0xc0008bb410, 0x0, 0x0)
        /go/src/github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/validation/worker.go:33 +0xd01
github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/validation.ValidateWorker(0x0, 0x0, 0x0, 0x0, 0x0, 0xc000b0ab28, 0x8, 0xc000b0ab38, 0x8, 0xc000884a80, ...)
        /go/src/github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/validation/shoot.go:83 +0x7ba
github.com/gardener/gardener-extension-provider-aws/pkg/validator.(*Shoot).validateShoot(0xc00017f620, 0x1dc1720, 0xc0007e1e80, 0xc00045bc00, 0x1, 0x1)
        /go/src/github.com/gardener/gardener-extension-provider-aws/pkg/validator/shoot_validator.go:73 +0x47f
github.com/gardener/gardener-extension-provider-aws/pkg/validator.(*Shoot).validateShootUpdate(0xc00017f620, 0x1dc1720, 0xc0007e1e80, 0xc00063dc00, 0xc00045bc00, 0x1d88ee0, 0xc00063dc00)
        /go/src/github.com/gardener/gardener-extension-provider-aws/pkg/validator/shoot_validator.go:124 +0x313
github.com/gardener/gardener-extension-provider-aws/pkg/validator.(*Shoot).Handle(0xc00017f620, 0x1dc1720, 0xc0007e1e80, 0xc000737950, 0x24, 0xc000d9b6e0, 0x13, 0xc000c1a4c0, 0x7, 0xc000c1a4c7, ...)
        /go/src/github.com/gardener/gardener-extension-provider-aws/pkg/validator/shoot_handler.go:65 +0x682
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle(0xc00017f650, 0x1dc1720, 0xc0007e1e80, 0xc000737950, 0x24, 0xc000d9b6e0, 0x13, 0xc000c1a4c0, 0x7, 0xc000c1a4c7, ...)
        /go/src/github.com/gardener/gardener-extension-provider-aws/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/webhook.go:135 +0xa7
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP(0xc00017f650, 0x1dbca20, 0xc00061c380, 0xc000518600)
        /go/src/github.com/gardener/gardener-extension-provider-aws/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/http.go:87 +0xada
sigs.k8s.io/controller-runtime/pkg/webhook.instrumentedHook.func1(0x1dbca20, 0xc00061c380, 0xc000518600)
        /go/src/github.com/gardener/gardener-extension-provider-aws/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/server.go:129 +0xec
net/http.HandlerFunc.ServeHTTP(0xc00017f6b0, 0x1dbca20, 0xc00061c380, 0xc000518600)
        /usr/local/go/src/net/http/server.go:2012 +0x44
net/http.(*ServeMux).ServeHTTP(0xc0007e1c40, 0x1dbca20, 0xc00061c380, 0xc000518600)
        /usr/local/go/src/net/http/server.go:2387 +0x1a5
net/http.serverHandler.ServeHTTP(0xc0002be0e0, 0x1dbca20, 0xc00061c380, 0xc000518600)
        /usr/local/go/src/net/http/server.go:2807 +0xa3
net/http.(*conn).serve(0xc0001d3720, 0x1dc1720, 0xc0007e1d80)
        /usr/local/go/src/net/http/server.go:1895 +0x86c
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:2933 +0x35c
2020/06/09 07:16:15 http: panic serving 10.40.0.177:52958: runtime error: invalid memory address or nil pointer dereference
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
