### PR TITLE
Update cloud credentials even for unwanted machine deployments.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,9 +33,9 @@ Write your release note:
 
 Format of block header: <category> <target_group>
 Possible values:
-- category:       improvement|noteworthy|action
-- target_group:   user|operator|developer
+- category:       breaking|feature|bugfix|doc|other
+- target_group:   user|operator|developer|dependency
 -->
-```improvement operator
+```other operator
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/frankban/quicktest v1.9.0 // indirect
 	github.com/gardener/etcd-druid v0.3.0
-	github.com/gardener/gardener v1.13.0
+	github.com/gardener/gardener v1.13.1-0.20201130092019-e4b9da08a171
 	github.com/gardener/machine-controller-manager v0.33.0
 	github.com/go-logr/logr v0.1.0
 	github.com/gobuffalo/packr/v2 v2.8.1

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/gardener/gardener v1.1.2/go.mod h1:CP9I0tCDVXTLPkJv/jUtXVUh948kSNKEGU
 github.com/gardener/gardener v1.3.1/go.mod h1:936P5tQbg6ViiW8BVC9ELM95sFrk4DgobKrxMNtn/LU=
 github.com/gardener/gardener v1.4.1-0.20200519155656-a8ccc6cc779a/go.mod h1:t9oESM37bAMIuezi9I0H0I8+++8jy8BUPitcf4ERRXY=
 github.com/gardener/gardener v1.11.3/go.mod h1:5DzqfOm+G8UftKu5zUbYJ+9Cnfd4XrvRNDabkM9AIp4=
