### PR TITLE
Run infra integration test on release

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -31,6 +31,13 @@ gardener-extension-provider-aws:
         options:
           public_build_logs: true
     release:
+      steps:
+        test-integration:
+          execute:
+          - test-integration.sh
+          depends:
+          - publish
+          image: 'eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable'
       traits:
         version:
           preprocess: 'finalize'

--- a/.ci/test-integration.sh
+++ b/.ci/test-integration.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd "$(dirname $0)/.."
+
+mkdir -p /tm
+/cc/utils/cli.py config attribute --cfg-type kubernetes --cfg-name testmachinery --key kubeconfig > /tm/kubeconfig
+/testrunner run \
+    --tm-kubeconfig-path=/tm/kubeconfig \
+    --no-execution-group \
+    --testrun-prefix tm-extension-aws- \
+    --timeout=1800 \
+    --testruns-chart-path=.ci/testruns/default \
+    --set revision="$(cat ./VERSION)"

--- a/.ci/testruns/default/Chart.yaml
+++ b/.ci/testruns/default/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for the default testrun
+name: default-testrun
+version: 0.1.0

--- a/.ci/testruns/default/templates/testrun.yaml
+++ b/.ci/testruns/default/templates/testrun.yaml
@@ -4,8 +4,16 @@ metadata:
   generateName: tm-extension-aws-
   namespace: default
 spec:
-
   ttlSecondsAfterFinished: 172800 # 2 days
+  {{- if .Values.revision }}
+  locationSets:
+  - default: true
+    name: provider-aws
+    locations:
+    - type: git
+      repo: https://github.com/gardener/gardener-extension-provider-aws.git
+      revision: {{ .Values.revision }}
+  {{- end }}
 
   config:
   - name: ACCESS_KEY_ID

--- a/.ci/tm-config.yaml
+++ b/.ci/tm-config.yaml
@@ -1,2 +1,4 @@
-test-single:
-  testrunPath: .ci/testruns/default.yaml
+test:
+  default:
+    testrunPath: .ci/testruns/default/templates/testrun.yaml
+    template: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority normal
/platform aws

**What this PR does / why we need it**:

This PR adapts the `pipeline_definitions` to run the infrastructure integration test in the release job.
This way, the release will also be blocked by any breaking changes in the infrastructure controller/test.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @schrodit, thanks for the help!

As I wanted to reuse the testrun manifest in both PR and release test runs, I had to adapt the `tm-config.yaml`. 
With this, the test can now be triggered on a PR by commenting `/test` instead of `/test-single`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
The infrastructure integration test can now be triggered on a PR by commenting `/test` instead of `/test-single`.
```
