### PR TITLE
Add docs about required infrastructure user privileges

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -23,6 +23,68 @@ data:
 
 Please look up https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys as well.
 
+### Permissions
+
+Please make sure that the provided credentials have the correct privileges. You can use the following AWS IAM policy document and attach it to the IAM user backed by the credentials you provided (please check the [official AWS documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage.html) as well):
+
+<details>
+  <summary>Click to expand the AWS IAM policy document!</summary>
+
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": "autoscaling:*",
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": "ec2:*",
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": "elasticloadbalancing:*",
+        "Resource": "*"
+      },
+      {
+        "Action": [
+          "iam:GetInstanceProfile",
+          "iam:GetPolicy",
+          "iam:GetPolicyVersion",
+          "iam:GetRole",
+          "iam:GetRolePolicy",
+          "iam:ListPolicyVersions",
+          "iam:ListAttachedRolePolicies",
+          "iam:ListInstanceProfilesForRole",
+          "iam:CreateInstanceProfile",
+          "iam:CreatePolicy",
+          "iam:CreatePolicyVersion",
+          "iam:CreateRole",
+          "iam:CreateServiceLinkedRole",
+          "iam:AddRoleToInstanceProfile",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:RemoveRoleFromInstanceProfile",
+          "iam:DeletePolicy",
+          "iam:DeletePolicyVersion",
+          "iam:DeleteRole",
+          "iam:DeleteRolePolicy",
+          "iam:DeleteInstanceProfile",
+          "iam:PutRolePolicy",
+          "iam:PassRole",
+          "iam:UpdateAssumeRolePolicy"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+      }
+    ]
+  }
+  ```
+</details>
+
 ## `InfrastructureConfig`
 
 The infrastructure configuration mainly describes how the network layout looks like in order to create the shoot worker nodes in a later step, thus, prepares everything relevant to create VMs, load balancers, volumes, etc.
@@ -76,7 +138,7 @@ If provided, no new Elastic IP will be created and, instead, the Elastic IP spec
 
 ⚠️ If you change this field for an already existing infrastructure then it will disrupt egress traffic while AWS applies this change.
 The reason is that the NAT gateway must be recreated with the new Elastic IP association.
-Also, please note that the existing Elastic IP will be permanently deleted if it was earlier created by the AWS extension. 
+Also, please note that the existing Elastic IP will be permanently deleted if it was earlier created by the AWS extension.
 
 You can configure [Gateway VPC Endpoints](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-gateway.html) by adding items in the optional list `networks.vpc.gatewayEndpoints`. Each item in the list is used as a service name and a corresponding endpoint is created for it. All created endpoints point to the service within the cluster's region. For example, consider this (partial) shoot config:
 
@@ -121,10 +183,10 @@ If you don't want to configure anything for the `cloudControllerManager` simply 
 
 ## `WorkerConfig`
 
-The AWS extension supports encryption for volumes plus support for additional data volumes per machine. 
+The AWS extension supports encryption for volumes plus support for additional data volumes per machine.
 For each data volume, you have to specify a name.
-By default (if not stated otherwise), all the disks (root & data volumes) are encrypted. 
-Please make sure that your [instance-type supports encryption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html). 
+By default (if not stated otherwise), all the disks (root & data volumes) are encrypted.
+Please make sure that your [instance-type supports encryption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html).
 If your instance-type doesn't support encryption, you will have to disable encryption (which is enabled by default) by setting `volume.encrpyted` to `false` (refer below shown YAML snippet).
 
 The following YAML is a snippet of a `Shoot` resource:

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -1,10 +1,16 @@
 # Using the AWS provider extension with Gardener as operator
 
-The [`core.gardener.cloud/v1alpha1.CloudProfile` resource](https://github.com/gardener/gardener/blob/master/example/30-cloudprofile.yaml) declares a `providerConfig` field that is meant to contain provider-specific configuration.
+The [`core.gardener.cloud/v1beta1.CloudProfile` resource](https://github.com/gardener/gardener/blob/master/example/30-cloudprofile.yaml) declares a `providerConfig` field that is meant to contain provider-specific configuration.
+Similarly, the [`core.gardener.cloud/v1beta1.Seed` resource](https://github.com/gardener/gardener/blob/master/example/50-seed.yaml) is structured.
+Additionally, it allows to configure settings for the backups of the main etcds' data of shoot clusters control planes running in this seed cluster.
 
-In this document we are describing how this configuration looks like for AWS and provide an example `CloudProfile` manifest with minimal configuration that you can use to allow creating AWS shoot clusters.
+This document explains what is necessary to configure for this provider extension.
 
-## `CloudProfileConfig`
+## `CloudProfile` resource
+
+In this section we are describing how the configuration for `CloudProfile`s looks like for AWS and provide an example `CloudProfile` manifest with minimal configuration that you can use to allow creating AWS shoot clusters.
+
+### `CloudProfileConfig`
 
 The cloud profile configuration contains information about the real machine image IDs in the AWS environment (AMIs).
 You have to map every version that you specify in `.spec.machineImages[].versions` here such that the AWS extension knows the AMI for every version you want to offer.
@@ -23,7 +29,7 @@ machineImages:
       ami: ami-034fd8c3f4026eb39
 ```
 
-## Example `CloudProfile` manifest
+### Example `CloudProfile` manifest
 
 Please find below an example `CloudProfile` manifest:
 
@@ -73,3 +79,64 @@ spec:
         - name: eu-central-1
           ami: ami-034fd8c3f4026eb39
 ```
+
+## `Seed` resource
+
+This provider extension does not support any provider configuration for the `Seed`'s `.spec.provider.providerConfig` field.
+However, it supports to manage backup infrastructure, i.e., you can specify configuration for the `.spec.backup` field.
+
+### Backup configuration
+
+Please find below an example `Seed` manifest (partly) that configures backups.
+As you can see, the location/region where the backups will be stored can be different to the region where the seed cluster is running.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backup-credentials
+  namespace: garden
+type: Opaque
+data:
+  accessKeyID: base64(access-key-id)
+  secretAccessKey: base64(secret-access-key)
+---
+apiVersion: core.gardener.cloud/v1beta1
+kind: Seed
+metadata:
+  name: my-seed
+spec:
+  provider:
+    type: aws
+    region: eu-west-1
+  backup:
+    provider: aws
+    region: eu-central-1
+    secretRef:
+      name: backup-credentials
+      namespace: garden
+  ...
+```
+
+Please look up https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys as well.
+
+#### Permissions for AWS IAM user
+
+Please make sure that the provided credentials have the correct privileges. You can use the following AWS IAM policy document and attach it to the IAM user backed by the credentials you provided (please check the [official AWS documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage.html) as well):
+
+<details>
+  <summary>Click to expand the AWS IAM policy document!</summary>
+
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": "s3:*",
+        "Resource": "*"
+      }
+    ]
+  }
+  ```
+</details>


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/priority normal
/platform aws

**What this PR does / why we need it**:
This PR adds documentation about the required AWS IAM user privileges for both usage as end-user (for shoots) and usage as operator (for backups).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
