### PR TITLE
Create gateway endpoints when existing vpc is used

### DIFF
--- a/charts/internal/aws-infra/templates/main.tf
+++ b/charts/internal/aws-infra/templates/main.tf
@@ -24,15 +24,6 @@ resource "aws_vpc" "vpc" {
 {{ include "aws-infra.common-tags" .Values | indent 2 }}
 }
 
-{{ range $ep := .Values.vpc.gatewayEndpoints }}
-resource "aws_vpc_endpoint" "vpc_gwep_{{ $ep }}" {
-  vpc_id       = aws_vpc.vpc.id
-  service_name = "com.amazonaws.{{ required "aws.region is required" $.Values.aws.region }}.{{ $ep }}"
-
-{{ include "aws-infra.tags-with-suffix" (set $.Values "suffix" (print "gw-" $ep)) | indent 2 }}
-}
-{{ end }}
-
 resource "aws_vpc_dhcp_options_association" "vpc_dhcp_options_association" {
   vpc_id          = aws_vpc.vpc.id
   dhcp_options_id = aws_vpc_dhcp_options.vpc_dhcp_options.id
@@ -48,6 +39,15 @@ resource "aws_internet_gateway" "igw" {
 {{ include "aws-infra.common-tags" .Values | indent 2 }}
 }
 {{- end}}
+
+{{ range $ep := .Values.vpc.gatewayEndpoints }}
+resource "aws_vpc_endpoint" "vpc_gwep_{{ $ep }}" {
+  vpc_id       = {{ required "vpc.id is required" $.Values.vpc.id }}
+  service_name = "com.amazonaws.{{ required "aws.region is required" $.Values.aws.region }}.{{ $ep }}"
+
+{{ include "aws-infra.tags-with-suffix" (set $.Values "suffix" (print "gw-" $ep)) | indent 2 }}
+}
+{{ end }}
 
 resource "aws_route_table" "routetable_main" {
   vpc_id = {{ required "vpc.id is required" .Values.vpc.id }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal
/platform aws

**What this PR does / why we need it**:
Create gateway endpoints when existing vpc is used as well.

**Which issue(s) this PR fixes**:
Fixes #156

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gateway endpoints are now also created when existing vpc (`networks.vpc.id`) is used.
```