-github.com/gardener/gardener v1.13.0 h1:2AUVb4TGYJuCp2Z9q2ySx+Aqx/ZYDozWYnDsBHRBsWI=
-github.com/gardener/gardener v1.13.0/go.mod h1:13i2DUTf2LH13yVtcPfbY6IZ9vZ1/o6Iu8ajXeR+lS4=
+github.com/gardener/gardener v1.13.1-0.20201130092019-e4b9da08a171 h1:Xt9jYLbOq9rDL1l7Xsb3EbeNheuIETeUrszc0kSTh3w=
+github.com/gardener/gardener v1.13.1-0.20201130092019-e4b9da08a171/go.mod h1:EaPYLYlo/QC5mhHqEwF3ZuDget/RElPhYnSuaenQiSU=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/gardener-resource-manager v0.13.1/go.mod h1:0No/XttYRUwDn5lSppq9EqlKdo/XJQ44aCZz5BVu3Vw=
 github.com/gardener/gardener-resource-manager v0.18.0 h1:bNB0yKhSqe8DnsvIp3xZr9nsFB4fm+AUAqj1EoIvWU8=

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -293,7 +293,7 @@ var _ = Describe("ValuesProvider", func() {
 			serviceKey := client.ObjectKey{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}
 			c.EXPECT().Get(ctx, serviceKey, &corev1.Service{}).DoAndReturn(clientGet(cpService))
 
-			values, err := vp.GetControlPlaneExposureChartValues(context.TODO(), cp, clusterK8sLessThan118, checksums)
+			values, err := vp.GetControlPlaneExposureChartValues(ctx, cp, clusterK8sLessThan118, checksums)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{
 				"domain":   "10.10.10.1",

--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -17,18 +17,16 @@ package infrastructure
 import (
 	"time"
 
+	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/imagevector"
 	"github.com/gardener/gardener/extensions/pkg/controller/common"
 	"github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	glogger "github.com/gardener/gardener/pkg/logger"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
-	"github.com/gardener/gardener-extension-provider-aws/pkg/imagevector"
 )
 
 type actuator struct {
@@ -45,8 +43,8 @@ func NewActuator() infrastructure.Actuator {
 
 // Helper functions
 
-func newTerraformer(restConfig *rest.Config, purpose string, infra *extensionsv1alpha1.Infrastructure) (terraformer.Terraformer, error) {
-	tf, err := terraformer.NewForConfig(glogger.NewLogger("info"), restConfig, purpose, infra.Namespace, infra.Name, imagevector.TerraformerImage())
+func newTerraformer(logger logr.Logger, restConfig *rest.Config, purpose string, infra *extensionsv1alpha1.Infrastructure) (terraformer.Terraformer, error) {
+	tf, err := terraformer.NewForConfig(logger, restConfig, purpose, infra.Namespace, infra.Name, imagevector.TerraformerImage())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/infrastructure/actuator_migrate.go
+++ b/pkg/controller/infrastructure/actuator_migrate.go
@@ -22,6 +22,7 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,7 +30,8 @@ import (
 
 // Migrate deletes only the ConfigMaps and Secrets of the Terraformer.
 func (a *actuator) Migrate(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, _ *extensionscontroller.Cluster) error {
-	return migrate(ctx, a.logger, a.RESTConfig(), a.Client(), infrastructure)
+	logger := a.logger.WithValues("infrastructure", kutils.KeyFromObject(infrastructure), "operation", "migrate")
+	return migrate(ctx, logger, a.RESTConfig(), a.Client(), infrastructure)
 }
 
 func migrate(
@@ -39,7 +41,7 @@ func migrate(
 	c client.Client,
 	infrastructure *extensionsv1alpha1.Infrastructure,
 ) error {
-	tf, err := newTerraformer(restConfig, aws.TerraformerPurposeInfra, infrastructure)
+	tf, err := newTerraformer(logger, restConfig, aws.TerraformerPurposeInfra, infrastructure)
 	if err != nil {
 		return fmt.Errorf("could not create the Terraformer: %+v", err)
 	}

--- a/pkg/controller/infrastructure/actuator_restore.go
+++ b/pkg/controller/infrastructure/actuator_restore.go
@@ -20,6 +20,7 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // Restore takes the infrastructure state and deploys it as terraform state ConfigMap before calling the terraformer
@@ -29,7 +30,8 @@ func (a *actuator) Restore(ctx context.Context, infrastructure *extensionsv1alph
 		return err
 	}
 
-	infrastructureStatus, state, err := Reconcile(ctx, a.RESTConfig(), a.Client(), a.Decoder(), a.ChartRenderer(), infrastructure, terraformer.CreateOrUpdateState{State: &terraformState.Data})
+	logger := a.logger.WithValues("infrastructure", kutils.KeyFromObject(infrastructure), "operation", "restore")
+	infrastructureStatus, state, err := Reconcile(ctx, logger, a.RESTConfig(), a.Client(), a.Decoder(), a.ChartRenderer(), infrastructure, terraformer.CreateOrUpdateState{State: &terraformState.Data})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/worker/machine_controller_manager.go
+++ b/pkg/controller/worker/machine_controller_manager.go
@@ -77,3 +77,9 @@ func (w *workerDelegate) GetMachineControllerManagerShootChartValues(ctx context
 		"providerName": aws.Name,
 	}, nil
 }
+
+// GetMachineControllerManagerCloudCredentials should return the IaaS credentials
+// with the secret keys used by the machine-controller-manager.
+func (w *workerDelegate) GetMachineControllerManagerCloudCredentials(ctx context.Context) (map[string][]byte, error) {
+	return w.generateMachineClassSecretData(ctx)
+}

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -52,6 +52,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var (
+	ctx = context.TODO()
+)
+
 var _ = Describe("Machines", func() {
 	var (
 		ctrl         *gomock.Controller
@@ -592,7 +596,7 @@ var _ = Describe("Machines", func() {
 					chartApplier.
 						EXPECT().
 						Apply(
-							context.TODO(),
+							ctx,
 							filepath.Join(aws.InternalChartsPath, "machineclass"),
 							namespace,
 							"machineclass",
@@ -600,7 +604,7 @@ var _ = Describe("Machines", func() {
 						).
 						Return(nil)
 
-					err := workerDelegate.DeployMachineClasses(context.TODO())
+					err := workerDelegate.DeployMachineClasses(ctx)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Test workerDelegate.UpdateMachineDeployments()
@@ -623,7 +627,6 @@ var _ = Describe("Machines", func() {
 						Object: expectedImages,
 					}
 
-					ctx := context.TODO()
 					c.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{})).Return(nil)
 					c.EXPECT().Status().Return(statusWriter)
 					statusWriter.EXPECT().Update(ctx, workerWithExpectedImages).Return(nil)
@@ -633,7 +636,7 @@ var _ = Describe("Machines", func() {
 
 					// Test workerDelegate.GenerateMachineDeployments()
 
-					result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
+					result, err := workerDelegate.GenerateMachineDeployments(ctx)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(machineDeployments))
 				})
@@ -641,10 +644,10 @@ var _ = Describe("Machines", func() {
 
 			It("should fail because the secret cannot be read", func() {
 				c.EXPECT().
-					Get(context.TODO(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
+					Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
 					Return(fmt.Errorf("error"))
 
-				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
 			})
@@ -655,7 +658,7 @@ var _ = Describe("Machines", func() {
 				clusterWithoutImages.Shoot.Spec.Kubernetes.Version = "invalid"
 				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
 
-				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
 			})
@@ -667,7 +670,7 @@ var _ = Describe("Machines", func() {
 
 				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
 
-				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
 			})
@@ -681,7 +684,7 @@ var _ = Describe("Machines", func() {
 
 				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
 
-				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
 			})
@@ -704,7 +707,7 @@ var _ = Describe("Machines", func() {
 
 				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
 
-				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
 			})
@@ -716,7 +719,7 @@ var _ = Describe("Machines", func() {
 
 				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
 
-				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
 			})
@@ -748,7 +751,7 @@ var _ = Describe("Machines", func() {
 
 				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
 
-				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
 			})
@@ -760,7 +763,7 @@ var _ = Describe("Machines", func() {
 
 				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
 
-				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
 			})
@@ -783,7 +786,7 @@ var _ = Describe("Machines", func() {
 
 				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
 
-				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				resultSettings := result[0].MachineConfiguration
 				resultNodeConditions := strings.Join(testNodeConditions, ",")
 
@@ -805,7 +808,7 @@ func encode(obj runtime.Object) []byte {
 
 func expectGetSecretCallToWork(c *mockclient.MockClient, awsAccessKeyID, awsSecretAccessKey string) {
 	c.EXPECT().
-		Get(context.TODO(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
+		Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
 		DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret) error {
 			secret.Data = map[string][]byte{
 				aws.AccessKeyID:     []byte(awsAccessKeyID),

--- a/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -39,6 +39,10 @@ func TestController(t *testing.T) {
 	RunSpecs(t, "Controlplane Exposure Webhook Suite")
 }
 
+var (
+	ctx = context.TODO()
+)
+
 var _ = Describe("Ensurer", func() {
 	var (
 		etcdStorage = &config.ETCDStorage{
@@ -66,14 +70,14 @@ var _ = Describe("Ensurer", func() {
 			svc.Labels = map[string]string{"core.gardener.cloud/apiserver-exposure": "gardener-managed"}
 			svcCopy := svc.DeepCopy()
 
-			err := ensurer.EnsureKubeAPIServerService(context.TODO(), dummyContext, svc, nil)
+			err := ensurer.EnsureKubeAPIServerService(ctx, dummyContext, svc, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
 			Expect(svc).To(Equal(svcCopy))
 		})
 
 		It("should add annotations to kube-apiserver service", func() {
-			err := ensurer.EnsureKubeAPIServerService(context.TODO(), dummyContext, svc, nil)
+			err := ensurer.EnsureKubeAPIServerService(ctx, dummyContext, svc, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
 			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout", "3600"))
@@ -113,7 +117,7 @@ var _ = Describe("Ensurer", func() {
 			// Create ensurer
 			ensurer := NewEnsurer(etcdStorage, logger)
 
-			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep, nil)
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, dummyContext, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
 			Expect(dep).To(Equal(depCopy))
@@ -141,7 +145,7 @@ var _ = Describe("Ensurer", func() {
 			ensurer := NewEnsurer(etcdStorage, logger)
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep, nil)
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, dummyContext, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			checkKubeAPIServerDeployment(dep)
 		})
@@ -169,7 +173,7 @@ var _ = Describe("Ensurer", func() {
 			ensurer := NewEnsurer(etcdStorage, logger)
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
-			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep, nil)
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, dummyContext, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			checkKubeAPIServerDeployment(dep)
 		})
@@ -187,7 +191,7 @@ var _ = Describe("Ensurer", func() {
 			ensurer := NewEnsurer(etcdStorage, logger)
 
 			// Call EnsureETCDStatefulSet method and check the result
-			err := ensurer.EnsureETCD(context.TODO(), dummyContext, etcd, nil)
+			err := ensurer.EnsureETCD(ctx, dummyContext, etcd, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			checkETCDMain(etcd)
 		})
@@ -207,7 +211,7 @@ var _ = Describe("Ensurer", func() {
 			ensurer := NewEnsurer(etcdStorage, logger)
 
 			// Call EnsureETCDStatefulSet method and check the result
-			err := ensurer.EnsureETCD(context.TODO(), dummyContext, etcd, nil)
+			err := ensurer.EnsureETCD(ctx, dummyContext, etcd, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			checkETCDMain(etcd)
 		})
@@ -223,7 +227,7 @@ var _ = Describe("Ensurer", func() {
 			ensurer := NewEnsurer(etcdStorage, logger)
 
 			// Call EnsureETCDStatefulSet method and check the result
-			err := ensurer.EnsureETCD(context.TODO(), dummyContext, etcd, nil)
+			err := ensurer.EnsureETCD(ctx, dummyContext, etcd, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			checkETCDEvents(etcd)
 		})
@@ -243,7 +247,7 @@ var _ = Describe("Ensurer", func() {
 			ensurer := NewEnsurer(etcdStorage, logger)
 
 			// Call EnsureETCDStatefulSet method and check the result
-			err := ensurer.EnsureETCD(context.TODO(), dummyContext, etcd, nil)
+			err := ensurer.EnsureETCD(ctx, dummyContext, etcd, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			checkETCDEvents(etcd)
 		})

--- a/test/e2e/networkpolicies/networkpolicy_test.go
+++ b/test/e2e/networkpolicies/networkpolicy_test.go
@@ -165,9 +165,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "cloud-controller-manager-http",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "cloud-controller-manager"},
+					"app":  "kubernetes",
+					"role": "cloud-controller-manager"},
 				ShootVersionConstraint: "< 1.13",
 				SeedClusterConstraints: sets.String(nil)},
 			Ports: []networkpolicies.Port{
@@ -184,9 +183,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "cloud-controller-manager-http",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "cloud-controller-manager"},
+					"app":  "kubernetes",
+					"role": "cloud-controller-manager"},
 				ShootVersionConstraint: "< 1.13",
 				SeedClusterConstraints: sets.String(nil)},
 			Port: networkpolicies.Port{
@@ -196,9 +194,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "cloud-controller-manager-https",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "cloud-controller-manager"},
+					"app":  "kubernetes",
+					"role": "cloud-controller-manager"},
 				ShootVersionConstraint: ">= 1.13",
 				SeedClusterConstraints: sets.String(nil)},
 			Ports: []networkpolicies.Port{
@@ -215,9 +212,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "cloud-controller-manager-https",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "cloud-controller-manager"},
+					"app":  "kubernetes",
+					"role": "cloud-controller-manager"},
 				ShootVersionConstraint: ">= 1.13",
 				SeedClusterConstraints: sets.String(nil)},
 			Port: networkpolicies.Port{
@@ -565,9 +561,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "machine-controller-manager",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "machine-controller-manager"},
+					"app":  "kubernetes",
+					"role": "machine-controller-manager"},
 				ShootVersionConstraint: "",
 				SeedClusterConstraints: sets.String(nil)},
 			Ports: []networkpolicies.Port{
@@ -586,9 +581,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "machine-controller-manager",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "machine-controller-manager"},
+					"app":  "kubernetes",
+					"role": "machine-controller-manager"},
 				ShootVersionConstraint: "",
 				SeedClusterConstraints: sets.String(nil)},
 			Port: networkpolicies.Port{

--- a/vendor/github.com/gardener/gardener/.github/pull_request_template.md
+++ b/vendor/github.com/gardener/gardener/.github/pull_request_template.md
@@ -32,9 +32,9 @@ Write your release note:
 
 Format of block header: <category> <target_group>
 Possible values:
-- category:       improvement|noteworthy|action
-- target_group:   user|operator|developer
+- category:       breaking|feature|bugfix|doc|other
+- target_group:   user|operator|developer|dependency
 -->
-```improvement operator
+```other operator
 
 ```

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -213,6 +213,27 @@ func (a *genericActuator) cleanupMachineClassSecrets(ctx context.Context, logger
 	return nil
 }
 
+// updateCloudCredentialsInAllMachineClassSecrets updates the cloud credentials
+// for all existing machine class secrets.
+func (a *genericActuator) updateCloudCredentialsInAllMachineClassSecrets(ctx context.Context, logger logr.Logger, cloudCredentials map[string][]byte, namespace string) error {
+	logger.Info("Updating cloud credentials for existing machine class secrets")
+	secretList, err := a.listMachineClassSecrets(ctx, namespace)
+	if err != nil {
+		return errors.Wrapf(err, "failed to list machine class secrets in namespace %s", namespace)
+	}
+
+	for _, secret := range secretList.Items {
+		secretCopy := secret.DeepCopy()
+		for key, value := range cloudCredentials {
+			secretCopy.Data[key] = value
+		}
+		if err := a.client.Patch(ctx, secretCopy, client.MergeFrom(&secret)); err != nil {
+			return errors.Wrapf(err, "failed to patch secret %s/%s with cloud credentials", namespace, secret.Name)
+		}
+	}
+	return nil
+}
+
 // shallowDeleteMachineClassSecrets deletes all unused machine class secrets (i.e., those which are not part
 // of the provided list <usedSecrets>) without waiting for MCM to do this.
 func (a *genericActuator) shallowDeleteMachineClassSecrets(ctx context.Context, logger logr.Logger, namespace string, wantedMachineDeployments worker.MachineDeployments) error {

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -64,6 +64,15 @@ func (a *genericActuator) Delete(ctx context.Context, worker *extensionsv1alpha1
 		return errors.Wrapf(err, "failed to deploy the machine classes")
 	}
 
+	// Update cloud credentials for all existing machine class secrets
+	cloudCredentials, err := workerDelegate.GetMachineControllerManagerCloudCredentials(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get the cloud credentials in namespace %s", worker.Namespace)
+	}
+	if err = a.updateCloudCredentialsInAllMachineClassSecrets(ctx, logger, cloudCredentials, worker.Namespace); err != nil {
+		return errors.Wrapf(err, "failed to update cloud credentials in machine class secrets for namespace %s", worker.Namespace)
+	}
+
 	// Mark all existing machines to become forcefully deleted.
 	logger.Info("Marking all machines to become forcefully deleted")
 	if err := a.markAllMachinesForcefulDeletion(ctx, logger, worker.Namespace); err != nil {

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -110,6 +110,15 @@ func (a *genericActuator) Reconcile(ctx context.Context, worker *extensionsv1alp
 		return errors.Wrapf(err, "failed to deploy the machine classes")
 	}
 
+	// Update cloud credentials for all existing machine class secrets
+	cloudCredentials, err := workerDelegate.GetMachineControllerManagerCloudCredentials(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get the cloud credentials in namespace %s", worker.Namespace)
+	}
+	if err = a.updateCloudCredentialsInAllMachineClassSecrets(ctx, logger, cloudCredentials, worker.Namespace); err != nil {
+		return errors.Wrapf(err, "failed to update cloud credentials in machine class secrets for namespace %s", worker.Namespace)
+	}
+
 	// Update the machine images in the worker provider status.
 	if err := workerDelegate.UpdateMachineImagesStatus(ctx); err != nil {
 		return errors.Wrapf(err, "failed to update the machine image status")

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/interface.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/interface.go
@@ -26,12 +26,15 @@ import (
 
 // WorkerDelegate is used for the Worker reconciliation.
 type WorkerDelegate interface {
-	// GetMachineControllerManagerChart should return the the chart and the values for the machine-controller-manager
+	// GetMachineControllerManagerChartValues should return the the chart and the values for the machine-controller-manager
 	// deployment.
 	GetMachineControllerManagerChartValues(context.Context) (map[string]interface{}, error)
-	// GetMachineControllerManagerShootChart should return the values to render the chart containing resources
+	// GetMachineControllerManagerShootChartValues should return the values to render the chart containing resources
 	// that are required by the machine-controller-manager inside the shoot cluster itself.
 	GetMachineControllerManagerShootChartValues(context.Context) (map[string]interface{}, error)
+	// GetMachineControllerManagerCloudCredentials should return the IaaS credentials
+	// with the secret keys used by the machine-controller-manager.
+	GetMachineControllerManagerCloudCredentials(context.Context) (map[string][]byte, error)
 
 	// MachineClassKind yields the name of the provider specific machine class.
 	MachineClassKind() string

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/reconciler.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/reconciler.go
@@ -145,9 +145,7 @@ func (r *reconciler) removeFinalizerFromWorker(logger logr.Logger, worker *exten
 
 func (r *reconciler) removeAnnotation(logger logr.Logger, worker *extensionsv1alpha1.Worker) error {
 	logger.Info("Removing operation annotation")
-	withOpAnnotation := worker.DeepCopyObject()
-	delete(worker.Annotations, v1beta1constants.GardenerOperation)
-	return r.client.Patch(r.ctx, worker, client.MergeFrom(withOpAnnotation))
+	return extensionscontroller.RemoveAnnotation(r.ctx, r.client, worker, v1beta1constants.GardenerOperation)
 }
 
 func (r *reconciler) migrate(logger logr.Logger, worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
@@ -192,7 +190,6 @@ func (r *reconciler) delete(logger logr.Logger, worker *extensionsv1alpha1.Worke
 
 	if err := r.actuator.Delete(r.ctx, worker, cluster); err != nil {
 		r.updateStatusError(err, worker, gardencorev1beta1.LastOperationTypeDelete, "Error deleting worker")
-
 		return extensionscontroller.ReconcileErr(err)
 	}
 

--- a/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/errors.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/errors.go
@@ -27,7 +27,7 @@ import (
 func retrieveTerraformErrors(logList map[string]string) []string {
 	var (
 		foundErrors = map[string]string{}
-		errorList   = []string{}
+		errorList   []string
 	)
 
 	for podName, output := range logList {
@@ -58,7 +58,7 @@ func findTerraformErrors(output string) string {
 		regexMultiNewline   = regexp.MustCompile(`\n{2,}`)
 
 		errorMessage = output
-		valid        = []string{}
+		valid        []string
 	)
 
 	// Strip optional explanation how Terraform behaves in case of errors.

--- a/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/state.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/state.go
@@ -44,8 +44,7 @@ type terraformStateV4 struct {
 }
 
 // GetState returns the Terraform state as byte slice.
-func (t *terraformer) GetState() ([]byte, error) {
-	ctx := context.TODO()
+func (t *terraformer) GetState(ctx context.Context) ([]byte, error) {
 	configMap := &corev1.ConfigMap{}
 	if err := t.client.Get(ctx, kutil.Key(t.namespace, t.stateName), configMap); err != nil {
 		return nil, err
@@ -56,7 +55,7 @@ func (t *terraformer) GetState() ([]byte, error) {
 
 // GetStateOutputVariables returns the given <variable> from the given Terraform <stateData>.
 // In case the variable was not found, an error is returned.
-func (t *terraformer) GetStateOutputVariables(variables ...string) (map[string]string, error) {
+func (t *terraformer) GetStateOutputVariables(ctx context.Context, variables ...string) (map[string]string, error) {
 	var (
 		output = make(map[string]string)
 
@@ -64,7 +63,7 @@ func (t *terraformer) GetStateOutputVariables(variables ...string) (map[string]s
 		foundVariables  = sets.NewString()
 	)
 
-	stateConfigMap, err := t.GetState()
+	stateConfigMap, err := t.GetState(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -93,8 +92,8 @@ func (t *terraformer) GetStateOutputVariables(variables ...string) (map[string]s
 }
 
 // IsStateEmpty returns true if the Terraform state is empty, and false otherwise.
-func (t *terraformer) IsStateEmpty() bool {
-	state, err := t.GetState()
+func (t *terraformer) IsStateEmpty(ctx context.Context) bool {
+	state, err := t.GetState(ctx)
 	if err != nil {
 		return apierrors.IsNotFound(err)
 	}
@@ -164,7 +163,7 @@ func sniffJSONStateVersion(stateConfigMap []byte) (uint64, error) {
 	return *sniff.Version, nil
 }
 
-// Initialize implements
+// Initialize implements StateConfigMapInitializer
 func (f StateConfigMapInitializerFunc) Initialize(ctx context.Context, c client.Client, namespace, name string) error {
 	return f(ctx, c, namespace, name)
 }

--- a/vendor/github.com/gardener/gardener/extensions/test/e2e/framework/networkpolicies/agnostic.go
+++ b/vendor/github.com/gardener/gardener/extensions/test/e2e/framework/networkpolicies/agnostic.go
@@ -168,9 +168,8 @@ func (a *Agnostic) CloudControllerManagerNotSecured() *SourcePod {
 	return &SourcePod{
 		Ports: NewSinglePort(10253),
 		Pod: NewPod("cloud-controller-manager-http", labels.Set{
-			v1beta1constants.LabelApp:             v1beta1constants.LabelKubernetes,
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
-			v1beta1constants.LabelRole:            "cloud-controller-manager",
+			v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
+			v1beta1constants.LabelRole: "cloud-controller-manager",
 		}, "< 1.13"),
 		ExpectedPolicies: sets.NewString(
 			"allow-from-prometheus",
@@ -187,9 +186,8 @@ func (a *Agnostic) CloudControllerManagerSecured() *SourcePod {
 	return &SourcePod{
 		Ports: NewSinglePort(10258),
 		Pod: NewPod("cloud-controller-manager-https", labels.Set{
-			v1beta1constants.LabelApp:             v1beta1constants.LabelKubernetes,
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
-			v1beta1constants.LabelRole:            "cloud-controller-manager",
+			v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
+			v1beta1constants.LabelRole: "cloud-controller-manager",
 		}, ">= 1.13"),
 		ExpectedPolicies: sets.NewString(
 			"allow-from-prometheus",
@@ -259,9 +257,8 @@ func (a *Agnostic) MachineControllerManager() *SourcePod {
 	return &SourcePod{
 		Ports: NewSinglePort(10258),
 		Pod: NewPod("machine-controller-manager", labels.Set{
-			v1beta1constants.LabelApp:             v1beta1constants.LabelKubernetes,
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
-			v1beta1constants.LabelRole:            "machine-controller-manager",
+			v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
+			v1beta1constants.LabelRole: "machine-controller-manager",
 		}),
 		ExpectedPolicies: sets.NewString(
 			"allow-from-prometheus",

--- a/vendor/github.com/gardener/gardener/hack/.ci/set_dependency_version
+++ b/vendor/github.com/gardener/gardener/hack/.ci/set_dependency_version
@@ -109,6 +109,8 @@ elif name == 'external-dns-management':
     names = ['dns-controller-manager']
 elif name == 'logging':
     names = ['fluent-bit-plugin-installer']
+elif name == 'etcd-custom-image':
+    names = ['etcd']
 else:
     names = [name]
 

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/addons.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/addons.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -220,23 +219,7 @@ func (b *Botanist) DeployManagedResources(ctx context.Context) error {
 		}
 	}
 
-	if err := b.deployCloudConfigExecutionManagedResource(ctx); err != nil {
-		return err
-	}
-
-	// TODO: remove in a future release
-	// Clean up the stale vpa-webhook-config MutatingWebhookConfiguration.
-	// We can delete vpa-webhook-config as the new vpa-webhook-config-shoot will be created by the shoot-core ManagedResource.
-	if b.Shoot.WantsVerticalPodAutoscaler {
-		webhook := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
-			ObjectMeta: metav1.ObjectMeta{Name: "vpa-webhook-config"},
-		}
-		if err := b.K8sShootClient.Client().Delete(ctx, webhook); client.IgnoreNotFound(err) != nil {
-			return err
-		}
-	}
-
-	return nil
+	return b.deployCloudConfigExecutionManagedResource(ctx)
 }
 
 // deployCloudConfigExecutionManagedResource creates the cloud config managed resource that contains:

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/botanist.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/botanist.go
@@ -24,6 +24,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist/clusteridentity"
 	"github.com/gardener/gardener/pkg/operation/botanist/controlplane/etcd"
@@ -73,6 +74,8 @@ func New(o *operation.Operation) (*Botanist, error) {
 	}
 
 	// extension components
+	o.Shoot.Components.Extensions.ControlPlane = b.DefaultControlPlane(b.K8sSeedClient.DirectClient(), extensionsv1alpha1.Normal)
+	o.Shoot.Components.Extensions.ControlPlaneExposure = b.DefaultControlPlane(b.K8sSeedClient.DirectClient(), extensionsv1alpha1.Exposure)
 	o.Shoot.Components.Extensions.DNS.ExternalProvider = b.DefaultExternalDNSProvider(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.DNS.ExternalOwner = b.DefaultExternalDNSOwner(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.DNS.ExternalEntry = b.DefaultExternalDNSEntry(b.K8sSeedClient.DirectClient())

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/cleanup.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/cleanup.go
@@ -70,7 +70,7 @@ var (
 	GracePeriodFiveMinutes = utilclient.DeleteWith{client.GracePeriodSeconds(5 * 60)}
 
 	// NotSystemComponent is a requirement that something doesn't have the GardenRole GardenRoleSystemComponent.
-	NotSystemComponent = utils.MustNewRequirement(v1beta1constants.DeprecatedGardenRole, selection.NotEquals, v1beta1constants.GardenRoleSystemComponent)
+	NotSystemComponent = utils.MustNewRequirement(v1beta1constants.GardenRole, selection.NotEquals, v1beta1constants.GardenRoleSystemComponent)
 	// NoCleanupPrevention is a requirement that the ShootNoCleanup label of something is not true.
 	NoCleanupPrevention = utils.MustNewRequirement(common.ShootNoCleanup, selection.NotEquals, "true")
 	// NotKubernetesProvider is a requirement that the Provider label of something is not KubernetesProvider.

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/component/interfaces.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/component/interfaces.go
@@ -18,8 +18,6 @@ import (
 	"context"
 
 	"github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Deployer is used to control the life-cycle of a component.
@@ -65,13 +63,6 @@ type CentralLoggingConfiguration func() (CentralLoggingConfig, error)
 
 // DependencyWatchdogConfiguration is a function alias for returning configuration for the dependency-watchdog.
 type DependencyWatchdogConfiguration func() (string, error)
-
-// BootstrapSeed is a function alias for components that require to bootstrap the seed cluster.
-type BootstrapSeed func(ctx context.Context, c client.Client, namespace, version string) error
-
-// DebootstrapSeed is a function alias for components that need to delete resources from the seed cluster that were
-// created during seed bootstrapping.
-type DebootstrapSeed func(ctx context.Context, c client.Client, namespace string) error
 
 // DeployWaiter controls and waits for life-cycle operations of a component.
 type DeployWaiter interface {

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/containerruntime.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/containerruntime.go
@@ -24,7 +24,7 @@ import (
 )
 
 // DefaultContainerRuntime creates the default deployer for the ContainerRuntime custom resource.
-func (b *Botanist) DefaultContainerRuntime(seedClient client.Client) shoot.ContainerRuntime {
+func (b *Botanist) DefaultContainerRuntime(seedClient client.Client) shoot.ExtensionContainerRuntime {
 	return containerruntime.New(
 		b.Logger,
 		seedClient,

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go
@@ -32,8 +32,10 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/controlplane"
 	"github.com/gardener/gardener/pkg/operation/botanist/controlplane/etcd"
+	extensionscontrolplane "github.com/gardener/gardener/pkg/operation/botanist/extensions/controlplane"
 	"github.com/gardener/gardener/pkg/operation/botanist/extensions/dns"
 	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -78,7 +80,6 @@ func (b *Botanist) DeployNamespace(ctx context.Context) error {
 			v1beta1constants.DeprecatedShootUID: string(b.Shoot.Info.Status.UID),
 		}
 		namespace.Labels = map[string]string{
-			v1beta1constants.DeprecatedGardenRole:    v1beta1constants.GardenRoleShoot,
 			v1beta1constants.GardenRole:              v1beta1constants.GardenRoleShoot,
 			v1beta1constants.LabelSeedProvider:       string(b.Seed.Info.Spec.Provider.Type),
 			v1beta1constants.LabelShootProvider:      string(b.Shoot.Info.Spec.Provider.Type),
@@ -375,198 +376,53 @@ func (b *Botanist) PrepareKubeAPIServerForMigration(ctx context.Context) error {
 	return b.DeleteKubeAPIServer(ctx)
 }
 
-// ControlPlaneDefaultTimeout is the default timeout and defines how long Gardener should wait
-// for a successful reconciliation of a control plane resource.
-const ControlPlaneDefaultTimeout = 3 * time.Minute
+// DefaultControlPlane creates the default deployer for the ControlPlane custom resource with the given purpose.
+func (b *Botanist) DefaultControlPlane(seedClient client.Client, purpose extensionsv1alpha1.Purpose) shoot.ExtensionControlPlane {
+	values := &extensionscontrolplane.Values{
+		Name:      b.Shoot.Info.Name,
+		Namespace: b.Shoot.SeedNamespace,
+		Purpose:   purpose,
+	}
 
-// DeployControlPlane creates the `ControlPlane` extension resource in the shoot namespace in the seed
-// cluster. Gardener waits until an external controller did reconcile the cluster successfully.
+	switch purpose {
+	case extensionsv1alpha1.Normal:
+		values.Type = b.Shoot.Info.Spec.Provider.Type
+		values.ProviderConfig = b.Shoot.Info.Spec.Provider.ControlPlaneConfig
+		values.Region = b.Shoot.Info.Spec.Region
+
+	case extensionsv1alpha1.Exposure:
+		values.Type = b.Seed.Info.Spec.Provider.Type
+		values.Region = b.Seed.Info.Spec.Provider.Region
+	}
+
+	return extensionscontrolplane.New(
+		b.Logger,
+		seedClient,
+		values,
+		extensionscontrolplane.DefaultInterval,
+		extensionscontrolplane.DefaultSevereThreshold,
+		extensionscontrolplane.DefaultTimeout,
+	)
+}
+
+// DeployControlPlane deploys or restores the ControlPlane custom resource (purpose normal).
 func (b *Botanist) DeployControlPlane(ctx context.Context) error {
-	var (
-		restorePhase      = b.isRestorePhase()
-		gardenerOperation = v1beta1constants.GardenerOperationReconcile
-		cp                = &extensionsv1alpha1.ControlPlane{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      b.Shoot.Info.Name,
-				Namespace: b.Shoot.SeedNamespace,
-			},
-		}
-		providerConfig *runtime.RawExtension
-	)
-
-	if cfg := b.Shoot.Info.Spec.Provider.ControlPlaneConfig; cfg != nil {
-		providerConfig = &runtime.RawExtension{
-			Raw: cfg.Raw,
-		}
-	}
-
-	if restorePhase {
-		gardenerOperation = v1beta1constants.GardenerOperationWaitForState
-	}
-
-	_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), cp, func() error {
-		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerOperation, gardenerOperation)
-		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
-
-		cp.Spec = extensionsv1alpha1.ControlPlaneSpec{
-			DefaultSpec: extensionsv1alpha1.DefaultSpec{
-				Type:           string(b.Shoot.Info.Spec.Provider.Type),
-				ProviderConfig: providerConfig,
-			},
-			Region: b.Shoot.Info.Spec.Region,
-			SecretRef: corev1.SecretReference{
-				Name:      v1beta1constants.SecretNameCloudProvider,
-				Namespace: cp.Namespace,
-			},
-			InfrastructureProviderStatus: &runtime.RawExtension{
-				Raw: b.Shoot.InfrastructureStatus,
-			},
-		}
-		return nil
+	b.Shoot.Components.Extensions.ControlPlane.SetInfrastructureProviderStatus(&runtime.RawExtension{
+		Raw: b.Shoot.InfrastructureStatus,
 	})
-	if err != nil {
-		return err
-	}
-
-	if restorePhase {
-		return b.restoreExtensionObject(ctx, cp, extensionsv1alpha1.ControlPlaneResource)
-	}
-
-	return nil
+	return b.deployOrRestoreControlPlane(ctx, b.Shoot.Components.Extensions.ControlPlane)
 }
 
-const controlPlaneExposureSuffix = "-exposure"
-
-// DeployControlPlaneExposure creates the `ControlPlane` extension resource with purpose `exposure` in the shoot
-// namespace in the seed cluster. Gardener waits until an external controller did reconcile the cluster successfully.
+// DeployControlPlane deploys or restores the ControlPlane custom resource (purpose exposure).
 func (b *Botanist) DeployControlPlaneExposure(ctx context.Context) error {
-	var (
-		restorePhase      = b.isRestorePhase()
-		gardenerOperation = v1beta1constants.GardenerOperationReconcile
-		cp                = &extensionsv1alpha1.ControlPlane{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      b.Shoot.Info.Name + controlPlaneExposureSuffix,
-				Namespace: b.Shoot.SeedNamespace,
-			},
-		}
-	)
+	return b.deployOrRestoreControlPlane(ctx, b.Shoot.Components.Extensions.ControlPlaneExposure)
+}
 
-	purpose := new(extensionsv1alpha1.Purpose)
-	*purpose = extensionsv1alpha1.Exposure
-
-	if restorePhase {
-		gardenerOperation = v1beta1constants.GardenerOperationWaitForState
+func (b *Botanist) deployOrRestoreControlPlane(ctx context.Context, controlPlane shoot.ExtensionControlPlane) error {
+	if b.isRestorePhase() {
+		return controlPlane.Restore(ctx, b.ShootState)
 	}
-
-	_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), cp, func() error {
-		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerOperation, gardenerOperation)
-		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
-		cp.Spec = extensionsv1alpha1.ControlPlaneSpec{
-			DefaultSpec: extensionsv1alpha1.DefaultSpec{
-				Type: b.Seed.Info.Spec.Provider.Type,
-			},
-			Region:  b.Seed.Info.Spec.Provider.Region,
-			Purpose: purpose,
-			SecretRef: corev1.SecretReference{
-				Name:      v1beta1constants.SecretNameCloudProvider,
-				Namespace: cp.Namespace,
-			},
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	if restorePhase {
-		return b.restoreExtensionObject(ctx, cp, extensionsv1alpha1.ControlPlaneResource)
-	}
-	return nil
-}
-
-// DestroyControlPlane deletes the `ControlPlane` extension resource in the shoot namespace in the seed cluster,
-// and it waits for a maximum of 10m until it is deleted.
-func (b *Botanist) DestroyControlPlane(ctx context.Context) error {
-	return b.destroyControlPlane(ctx, b.Shoot.Info.Name)
-}
-
-// DestroyControlPlaneExposure deletes the `ControlPlane` extension resource with purpose `exposure`
-// in the shoot namespace in the seed cluster, and it waits for a maximum of 10m until it is deleted.
-func (b *Botanist) DestroyControlPlaneExposure(ctx context.Context) error {
-	return b.destroyControlPlane(ctx, b.Shoot.Info.Name+controlPlaneExposureSuffix)
-}
-
-// destroyControlPlane deletes the `ControlPlane` extension resource with the following name in the shoot namespace
-// in the seed cluster, and it waits for a maximum of 10m until it is deleted.
-func (b *Botanist) destroyControlPlane(ctx context.Context, name string) error {
-	return common.DeleteExtensionCR(
-		ctx,
-		b.K8sSeedClient.Client(),
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ControlPlane{} },
-		b.Shoot.SeedNamespace,
-		name,
-	)
-}
-
-// WaitUntilControlPlaneExposureReady waits until the control plane resource with purpose `exposure` has been reconciled successfully.
-func (b *Botanist) WaitUntilControlPlaneExposureReady(ctx context.Context) error {
-	return b.waitUntilControlPlaneReady(ctx, b.Shoot.Info.Name+controlPlaneExposureSuffix)
-}
-
-// WaitUntilControlPlaneReady waits until the control plane resource has been reconciled successfully.
-func (b *Botanist) WaitUntilControlPlaneReady(ctx context.Context) error {
-	return b.waitUntilControlPlaneReady(ctx, b.Shoot.Info.Name)
-}
-
-// waitUntilControlPlaneReady waits until the control plane resource has been reconciled successfully.
-func (b *Botanist) waitUntilControlPlaneReady(ctx context.Context, name string) error {
-	return common.WaitUntilExtensionCRReady(
-		ctx,
-		b.K8sSeedClient.DirectClient(),
-		b.Logger,
-		func() runtime.Object { return &extensionsv1alpha1.ControlPlane{} },
-		"ControlPlane",
-		b.Shoot.SeedNamespace,
-		name,
-		DefaultInterval,
-		DefaultSevereThreshold,
-		ControlPlaneDefaultTimeout,
-		func(o runtime.Object) error {
-			obj, ok := o.(extensionsv1alpha1.Object)
-			if !ok {
-				return fmt.Errorf("expected extensionsv1alpha1.Object but got %T", o)
-			}
-			if providerStatus := obj.GetExtensionStatus().GetProviderStatus(); providerStatus != nil {
-				b.Shoot.ControlPlaneStatus = providerStatus.Raw
-			}
-			return nil
-		},
-	)
-}
-
-// WaitUntilControlPlaneExposureDeleted waits until the control plane resource with purpose `exposure` has been deleted.
-func (b *Botanist) WaitUntilControlPlaneExposureDeleted(ctx context.Context) error {
-	return b.waitUntilControlPlaneDeleted(ctx, b.Shoot.Info.Name+controlPlaneExposureSuffix)
-}
-
-// WaitUntilControlPlaneDeleted waits until the control plane resource has been deleted.
-func (b *Botanist) WaitUntilControlPlaneDeleted(ctx context.Context) error {
-	return b.waitUntilControlPlaneDeleted(ctx, b.Shoot.Info.Name)
-}
-
-// waitUntilControlPlaneDeleted waits until the control plane resource with the following name has been deleted.
-func (b *Botanist) waitUntilControlPlaneDeleted(ctx context.Context, name string) error {
-	return common.WaitUntilExtensionCRDeleted(
-		ctx,
-		b.K8sSeedClient.DirectClient(),
-		b.Logger,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ControlPlane{} },
-		"ControlPlane",
-		b.Shoot.SeedNamespace,
-		name,
-		DefaultInterval,
-		ControlPlaneDefaultTimeout,
-	)
+	return controlPlane.Deploy(ctx)
 }
 
 // DeployGardenerResourceManager deploys the gardener-resource-manager which will use CRD resources in order
@@ -862,7 +718,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		defaultValues["sni"] = map[string]interface{}{
 			"enabled":           true,
 			"advertiseIP":       b.APIServerClusterIP,
-			"apiserverFQDN":     b.outOfClusterAPIServerFQDN(),
+			"apiserverFQDN":     b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
 			"podMutatorEnabled": b.APIServerSNIPodMutatorEnabled(),
 		}
 	}

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane/clusterautoscaler/bootstrap.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane/clusterautoscaler/bootstrap.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 
@@ -33,12 +34,20 @@ const (
 	managedResourceControlName = "cluster-autoscaler"
 )
 
-// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy
-// or deleted.
-var TimeoutWaitForManagedResource = 2 * time.Minute
+// NewBootstrapper creates a new instance of DeployWaiter for the cluster-autoscaler bootstrapper.
+func NewBootstrapper(client client.Client, namespace string) component.DeployWaiter {
+	return &bootstrapper{
+		client:    client,
+		namespace: namespace,
+	}
+}
 
-// BootstrapSeed deploys the RBAC configuration for the control cluster.
-func BootstrapSeed(ctx context.Context, c client.Client, namespace, _ string) error {
+type bootstrapper struct {
+	client    client.Client
+	namespace string
+}
+
+func (b *bootstrapper) Deploy(ctx context.Context) error {
 	var (
 		registry = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 
@@ -61,24 +70,27 @@ func BootstrapSeed(ctx context.Context, c client.Client, namespace, _ string) er
 		return err
 	}
 
-	if err := common.DeployManagedResourceForSeed(ctx, c, managedResourceControlName, namespace, false, resources); err != nil {
-		return err
-	}
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
-	defer cancel()
-
-	return managedresources.WaitUntilManagedResourceHealthy(timeoutCtx, c, namespace, managedResourceControlName)
+	return common.DeployManagedResourceForSeed(ctx, b.client, managedResourceControlName, b.namespace, false, resources)
 }
 
-// DebootstrapSeed deletes all the resources deployed during the seed bootstrapping.
-func DebootstrapSeed(ctx context.Context, c client.Client, namespace string) error {
-	if err := common.DeleteManagedResourceForSeed(ctx, c, managedResourceControlName, namespace); err != nil {
-		return err
-	}
+func (b *bootstrapper) Destroy(ctx context.Context) error {
+	return common.DeleteManagedResourceForSeed(ctx, b.client, managedResourceControlName, b.namespace)
+}
 
+// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy
+// or deleted.
+var TimeoutWaitForManagedResource = 2 * time.Minute
+
+func (b *bootstrapper) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()
 
-	return managedresources.WaitUntilManagedResourceDeleted(timeoutCtx, c, namespace, managedResourceControlName)
+	return managedresources.WaitUntilManagedResourceHealthy(timeoutCtx, b.client, b.namespace, managedResourceControlName)
+}
+
+func (b *bootstrapper) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilManagedResourceDeleted(timeoutCtx, b.client, b.namespace, managedResourceControlName)
 }

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane/etcd/bootstrap.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane/etcd/bootstrap.go
@@ -23,6 +23,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
@@ -60,13 +61,33 @@ const (
 	druidDeploymentVolumeNameImageVectorOverwrite      = "imagevector-overwrite"
 )
 
-// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy
-// or deleted.
-var TimeoutWaitForManagedResource = 2 * time.Minute
+// NewBootstrapper creates a new instance of DeployWaiter for the etcd bootstrapper.
+func NewBootstrapper(
+	client client.Client,
+	namespace string,
+	image string,
+	kubernetesVersion string,
+	imageVectorOverwrite *string,
+) component.DeployWaiter {
+	return &bootstrapper{
+		client:               client,
+		namespace:            namespace,
+		image:                image,
+		kubernetesVersion:    kubernetesVersion,
+		imageVectorOverwrite: imageVectorOverwrite,
+	}
+}
 
-// BootstrapSeed deploys the etcd-druid for the control cluster.
-func BootstrapSeed(ctx context.Context, c client.Client, namespace, seedVersion, etcdDruidImage string, imageVectorOverwrite *string) error {
-	v, err := semver.NewVersion(seedVersion)
+type bootstrapper struct {
+	client               client.Client
+	namespace            string
+	image                string
+	kubernetesVersion    string
+	imageVectorOverwrite *string
+}
+
+func (b *bootstrapper) Deploy(ctx context.Context) error {
+	v, err := semver.NewVersion(b.kubernetesVersion)
 	if err != nil {
 		return err
 	}
@@ -83,7 +104,7 @@ func BootstrapSeed(ctx context.Context, c client.Client, namespace, seedVersion,
 		serviceAccount = &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      druidServiceAccountName,
-				Namespace: namespace,
+				Namespace: b.namespace,
 				Labels:    labels(),
 			},
 		}
@@ -141,7 +162,7 @@ func BootstrapSeed(ctx context.Context, c client.Client, namespace, seedVersion,
 				{
 					Kind:      rbacv1.ServiceAccountKind,
 					Name:      druidServiceAccountName,
-					Namespace: namespace,
+					Namespace: b.namespace,
 				},
 			},
 		}
@@ -149,7 +170,7 @@ func BootstrapSeed(ctx context.Context, c client.Client, namespace, seedVersion,
 		configMapImageVectorOverwrite = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      druidConfigMapImageVectorOverwriteName,
-				Namespace: namespace,
+				Namespace: b.namespace,
 				Labels:    labels(),
 			},
 		}
@@ -158,7 +179,7 @@ func BootstrapSeed(ctx context.Context, c client.Client, namespace, seedVersion,
 		vpa           = &autoscalingv1beta2.VerticalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      druidVPAName,
-				Namespace: namespace,
+				Namespace: b.namespace,
 				Labels:    labels(),
 			},
 			Spec: autoscalingv1beta2.VerticalPodAutoscalerSpec{
@@ -185,7 +206,7 @@ func BootstrapSeed(ctx context.Context, c client.Client, namespace, seedVersion,
 		deployment = &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      druidDeploymentName,
-				Namespace: namespace,
+				Namespace: b.namespace,
 				Labels:    labels(),
 			},
 			Spec: appsv1.DeploymentSpec{
@@ -203,7 +224,7 @@ func BootstrapSeed(ctx context.Context, c client.Client, namespace, seedVersion,
 						Containers: []corev1.Container{
 							{
 								Name:            Druid,
-								Image:           etcdDruidImage,
+								Image:           b.image,
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Command: []string{
 									"/bin/etcd-druid",
@@ -239,11 +260,11 @@ func BootstrapSeed(ctx context.Context, c client.Client, namespace, seedVersion,
 		}
 	)
 
-	if imageVectorOverwrite != nil {
-		configMapImageVectorOverwrite.Data = map[string]string{druidConfigMapImageVectorOverwriteDataKey: *imageVectorOverwrite}
+	if b.imageVectorOverwrite != nil {
+		configMapImageVectorOverwrite.Data = map[string]string{druidConfigMapImageVectorOverwriteDataKey: *b.imageVectorOverwrite}
 		resourcesToAdd = append(resourcesToAdd, configMapImageVectorOverwrite)
 
-		deployment.Spec.Template.Labels["checksum/configmap-imagevector-overwrite"] = utils.ComputeChecksum(configMapImageVectorOverwrite.Data)
+		metav1.SetMetaDataAnnotation(&deployment.Spec.Template.ObjectMeta, "checksum/configmap-imagevector-overwrite", utils.ComputeChecksum(configMapImageVectorOverwrite.Data))
 		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: druidDeploymentVolumeNameImageVectorOverwrite,
 			VolumeSource: corev1.VolumeSource{
@@ -271,20 +292,12 @@ func BootstrapSeed(ctx context.Context, c client.Client, namespace, seedVersion,
 	}
 	resources["crd.yaml"] = crdYAML.Bytes()
 
-	if err := common.DeployManagedResourceForSeed(ctx, c, managedResourceControlName, namespace, false, resources); err != nil {
-		return err
-	}
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
-	defer cancel()
-
-	return managedresources.WaitUntilManagedResourceHealthy(timeoutCtx, c, namespace, managedResourceControlName)
+	return common.DeployManagedResourceForSeed(ctx, b.client, managedResourceControlName, b.namespace, false, resources)
 }
 
-// DebootstrapSeed deletes all the resources deployed during the seed bootstrapping.
-func DebootstrapSeed(ctx context.Context, c client.Client, namespace string) error {
+func (b *bootstrapper) Destroy(ctx context.Context) error {
 	etcdList := &druidv1alpha1.EtcdList{}
-	if err := c.List(ctx, etcdList); err != nil {
+	if err := b.client.List(ctx, etcdList); err != nil {
 		return err
 	}
 
@@ -292,18 +305,29 @@ func DebootstrapSeed(ctx context.Context, c client.Client, namespace string) err
 		return fmt.Errorf("cannot debootstrap etcd-druid because there are still druidv1alpha1.Etcd resources left in the cluster")
 	}
 
-	if err := common.ConfirmDeletion(ctx, c, &apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: crdName}}); err != nil {
+	if err := common.ConfirmDeletion(ctx, b.client, &apiextensionsv1beta1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: crdName}}); err != nil {
 		return err
 	}
 
-	if err := common.DeleteManagedResourceForSeed(ctx, c, managedResourceControlName, namespace); err != nil {
-		return err
-	}
+	return common.DeleteManagedResourceForSeed(ctx, b.client, managedResourceControlName, b.namespace)
+}
 
+// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy
+// or deleted.
+var TimeoutWaitForManagedResource = 2 * time.Minute
+
+func (b *bootstrapper) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()
 
-	return managedresources.WaitUntilManagedResourceDeleted(timeoutCtx, c, namespace, managedResourceControlName)
+	return managedresources.WaitUntilManagedResourceHealthy(timeoutCtx, b.client, b.namespace, managedResourceControlName)
+}
+
+func (b *bootstrapper) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilManagedResourceDeleted(timeoutCtx, b.client, b.namespace, managedResourceControlName)
 }
 
 var (

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane/etcd/etcd.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane/etcd/etcd.go
@@ -279,7 +279,11 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 			v1beta1constants.GardenerTimestamp: TimeNow().UTC().String(),
 		}
-		etcd.Labels = e.getLabels()
+		etcd.Labels = map[string]string{
+			v1beta1constants.LabelRole:            e.role,
+			v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
+			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
+		}
 		etcd.Spec.Replicas = replicas
 		etcd.Spec.PriorityClassName = pointer.StringPtr(v1beta1constants.PriorityClassNameShootControlPlane)
 		etcd.Spec.Annotations = annotations

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager.go
@@ -169,6 +169,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, k.seedClient, deployment, func() error {
 		deployment.Labels = utils.MergeStringMaps(getLabels(), map[string]string{
+			v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
 			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
 		})
 		deployment.Spec.Replicas = &k.replicas
@@ -504,7 +505,6 @@ func (k *kubeControllerManager) getHorizontalPodAutoscalerConfig() gardencorev1b
 }
 
 var (
-	versionConstraintK8sEqual113        *semver.Constraints
 	versionConstraintK8sGreaterEqual112 *semver.Constraints
 	versionConstraintK8sSmaller112      *semver.Constraints
 	versionConstraintK8sGreaterEqual113 *semver.Constraints
@@ -520,8 +520,6 @@ func init() {
 	versionConstraintK8sSmaller112, err = semver.NewConstraint("< 1.12")
 	utilruntime.Must(err)
 	versionConstraintK8sGreaterEqual112, err = semver.NewConstraint(">= 1.12")
-	utilruntime.Must(err)
-	versionConstraintK8sEqual113, err = semver.NewConstraint("~ 1.13")
 	utilruntime.Must(err)
 	versionConstraintK8sGreaterEqual113, err = semver.NewConstraint(">= 1.13")
 	utilruntime.Must(err)

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler.go
@@ -165,6 +165,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, k.client, deployment, func() error {
 		deployment.Labels = utils.MergeStringMaps(getLabels(), map[string]string{
+			v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
 			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
 		})
 		deployment.Spec.Replicas = &k.replicas

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/extensions/containerruntime/containerruntime.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/extensions/containerruntime/containerruntime.go
@@ -57,21 +57,21 @@ type Values struct {
 type containerruntime struct {
 	values              *Values
 	client              client.Client
-	logger              *logrus.Entry
+	logger              logrus.FieldLogger
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
 	waitTimeout         time.Duration
 }
 
-// New creates a new instance of ContainerRuntime deployer.
+// New creates a new instance of ExtensionContainerRuntime deployer.
 func New(
-	logger *logrus.Entry,
+	logger logrus.FieldLogger,
 	client client.Client,
 	values *Values,
 	waitInterval time.Duration,
 	waitSevereThreshold time.Duration,
 	waitTimeout time.Duration,
-) shoot.ContainerRuntime {
+) shoot.ExtensionContainerRuntime {
 	return &containerruntime{
 		values:              values,
 		client:              client,
@@ -127,7 +127,7 @@ func (d *containerruntime) WaitCleanup(ctx context.Context) error {
 		d.logger,
 		&extensionsv1alpha1.ContainerRuntimeList{},
 		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
-		"ContainerRuntime",
+		extensionsv1alpha1.ContainerRuntimeResource,
 		d.values.Namespace,
 		d.waitInterval,
 		d.waitTimeout,
@@ -135,7 +135,7 @@ func (d *containerruntime) WaitCleanup(ctx context.Context) error {
 	)
 }
 
-// Restore uses the seed client and the ShootState to create the ContainereRuntime resources and restore their state.
+// Restore uses the seed client and the ShootState to create the ContainerRuntime resources and restore their state.
 func (d *containerruntime) Restore(ctx context.Context, shootState *gardencorev1alpha1.ShootState) error {
 	fns := d.forEachContainerRuntime(func(ctx context.Context, workerName string, cr gardencorev1beta1.ContainerRuntime) error {
 		rd := resourceDeployer{d.values.Namespace, workerName, cr, d.client}

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/extensions/controlplane/controlplane.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/extensions/controlplane/controlplane.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/shoot"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	// DefaultInterval is the default interval for retry operations.
+	DefaultInterval = 5 * time.Second
+	// DefaultSevereThreshold is the default threshold until an error reported by another component is treated as
+	// 'severe'.
+	DefaultSevereThreshold = 30 * time.Second
+	// DefaultTimeout is the default timeout and defines how long Gardener should wait for a successful reconciliation
+	// of a ControlPlane resource.
+	DefaultTimeout = 3 * time.Minute
+)
+
+// TimeNow returns the current time. Exposed for testing.
+var TimeNow = time.Now
+
+// Values contains the values used to create an ControlPlane resources.
+type Values struct {
+	// Namespace is the Shoot namespace in the seed.
+	Namespace string
+	// Name is the name of the ControlPlane resource. Commonly the Shoot's name.
+	Name string
+	// Type is the type of the ControlPlane provider.
+	Type string
+	// ProviderConfig contains the provider config for the ControlPlane provider.
+	ProviderConfig *runtime.RawExtension
+	// Purpose is the purpose of the ControlPlane resource (normal/exposure).
+	Purpose extensionsv1alpha1.Purpose
+	// Region is the region of the shoot.
+	Region string
+	// InfrastructureProviderStatus is the provider status of the Infrastructure resource which might be relevant for
+	// the ControlPlane reconciliation.
+	InfrastructureProviderStatus *runtime.RawExtension
+}
+
+// New creates a new instance of an ControlPlane deployer.
+func New(
+	logger logrus.FieldLogger,
+	client client.Client,
+	values *Values,
+	waitInterval time.Duration,
+	waitSevereThreshold time.Duration,
+	waitTimeout time.Duration,
+) shoot.ExtensionControlPlane {
+	return &controlPlane{
+		client:              client,
+		logger:              logger,
+		values:              values,
+		waitInterval:        waitInterval,
+		waitSevereThreshold: waitSevereThreshold,
+		waitTimeout:         waitTimeout,
+	}
+}
+
+type controlPlane struct {
+	values              *Values
+	logger              logrus.FieldLogger
+	client              client.Client
+	waitInterval        time.Duration
+	waitSevereThreshold time.Duration
+	waitTimeout         time.Duration
+
+	providerStatus *runtime.RawExtension
+}
+
+func (i *controlPlane) name() string {
+	if i.values.Purpose == extensionsv1alpha1.Exposure {
+		return i.values.Name + "-exposure"
+	}
+	return i.values.Name
+}
+
+// Deploy uses the seed client to create or update the ControlPlane resource.
+func (i *controlPlane) Deploy(ctx context.Context) error {
+	_, err := i.deploy(ctx, v1beta1constants.GardenerOperationReconcile)
+	return err
+}
+
+func (i *controlPlane) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
+	var (
+		controlPlane = &extensionsv1alpha1.ControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      i.name(),
+				Namespace: i.values.Namespace,
+			},
+		}
+		providerConfig *runtime.RawExtension
+	)
+
+	if cfg := i.values.ProviderConfig; cfg != nil {
+		providerConfig = &runtime.RawExtension{Raw: cfg.Raw}
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, i.client, controlPlane, func() error {
+		metav1.SetMetaDataAnnotation(&controlPlane.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+		metav1.SetMetaDataAnnotation(&controlPlane.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+
+		controlPlane.Spec = extensionsv1alpha1.ControlPlaneSpec{
+			DefaultSpec: extensionsv1alpha1.DefaultSpec{
+				Type:           i.values.Type,
+				ProviderConfig: providerConfig,
+			},
+			Region:  i.values.Region,
+			Purpose: &i.values.Purpose,
+			SecretRef: corev1.SecretReference{
+				Name:      v1beta1constants.SecretNameCloudProvider,
+				Namespace: controlPlane.Namespace,
+			},
+			InfrastructureProviderStatus: i.values.InfrastructureProviderStatus,
+		}
+
+		return nil
+	})
+
+	return controlPlane, err
+}
+
+// Restore uses the seed client and the ShootState to create the ControlPlane resources and restore their state.
+func (i *controlPlane) Restore(ctx context.Context, shootState *gardencorev1alpha1.ShootState) error {
+	return common.RestoreExtensionWithDeployFunction(
+		ctx,
+		shootState,
+		i.client,
+		extensionsv1alpha1.ControlPlaneResource,
+		i.values.Namespace,
+		i.deploy,
+	)
+}
+
+// Migrate migrates the ControlPlane resources.
+func (i *controlPlane) Migrate(ctx context.Context) error {
+	return common.MigrateExtensionCRs(
+		ctx,
+		i.client,
+		&extensionsv1alpha1.ControlPlaneList{},
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ControlPlane{} },
+		i.values.Namespace,
+	)
+}
+
+// Destroy deletes the ControlPlane resource.
+func (i *controlPlane) Destroy(ctx context.Context) error {
+	return common.DeleteExtensionCR(
+		ctx,
+		i.client,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ControlPlane{} },
+		i.values.Namespace,
+		i.name(),
+	)
+}
+
+// Wait waits until the ControlPlane resource is ready.
+func (i *controlPlane) Wait(ctx context.Context) error {
+	return common.WaitUntilExtensionCRReady(
+		ctx,
+		i.client,
+		i.logger,
+		func() runtime.Object { return &extensionsv1alpha1.ControlPlane{} },
+		extensionsv1alpha1.ControlPlaneResource,
+		i.values.Namespace,
+		i.name(),
+		i.waitInterval,
+		i.waitSevereThreshold,
+		i.waitTimeout,
+		func(obj runtime.Object) error {
+			controlPlane, ok := obj.(*extensionsv1alpha1.ControlPlane)
+			if !ok {
+				return fmt.Errorf("expected extensionsv1alpha1.ControlPlane but got %T", controlPlane)
+			}
+
+			i.providerStatus = controlPlane.Status.ProviderStatus
+			return nil
+		},
+	)
+}
+
+// WaitMigrate waits until the ControlPlane resources are migrated successfully.
+func (i *controlPlane) WaitMigrate(ctx context.Context) error {
+	return common.WaitUntilExtensionCRMigrated(
+		ctx,
+		i.client,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ControlPlane{} },
+		i.values.Namespace,
+		i.name(),
+		i.waitInterval,
+		i.waitTimeout,
+	)
+}
+
+// WaitCleanup waits until the ControlPlane resource is deleted.
+func (i *controlPlane) WaitCleanup(ctx context.Context) error {
+	return common.WaitUntilExtensionCRDeleted(
+		ctx,
+		i.client,
+		i.logger,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ControlPlane{} },
+		extensionsv1alpha1.ControlPlaneResource,
+		i.values.Namespace,
+		i.name(),
+		i.waitInterval,
+		i.waitTimeout,
+	)
+}
+
+// SetInfrastructureProviderStatus sets the infrastructure provider status in the values.
+func (i *controlPlane) SetInfrastructureProviderStatus(status *runtime.RawExtension) {
+	i.values.InfrastructureProviderStatus = status
+}
+
+// ProviderStatus returns the generated status of the provider.
+func (i *controlPlane) ProviderStatus() *runtime.RawExtension {
+	return i.providerStatus
+}

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
@@ -72,12 +72,12 @@ type Values struct {
 	DeploymentRequested bool
 }
 
-// New creates a new instance of an Infrastructure deployer.
+// New creates a new instance of an ExtensionInfrastructure deployer.
 func New(
 	logger logrus.FieldLogger,
 	client client.Client,
 	values *Values,
-) shoot.Infrastructure {
+) shoot.ExtensionInfrastructure {
 	return &infrastructure{
 		client:              client,
 		logger:              logger,
@@ -166,7 +166,7 @@ func (i *infrastructure) Wait(ctx context.Context) error {
 		i.client,
 		i.logger,
 		func() runtime.Object { return &extensionsv1alpha1.Infrastructure{} },
-		"Infrastructure",
+		extensionsv1alpha1.InfrastructureResource,
 		i.values.Namespace,
 		i.values.Name,
 		i.waitInterval,
@@ -192,7 +192,7 @@ func (i *infrastructure) WaitCleanup(ctx context.Context) error {
 		i.client,
 		i.logger,
 		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Infrastructure{} },
-		"Infrastructure",
+		extensionsv1alpha1.InfrastructureResource,
 		i.values.Namespace,
 		i.values.Name,
 		i.waitInterval,

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/health_check.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/health_check.go
@@ -54,6 +54,7 @@ import (
 )
 
 func mustGardenRoleLabelSelector(gardenRoles ...string) labels.Selector {
+	// TODO (ialidzhikov): switch to v1beta1constants.GardenRole in a future version.
 	if len(gardenRoles) == 1 {
 		return labels.SelectorFromSet(map[string]string{v1beta1constants.DeprecatedGardenRole: gardenRoles[0]})
 	}
@@ -311,10 +312,6 @@ func computeRequiredMonitoringStatefulSets(wantsAlertmanager bool) sets.String {
 	return requiredMonitoringStatefulSets
 }
 
-// deprecatedGardenRoleVPA is the role name for VPA deployments used by older Gardener versions.
-// TODO: remove in a future version
-const deprecatedGardenRoleVPA = "vpa"
-
 // CheckControlPlane checks whether the control plane components in the given listers are complete and healthy.
 func (b *HealthChecker) CheckControlPlane(
 	shoot *gardencorev1beta1.Shoot,
@@ -333,14 +330,6 @@ func (b *HealthChecker) CheckControlPlane(
 	if err != nil {
 		return nil, err
 	}
-
-	// Required for backwards compatibility
-	// TODO: remove in a future version
-	vpaDeployments, err := deploymentLister.Deployments(namespace).List(mustGardenRoleLabelSelector(deprecatedGardenRoleVPA))
-	if err != nil {
-		return nil, err
-	}
-	deployments = append(deployments, vpaDeployments...)
 
 	if exitCondition := b.checkRequiredDeployments(condition, requiredControlPlaneDeployments, deployments); exitCondition != nil {
 		return exitCondition, nil
@@ -476,11 +465,11 @@ func (b *HealthChecker) CheckMonitoringControlPlane(
 // CheckLoggingControlPlane checks whether the logging components in the given listers are complete and healthy.
 func (b *HealthChecker) CheckLoggingControlPlane(
 	namespace string,
-	checkObsolete bool,
+	isTestingShoot bool,
 	condition gardencorev1beta1.Condition,
 	statefulSetLister kutil.StatefulSetLister,
 ) (*gardencorev1beta1.Condition, error) {
-	if checkObsolete {
+	if isTestingShoot {
 		return nil, nil
 	}
 
@@ -555,7 +544,7 @@ func (b *Botanist) checkControlPlane(
 		return exitCondition, err
 	}
 	if gardenletfeatures.FeatureGate.Enabled(features.Logging) {
-		if exitCondition, err := checker.CheckLoggingControlPlane(b.Shoot.SeedNamespace, b.isLoggingHealthCheckObsolete(), condition, seedStatefulSetLister); err != nil || exitCondition != nil {
+		if exitCondition, err := checker.CheckLoggingControlPlane(b.Shoot.SeedNamespace, b.Shoot.GetPurpose() == gardencorev1beta1.ShootPurposeTesting, condition, seedStatefulSetLister); err != nil || exitCondition != nil {
 			return exitCondition, err
 		}
 	}
@@ -793,8 +782,6 @@ var (
 		v1beta1constants.GardenRoleControlPlane,
 		v1beta1constants.GardenRoleMonitoring,
 		v1beta1constants.GardenRoleLogging,
-		// TODO: remove in a future version
-		deprecatedGardenRoleVPA,
 	)
 )
 
@@ -866,30 +853,6 @@ func (b *Botanist) healthChecks(
 	})(ctx)
 
 	return apiserverAvailability, controlPlane, nodes, systemComponents
-}
-
-/*Shoot clusters prior gardener v1.8 were using EFK based stack, but from this version onward Loki is used.
-On some landscapes, shoots clusters are reconciled only in their maintenance time window and to prevent failing health checks,
-they are executed only for shoots that have already been reconciled by Gardener v1.8.x+ */
-func (b *Botanist) isLoggingHealthCheckObsolete() bool {
-	if b.Shoot.GetPurpose() == gardencorev1beta1.ShootPurposeTesting {
-		return true
-	}
-
-	if b.Shoot == nil || b.Shoot.Info == nil {
-		return true
-	}
-
-	c, err := semver.NewConstraint("<1.8.0")
-	if err != nil {
-		return true
-	}
-
-	lastGardenerVersion, err := semver.NewVersion(b.Shoot.Info.Status.Gardener.Version)
-	if err != nil {
-		return true
-	}
-	return c.Check(lastGardenerVersion)
 }
 
 func isUnstableLastOperation(lastOperation *gardencorev1beta1.LastOperation, lastErrors []gardencorev1beta1.LastError) bool {

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/infrastructure.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/infrastructure.go
@@ -32,7 +32,7 @@ import (
 )
 
 // DefaultInfrastructure creates the default deployer for the Infrastructure custom resource.
-func (b *Botanist) DefaultInfrastructure(seedClient client.Client) shoot.Infrastructure {
+func (b *Botanist) DefaultInfrastructure(seedClient client.Client) shoot.ExtensionInfrastructure {
 	return infrastructure.New(
 		b.Logger,
 		seedClient,

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server.go
@@ -260,8 +260,8 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 				Name:      deploymentName,
 				Namespace: metav1.NamespaceSystem,
 				Labels: utils.MergeStringMaps(getLabels(), map[string]string{
-					common.ManagedResourceLabelKeyOrigin:  common.ManagedResourceLabelValueGardener,
-					v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleSystemComponent,
+					common.ManagedResourceLabelKeyOrigin: common.ManagedResourceLabelValueGardener,
+					v1beta1constants.GardenRole:          v1beta1constants.GardenRoleSystemComponent,
 				}),
 			},
 			Spec: appsv1.DeploymentSpec{
@@ -276,7 +276,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: utils.MergeStringMaps(getLabels(), map[string]string{
 							common.ManagedResourceLabelKeyOrigin:                common.ManagedResourceLabelValueGardener,
-							v1beta1constants.DeprecatedGardenRole:               v1beta1constants.GardenRoleSystemComponent,
+							v1beta1constants.GardenRole:                         v1beta1constants.GardenRoleSystemComponent,
 							v1beta1constants.LabelNetworkPolicyShootFromSeed:    v1beta1constants.LabelNetworkPolicyAllowed,
 							v1beta1constants.LabelNetworkPolicyShootToAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,
 							v1beta1constants.LabelNetworkPolicyShootToKubelet:   v1beta1constants.LabelNetworkPolicyAllowed,
@@ -300,6 +300,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 							RunAsUser: pointer.Int64Ptr(65534),
 							FSGroup:   pointer.Int64Ptr(65534),
 						},
+						DNSPolicy:          corev1.DNSDefault, // make sure to not use the coredns for DNS resolution.
 						ServiceAccountName: serviceAccount.Name,
 						Containers: []corev1.Container{{
 							Name:            containerName,

--- a/vendor/github.com/gardener/gardener/pkg/operation/common/extensions.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/common/extensions.go
@@ -208,11 +208,7 @@ func DeleteExtensionCR(
 		return err
 	}
 
-	if err := client.IgnoreNotFound(c.Delete(ctx, obj, deleteOpts...)); err != nil {
-		return err
-	}
-
-	return nil
+	return client.IgnoreNotFound(c.Delete(ctx, obj, deleteOpts...))
 }
 
 // DeleteExtensionCRs lists all extension resources and loops over them. It executes the given <predicateFunc> for each
@@ -365,7 +361,7 @@ func RestoreExtensionWithDeployFunction(
 	return AnnotateExtensionObjectWithOperation(ctx, c, extensionObj, v1beta1constants.GardenerOperationRestore)
 }
 
-//RestoreExtensionObjectState restores the status.state field of the extension resources and deploys any required resources from the provided shoot state
+// RestoreExtensionObjectState restores the status.state field of the extension resources and deploys any required resources from the provided shoot state
 func RestoreExtensionObjectState(
 	ctx context.Context,
 	c client.Client,

--- a/vendor/github.com/gardener/gardener/pkg/operation/garden/garden.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/garden/garden.go
@@ -370,8 +370,7 @@ func generateMonitoringSecret(k8sGardenClient kubernetes.Interface, gardenNamesp
 	}
 	if _, err := controllerutil.CreateOrUpdate(context.TODO(), k8sGardenClient.Client(), secret, func() error {
 		secret.Labels = map[string]string{
-			v1beta1constants.GardenRole:           common.GardenRoleGlobalMonitoring,
-			v1beta1constants.DeprecatedGardenRole: common.GardenRoleGlobalMonitoring,
+			v1beta1constants.GardenRole: common.GardenRoleGlobalMonitoring,
 		}
 		secret.Type = corev1.SecretTypeOpaque
 		secret.Data = basicAuth.SecretData()

--- a/vendor/github.com/gardener/gardener/pkg/operation/shoot/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/shoot/types.go
@@ -108,10 +108,12 @@ type ControlPlane struct {
 
 // Extensions contains references to extension resources.
 type Extensions struct {
-	DNS              *DNS
-	Infrastructure   Infrastructure
-	Network          component.DeployMigrateWaiter
-	ContainerRuntime ContainerRuntime
+	ControlPlane         ExtensionControlPlane
+	ControlPlaneExposure ExtensionControlPlane
+	DNS                  *DNS
+	Infrastructure       ExtensionInfrastructure
+	Network              component.DeployMigrateWaiter
+	ContainerRuntime     ExtensionContainerRuntime
 }
 
 // SystemComponents contains references to system components.
@@ -132,17 +134,24 @@ type DNS struct {
 	NginxEntry          component.DeployWaiter
 }
 
-// Infrastructure contains references to an Infrastructure extension deployer and its generated
-// provider status.
-type Infrastructure interface {
+// ExtensionInfrastructure contains references to an Infrastructure extension deployer and its generated provider
+// status.
+type ExtensionInfrastructure interface {
 	component.DeployWaiter
 	SetSSHPublicKey([]byte)
 	ProviderStatus() *runtime.RawExtension
 	NodesCIDR() *string
 }
 
-// ContainerRuntime contains references to a ContainerRuntime extension deployer.
-type ContainerRuntime interface {
+// ExtensionControlPlane contains references to a ControlPlane extension deployer and its generated provider status.
+type ExtensionControlPlane interface {
+	component.DeployMigrateWaiter
+	SetInfrastructureProviderStatus(*runtime.RawExtension)
+	ProviderStatus() *runtime.RawExtension
+}
+
+// ExtensionContainerRuntime contains references to a ContainerRuntime extension deployer.
+type ExtensionContainerRuntime interface {
 	component.DeployMigrateWaiter
 	DeleteStaleResources(ctx context.Context) error
 }

--- a/vendor/github.com/gardener/gardener/pkg/operation/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/types.go
@@ -16,9 +16,6 @@ package operation
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"net/http"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -31,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 
-	prometheusapi "github.com/prometheus/client_golang/api"
 	prometheusclient "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -79,15 +75,4 @@ type Operation struct {
 
 	// ControlPlaneWildcardCert is a wildcard tls certificate which is issued for the seed's ingress domain.
 	ControlPlaneWildcardCert *corev1.Secret
-}
-
-type prometheusRoundTripper struct {
-	authHeader string
-	ca         *x509.CertPool
-}
-
-func (r prometheusRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("Authorization", r.authHeader)
-	prometheusapi.DefaultRoundTripper.(*http.Transport).TLSClientConfig = &tls.Config{RootCAs: r.ca}
-	return prometheusapi.DefaultRoundTripper.RoundTrip(req)
 }

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/health/health.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/health/health.go
@@ -246,11 +246,26 @@ var (
 
 // CheckSeed checks if the Seed is up-to-date and if its extensions have been successfully bootstrapped.
 func CheckSeed(seed *gardencorev1beta1.Seed, identity *gardencorev1beta1.Gardener) error {
-	if seed.Status.ObservedGeneration < seed.Generation {
-		return fmt.Errorf("observed generation outdated (%d/%d)", seed.Status.ObservedGeneration, seed.Generation)
-	}
 	if !apiequality.Semantic.DeepEqual(seed.Status.Gardener, identity) {
 		return fmt.Errorf("observing Gardener version not up to date (%v/%v)", seed.Status.Gardener, identity)
+	}
+
+	return checkSeed(seed, identity)
+}
+
+// CheckSeedForMigration checks if the Seed is up-to-date (comparing only the versions) and if its extensions have been successfully bootstrapped.
+func CheckSeedForMigration(seed *gardencorev1beta1.Seed, identity *gardencorev1beta1.Gardener) error {
+	if seed.Status.Gardener.Version != identity.Version {
+		return fmt.Errorf("observing Gardener version not up to date (%s/%s)", seed.Status.Gardener.Version, identity.Version)
+	}
+
+	return checkSeed(seed, identity)
+}
+
+// checkSeed checks if the seed.Status.ObservedGeneration ObservedGeneration is not outdated and if its extensions have been successfully bootstrapped.
+func checkSeed(seed *gardencorev1beta1.Seed, identity *gardencorev1beta1.Gardener) error {
+	if seed.Status.ObservedGeneration < seed.Generation {
+		return fmt.Errorf("observed generation outdated (%d/%d)", seed.Status.ObservedGeneration, seed.Generation)
 	}
 
 	for _, trueConditionType := range trueSeedConditionTypes {

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/patch.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/patch.go
@@ -121,5 +121,5 @@ func IsEmptyPatch(patch []byte) bool {
 
 // SubmitEmptyPatch submits an empty patch to the given `obj` with the given `client` instance.
 func SubmitEmptyPatch(ctx context.Context, c client.Client, obj runtime.Object) error {
-	return c.Patch(ctx, obj, client.ConstantPatch(types.StrategicMergePatchType, []byte("{}")))
+	return c.Patch(ctx, obj, client.RawPatch(types.StrategicMergePatchType, []byte("{}")))
 }

--- a/vendor/github.com/gardener/gardener/test/framework/common.go
+++ b/vendor/github.com/gardener/gardener/test/framework/common.go
@@ -38,10 +38,8 @@ const (
 // SearchResponse represents the response from a search query to loki
 type SearchResponse struct {
 	Data struct {
-		Stats struct {
-			Summary struct {
-				TotalLinesProcessed int `json:"totalLinesProcessed"`
-			} `json:"summary"`
-		} `json:"stats"`
+		Result []struct {
+			Value []interface{} `json:"value"`
+		} `json:"result"`
 	} `json:"data"`
 }

--- a/vendor/github.com/gardener/gardener/test/framework/dump.go
+++ b/vendor/github.com/gardener/gardener/test/framework/dump.go
@@ -393,23 +393,6 @@ func (f *CommonFramework) dumpPodInfoForNamespace(ctx context.Context, ctxIdenti
 }
 
 // dumpEventsInNamespace prints all events of a namespace
-func (f *CommonFramework) dumpEventsInAllNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, filters ...EventFilterFunc) error {
-	namespaces := &corev1.NamespaceList{}
-	if err := k8sClient.DirectClient().List(ctx, namespaces); err != nil {
-		return err
-	}
-
-	var result error
-
-	for _, ns := range namespaces.Items {
-		if err := f.dumpEventsInNamespace(ctx, ctxIdentifier, k8sClient, ns.Name); err != nil {
-			result = multierror.Append(result, err)
-		}
-	}
-	return result
-}
-
-// dumpEventsInNamespace prints all events of a namespace
 func (f *CommonFramework) dumpEventsInNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string, filters ...EventFilterFunc) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [EVENTS]", ctxIdentifier, namespace)
 	events := &corev1.EventList{}

--- a/vendor/github.com/gardener/gardener/test/framework/shootframework.go
+++ b/vendor/github.com/gardener/gardener/test/framework/shootframework.go
@@ -23,6 +23,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	gardenextensionsscheme "github.com/gardener/gardener/pkg/client/extensions/clientset/versioned/scheme"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -216,6 +217,7 @@ func (f *ShootFramework) AddShoot(ctx context.Context, shootName, shootNamespace
 		apiextensionsscheme.AddToScheme,
 		apiregistrationscheme.AddToScheme,
 		metricsscheme.AddToScheme,
+		gardenextensionsscheme.AddToScheme,
 	)
 	err = shootSchemeBuilder.AddToScheme(shootScheme)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -96,7 +96,7 @@ github.com/gardener/etcd-druid/api/v1alpha1
 # github.com/gardener/external-dns-management v0.7.18
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
-# github.com/gardener/gardener v1.13.0
+# github.com/gardener/gardener v1.13.1-0.20201130092019-e4b9da08a171
 ## explicit
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE
@@ -196,6 +196,7 @@ github.com/gardener/gardener/pkg/operation/botanist/controlplane/etcd
 github.com/gardener/gardener/pkg/operation/botanist/controlplane/kubecontrollermanager
 github.com/gardener/gardener/pkg/operation/botanist/controlplane/kubescheduler
 github.com/gardener/gardener/pkg/operation/botanist/extensions/containerruntime
+github.com/gardener/gardener/pkg/operation/botanist/extensions/controlplane
 github.com/gardener/gardener/pkg/operation/botanist/extensions/dns
 github.com/gardener/gardener/pkg/operation/botanist/extensions/infrastructure
 github.com/gardener/gardener/pkg/operation/botanist/extensions/network


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority normal
/platform aws

**What this PR does / why we need it**:
Ensures that even the unwanted machine classes have up-to-date AWS credentials.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3023
Related to gardener/gardener#3223 
**Special notes for your reviewer**:
I am opening this PR as draft till https://github.com/gardener/gardener/pull/3224 is merged.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug that was preventing the deletion machines with outdated credentials is now fixed.
```


```noteworthy operator
Logging in the infrastructure actuator has been improved to make it consistent in the logging format and more readable/helpful.
```

