### PR TITLE
Remove bastion IAM role, profiles and policies

### DIFF
--- a/charts/internal/aws-infra/templates/main.tf
+++ b/charts/internal/aws-infra/templates/main.tf
@@ -267,53 +267,6 @@ resource "aws_route_table_association" "routetable_private_utility_z{{ $index }}
 //= IAM instance profiles
 //=====================================================================
 
-resource "aws_iam_role" "bastions" {
-  name = "{{ required "clusterName is required" .Values.clusterName }}-bastions"
-  path = "/"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_instance_profile" "bastions" {
-  name = "{{ required "clusterName is required" .Values.clusterName }}-bastions"
-  role = aws_iam_role.bastions.name
-}
-
-resource "aws_iam_role_policy" "bastions" {
-  name = "{{ required "clusterName is required" .Values.clusterName }}-bastions"
-  role = aws_iam_role.bastions.id
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:DescribeRegions"
-      ],
-      "Resource": [
-        "*"
-      ]
-    }
-  ]
-}
-EOF
-}
-
 resource "aws_iam_role" "nodes" {
   name = "{{ required "clusterName is required" .Values.clusterName }}-nodes"
   path = "/"


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/area security
/kind cleanup
/priority normal
/platform aws

**What this PR does / why we need it**:

IAM Instance profiles are not needed for bastions as they should only be used as jump hosts.

**Which issue(s) this PR fixes**:

Fixes #4

**Special notes for your reviewer**:

PR in https://github.com/gardener/gardenctl/pull/218 which removes the instance profile when launching such machines. Only `gardenctl` versions which have https://github.com/gardener/gardenctl/pull/218 can be used to create instances once this PR is merged.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
IAM roles, policies and instance profiles for bastion instances are no longer created and existing ones are removed during the next infra reconciliation.
```

```action operator
Upgrade `gardenctl` to the latest version as creation of bastion nodes would not succeed. See gardenctl [issue](https://github.com/gardener/gardenctl/pull/218) for more details.
```
