### PR TITLE
Upgrade github.com/gardener/cloud-provider-aws

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -11,17 +11,17 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-aws
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
-  tag: "v1.17.9"
+  tag: "v1.17.13"
   targetVersion: "1.17.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-aws
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
-  tag: "v1.18.6"
+  tag: "v1.18.10"
   targetVersion: "1.18.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-aws
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
-  tag: "v1.19.0"
+  tag: "v1.19.3"
   targetVersion: ">= 1.19"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/cloud-provider-aws $ff3f6e5745765276d653bda693ed1538ac997176
`k8s.io/legacy-cloud-providers` is now updated to `v0.17.13`.
```

``` improvement operator github.com/gardener/cloud-provider-aws $c4b008115810354c6cab834fe2d18b7f2a9e1603
`k8s.io/legacy-cloud-providers` is now updated to `v0.18.10`.
```

``` improvement operator github.com/gardener/cloud-provider-aws $b9aeadd546ca39ca6f25a878d184b2ce8e32ceef
`k8s.io/legacy-cloud-providers` is now updated to `v0.19.3`.
```