### PR TITLE
Infrastructure controller validates VPC attributes

### DIFF
--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -33,6 +33,7 @@ const (
 type Interface interface {
 	GetAccountID(ctx context.Context) (string, error)
 	GetInternetGateway(ctx context.Context, vpcID string) (string, error)
+	VerifyVPCAttributes(ctx context.Context, vpcID string) error
 
 	// S3 wrappers
 	DeleteObjectsWithPrefix(ctx context.Context, bucket, prefix string) error

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -123,14 +123,18 @@ func generateTerraformInfraConfig(ctx context.Context, infrastructure *extension
 			return nil, err
 		}
 		existingVpcID := *infrastructureConfig.Networks.VPC.ID
+		if err := awsClient.VerifyVPCAttributes(ctx, existingVpcID); err != nil {
+			return nil, err
+		}
 		existingInternetGatewayID, err := awsClient.GetInternetGateway(ctx, existingVpcID)
 		if err != nil {
 			return nil, err
 		}
 		vpcID = strconv.Quote(existingVpcID)
 		internetGatewayID = strconv.Quote(existingInternetGatewayID)
+
 	case infrastructureConfig.Networks.VPC.CIDR != nil:
-		vpcCIDR = string(*infrastructureConfig.Networks.VPC.CIDR)
+		vpcCIDR = *infrastructureConfig.Networks.VPC.CIDR
 	}
 
 	var zones []map[string]interface{}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/priority normal
/platform aws

**What this PR does / why we need it**:
When an existing VPC is used for the shoot infrastructure then we require both `enableDnsSupport` and `enableDnsHostnames` to be set to `true`, see also the user documentation: https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage-as-end-user.md#infrastructureconfig

This was not validated earlier, i.e., when such a VPC was used, the shoot reconciliation often failed because the worker nodes couldn't join the cluster. The end-user did not know why this is the case and required support.
With this PR, we check the VPC attributes upfront before the `Infrastructure` reconciliation to clearly indicate this error.

**Which issue(s) this PR fixes**:
Fixes #158

**Special notes for your reviewer**:
/invite @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action user
The `Infrastructure` controller does now check for the required VPC attributes `enableDnsSupport` and `enableDnsHostnames` to be enabled when an existing VPC is used for the shoot infrastructure. If any of them is disabled then the reconciliation will fail (see also [user guide](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage-as-end-user.md#infrastructureconfig)). Make sure to enable these attributes for your existing VPCs that are used for shoots.
```
