### PR TITLE
Enable encryption by default AWS instance EBS vols

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -121,9 +121,12 @@ If you don't want to configure anything for the `cloudControllerManager` simply 
 
 ## `WorkerConfig`
 
-The AWS extension supports encryption for volumes plus support for additional data volumes per machine.
-By default (if not stated otherwise), all the disks are unencrypted.
+The AWS extension supports encryption for volumes plus support for additional data volumes per machine. 
 For each data volume, you have to specify a name.
+By default (if not stated otherwise), all the disks (root & data volumes) are encrypted. 
+Please make sure that your [instance-type supports encryption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html). 
+If your instance-type doesn't support encryption, you will have to disable encryption (which is enabled by default) by setting `volume.encrpyted` to `false` (refer below shown YAML snippet).
+
 The following YAML is a snippet of a `Shoot` resource:
 
 ```yaml
@@ -135,7 +138,7 @@ spec:
       volume:
         type: gp2
         size: 20Gi
-        encrypted: true
+        encrypted: false
       dataVolumes:
       - name: kubelet-dir
         type: gp2

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -274,7 +274,7 @@ func computeEBS(size string, volumeType *string, encrypted *bool) (map[string]in
 
 	ebs := map[string]interface{}{
 		"volumeSize":          volumeSize,
-		"encrypted":           false,
+		"encrypted":           true,
 		"deleteOnTermination": true,
 	}
 

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -427,7 +427,7 @@ var _ = Describe("Machines", func() {
 									"volumeSize":          volumeSize,
 									"volumeType":          volumeType,
 									"deleteOnTermination": true,
-									"encrypted":           false,
+									"encrypted":           true,
 								},
 							},
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/priority normal
/platform aws

**What this PR does / why we need it**:
The PR enables encryption by default for EBS volumes used by AWS EC2 instances. 

**Which issue(s) this PR fixes**:
Fixes #126 

**Special notes for your reviewer**:
This might cause issues with machines that do not support encryption by default. Refer list here - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#ebs-encryption-requirements. 

However, this is something that can be overridden by setting the encryption flag to `false` on the [machine volume settings here](https://github.com/gardener/gardener/blob/master/example/90-shoot.yaml#L49). 

I checked with our cloud profile and I found 6 machine types with `g4dn` which don't have support for encryption. Something that we need to disable from the cloud profile?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Enable encryption by default for AWS instance EBS volumes.
```
```action operator
Need to remove EC2 instances without encryption support in the cloud profile.
```

