### PR TITLE
Nit: Do no longer ignore deprecated item usage

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,9 +5,3 @@ run:
 linters:
   disable:
   - unused
-
-issues:
-  exclude-rules:
-  - linters:
-    - staticcheck
-    text: "SA1019:" # Excludes messages where deprecated variables are used


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup
/priority normal
/platform aws

**What this PR does / why we need it**:
We added this exclusion back in d804e2b37c1644ef4657bdbd859031b1a09d290b to prevent the following failure:

```
$ make check
> Check
Executing golangci-lint
test/e2e/networkpolicies/networkpolicy_test.go:35:2: SA1019: package github.com/gardener/gardener/test/integration/framework is deprecated: this is the deprecated gardener testframework. Use gardener/test/framework instead  (staticcheck)
	gardenerframework "github.com/gardener/gardener/test/integration/framework"
	^
make: *** [check] Error 1
```

But in 0a4f1f16d3d380f3fa8123e1b267f50e9ac83b77 `test/e2e/networkpolicies/networkpolicy_test.go` is deleted.
So we can now bring back the check that prevents usage of deprecated items.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
