### PR TITLE
Error wrapping for UpdateMachineImagesStatus function

### DIFF
--- a/pkg/controller/worker/machine_images.go
+++ b/pkg/controller/worker/machine_images.go
@@ -29,18 +29,22 @@ import (
 func (w *workerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
 	if w.machineImages == nil {
 		if err := w.generateMachineConfig(ctx); err != nil {
-			return err
+			return errors.Wrapf(err, "unable to generate the machine config")
 		}
 	}
 
 	// Decode the current worker provider status.
 	workerStatus, err := w.decodeWorkerProviderStatus()
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "unable to decode the worker provider status")
 	}
 
 	workerStatus.MachineImages = w.machineImages
-	return w.updateWorkerProviderStatus(ctx, workerStatus)
+	if err := w.updateWorkerProviderStatus(ctx, workerStatus); err != nil {
+		return errors.Wrapf(err, "unable to update worker provider status")
+	}
+
+	return nil
 }
 
 func (w *workerDelegate) findMachineImage(name, version, region string) (string, error) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal
/platform aws

**What this PR does / why we need it**:
Introduce error wrapping for `UpdateMachineImagesStatus` function.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3119

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
