### PR TITLE
Remove NoExecute toleration from CCM and LB readvertiser

### DIFF
--- a/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser.yaml
+++ b/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser.yaml
@@ -25,9 +25,6 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-      tolerations:
-      - effect: NoExecute
-        operator: Exists
       containers:
       - name: aws-lb-readvertiser
         image: {{ index .Values.images "aws-lb-readvertiser" }}

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
@@ -32,9 +32,6 @@ spec:
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}
     spec:
-      tolerations:
-      - effect: NoExecute
-        operator: Exists
       containers:
       - name: aws-cloud-controller-manager
         image: {{ index .Values.images "cloud-controller-manager" }}


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind bug
/priority normal
/platform aws

**What this PR does / why we need it**:
Removes the `NoExecute` toleration from components running in the Seed cluster, such as the CCM. This toleration should not be needed for such components, see the discussion in https://github.com/gardener/gardener-extension-provider-azure/pull/120.

**Release note**:
```improvement operator
NONE
```
