### PR TITLE
Add kcm mounts when not using csi

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -246,6 +246,23 @@ var (
 		},
 	}
 
+	usrShareCaCerts            = "usr-share-cacerts"
+	directoryOrCreate          = corev1.HostPathDirectoryOrCreate
+	usrShareCaCertsVolumeMount = corev1.VolumeMount{
+		Name:      usrShareCaCerts,
+		MountPath: "/usr/share/ca-certificates",
+		ReadOnly:  true,
+	}
+	usrShareCaCertsVolume = corev1.Volume{
+		Name: usrShareCaCerts,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/usr/share/ca-certificates",
+				Type: &directoryOrCreate,
+			},
+		},
+	}
+
 	cloudProviderConfigVolumeMount = corev1.VolumeMount{
 		Name:      aws.CloudProviderConfigName,
 		MountPath: "/etc/kubernetes/cloudprovider",
@@ -281,6 +298,8 @@ func ensureVolumeMounts(c *corev1.Container, version string, csiEnabled, csiMigr
 	c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, cloudProviderConfigVolumeMount)
 	if mustMountEtcSSLFolder(version) {
 		c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, etcSSLVolumeMount)
+		// some distros have symlinks from /etc/ssl/certs to /usr/share/ca-certificates
+		c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, usrShareCaCertsVolumeMount)
 	}
 }
 
@@ -294,6 +313,8 @@ func ensureVolumes(ps *corev1.PodSpec, version string, csiEnabled, csiMigrationC
 	ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, cloudProviderConfigVolume)
 	if mustMountEtcSSLFolder(version) {
 		ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, etcSSLVolume)
+		// some distros have symlinks from /etc/ssl/certs to /usr/share/ca-certificates
+		ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, usrShareCaCertsVolume)
 	}
 }
 

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
+
+	"github.com/coreos/go-systemd/unit"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/csimigration"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
@@ -29,8 +31,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/utils/version"
-
-	"github.com/coreos/go-systemd/unit"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -776,6 +776,8 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, l
 		if !k8sVersionLessThan117 {
 			Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
 			Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
+			Expect(c.VolumeMounts).To(ContainElement(usrShareCaCertsVolumeMount))
+			Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(usrShareCaCertsVolume))
 		}
 		if k8sVersionAtLeast118 {
 			Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationAWS=true"))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/kind bug
/priority normal
/platform aws

**What this PR does / why we need it**:

Adds a host path volume to the KCM that is required for certain OS.

The KCM discovers the Root CAs available on the node via [predefined locations](https://github.com/golang/go/blob/1bb247a469e306c57a5e0eaba788efb8b3b1acef/src/crypto/x509/root_linux.go#L7-L15).

```
	"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
	"/etc/pki/tls/cacert.pem",                           // OpenELEC
	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
	"/etc/ssl/cert.pem",                                 // Alpine Linux
```

This is why the kcm mounts the `etc/ssl` directory.

For certain OS (e.g coreos 2512.3.0), the `etc/ssl/certs` contains only symlinks to the actual `ca-certificates.crt` file.
```
lrwxrwxrwx. 1 root root    54 May 22 20:41  ca-certificates.crt -> ../../../usr/share/ca-certificates/ca-certificates.crt
```
 
However, the KCM cannot access `ca-certificates/ca-certificates.crt` , because it does not mount the correct directory.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Please also see [related issue on kubeadm for coreos](https://github.com/kubernetes/kubeadm/issues/671) and [this](https://github.com/kubernetes/kubernetes/pull/59122).

We can also think about mounting the other directories like `"/etc/pki/tls/certs/`. 
But I would like to talk about and first go ahead with this issue.

This change is independent of the provider, so should also be added for other providers as well.
However, we are having issues on AWS, so this should be first.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
KCM mounts `/usr/share/ca-certificates` required for certain OS (e.g CoreOS 2512.3.0),
```
