### PR TITLE
Migration of in-tree to out-of-tree MCM providers

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -32,6 +32,10 @@ images:
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
   tag: "v0.36.0"
+- name: machine-controller-manager-provider-aws
+  sourceRepository: github.com/gardener/machine-controller-manager-provider-aws
+  repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-aws
+  tag: "v0.3.0"
 - name: aws-lb-readvertiser
   sourceRepository: github.com/gardener/aws-lb-readvertiser
   repository: eu.gcr.io/gardener-project/gardener/aws-lb-readvertiser

--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -39,24 +39,51 @@ spec:
       serviceAccountName: machine-controller-manager
       terminationGracePeriodSeconds: 5
       containers:
+      - name: machine-controller-manager-provider-aws
+        image: {{ index .Values.images "machine-controller-manager-provider-aws" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - ./machine-controller
+        - --control-kubeconfig=inClusterConfig
+        - --machine-creation-timeout=20m
+        - --machine-drain-timeout=2h
+        - --machine-health-timeout=10m
+        - --namespace={{ .Release.Namespace }}
+        - --port={{ .Values.metricsPortAWS }}
+        - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
+        - --v=3
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: {{ .Values.metricsPortAWS }}
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/machine-controller-manager
+          name: machine-controller-manager
+          readOnly: true
       - name: aws-machine-controller-manager
         image: {{ index .Values.images "machine-controller-manager" }}
         imagePullPolicy: IfNotPresent
         command:
         - ./machine-controller-manager
         - --control-kubeconfig=inClusterConfig
-        - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
-        - --namespace={{ .Release.Namespace }}
-        - --port={{ .Values.metricsPort }}
-        - --machine-creation-timeout=20m
-        - --machine-drain-timeout=2h
-        - --machine-health-timeout=10m
+        - --delete-migrated-machine-class=true
         - --machine-safety-apiserver-statuscheck-timeout=30s
         - --machine-safety-apiserver-statuscheck-period=1m
         - --machine-safety-orphan-vms-period=30m
         - --machine-safety-overshooting-period=1m
+        - --namespace={{ .Release.Namespace }}
+        - --port={{ .Values.metricsPort }}
         - --safety-up=2
         - --safety-down=1
+        - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
         - --v=3
         livenessProbe:
           failureThreshold: 3

--- a/charts/internal/machine-controller-manager/seed/values.yaml
+++ b/charts/internal/machine-controller-manager/seed/values.yaml
@@ -1,5 +1,6 @@
 images:
   machine-controller-manager: image-repository:image-tag
+  machine-controller-manager-provider-aws: image-repository:image-tag
 
 replicas: 1
 
@@ -13,6 +14,7 @@ namespace:
   uid: uuid-of-namespace
 
 metricsPort: 10258
+metricsPortAWS: 10259
 
 vpa:
   enabled: true

--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -14,7 +14,7 @@ data:
   userData: {{ $machineClass.secret.cloudConfig | b64enc }}
 ---
 apiVersion: machine.sapcloud.io/v1alpha1
-kind: AWSMachineClass
+kind: MachineClass
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
@@ -22,7 +22,7 @@ metadata:
   labels:
 {{ toYaml $machineClass.labels | indent 4 }}
 {{- end }}
-spec:
+providerSpec:
   ami: {{ $machineClass.ami }}
   region: {{ $machineClass.region }}
   machineType: {{ $machineClass.machineType }}
@@ -35,12 +35,13 @@ spec:
   tags:
 {{ toYaml $machineClass.tags | indent 4 }}
 {{- end }}
-  secretRef:
-    name: {{ $machineClass.name }}
-    namespace: {{ $.Release.Namespace }}
-  credentialsSecretRef:
-    name: {{ $machineClass.credentialsSecretRef.name }}
-    namespace: {{ $machineClass.credentialsSecretRef.namespace }}
   blockDevices:
 {{ toYaml $machineClass.blockDevices | indent 2 }}
+secretRef:
+  name: {{ $machineClass.name }}
+  namespace: {{ $.Release.Namespace }}
+credentialsSecretRef:
+  name: {{ $machineClass.credentialsSecretRef.name }}
+  namespace: {{ $machineClass.credentialsSecretRef.namespace }}
+provider: "AWS"
 {{- end }}

--- a/pkg/aws/types.go
+++ b/pkg/aws/types.go
@@ -51,6 +51,8 @@ const (
 
 	// MachineControllerManagerImageName is the name of the MachineControllerManager image.
 	MachineControllerManagerImageName = "machine-controller-manager"
+	// MachineControllerManagerProviderAWSImageName is the name of the MachineController AWS image.
+	MachineControllerManagerProviderAWSImageName = "machine-controller-manager-provider-aws"
 	// TerraformerImageName is the name of the Terraformer image.
 	TerraformerImageName = "terraformer"
 

--- a/pkg/controller/worker/machine_controller_manager.go
+++ b/pkg/controller/worker/machine_controller_manager.go
@@ -34,7 +34,7 @@ var (
 	mcmChart = &chart.Chart{
 		Name:   aws.MachineControllerManagerName,
 		Path:   filepath.Join(aws.InternalChartsPath, aws.MachineControllerManagerName, "seed"),
-		Images: []string{aws.MachineControllerManagerImageName},
+		Images: []string{aws.MachineControllerManagerImageName, aws.MachineControllerManagerProviderAWSImageName},
 		Objects: []*chart.Object{
 			{Type: &appsv1.Deployment{}, Name: aws.MachineControllerManagerName},
 			{Type: &corev1.Service{}, Name: aws.MachineControllerManagerName},


### PR DESCRIPTION
- This also includes migration from AWSMachineClass to MachineClass. This migration occurs implicitly without causing rollouts of existing nodes/VMs.
- Added tests to verify deletion of old machineClass objects

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind  api-change
/priority normal
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
⚠️ Before upgrading your `gardener/gardener-extension-provider-aws` to [>= v1.20.0](https://github.com/gardener/gardener-extension-provider-aws/releases/tag/v1.20.0), please upgrade your `gardener/gardener` component version to [>= v1.14.0](https://github.com/gardener/gardener/releases/tag/v1.14.0) to avoid breaking of clusters that are using the scale from/to zero feature (clusters that allowing scaling from/to 0 worker pools). If used with an older `gardener/gardener` version, this would lead to failure of clusters making use of this feature. 
```
```other developer
Migration of MCM provider from in-tree to out-of-tree. Refer - [MCM provider AWS](https://github.com/gardener/machine-controller-manager-provider-aws).
```
```other developer
Migration of `AWSMachineClass` to `MachineClass`. This migration occurs implicitly without causing rollouts of existing nodes/VMs.
```
