### PR TITLE
Adding additional test definition provider-aws-extended 

### DIFF
--- a/.test-defs/provider-aws-extended.yaml
+++ b/.test-defs/provider-aws-extended.yaml
@@ -1,0 +1,21 @@
+kind: TestDefinition
+metadata:
+  name: gen-provider-aws-extended
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: Generates the aws provider specific configurations
+  activeDeadlineSeconds: 3600
+
+  command: [bash, -c]
+  args:
+  - >-
+    go run -mod=vendor ./test/tm/generator.go
+     --infrastructure-provider-config-filepath=$INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
+     --controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
+     --network-vpc-cidr=$NETWORK_VPC_CIDR
+     --network-internal-cidr=$NETWORK_INTERNAL_CIDR
+     --network-public-cidr=$NETWORK_PUBLIC_CIDR
+     --network-worker-cidr=$NETWORK_WORKER_CIDR
+     --zone=$ZONE
+
+  image: golang:1.13.0


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/priority normal
/platform aws

**What this PR does / why we need it**:
This PR adds additional test definition "provider-aws-extended" that includes all parameters from the respective test file, not only the mandatory, like the "provider-aws" test definition.
This test definition will be used by the integration tests where shoots with different networks from the defaults must be created (e.g. for registering a new seed for the control plane migration).
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
NONE
