### PR TITLE
Remove deprecated role label key from components

### DIFF
--- a/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser.yaml
+++ b/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aws-lb-readvertiser
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
     app: aws-lb-readvertiser
 spec:
   revisionHistoryLimit: 0
@@ -16,6 +15,7 @@ spec:
     metadata:
       labels:
         garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         app: aws-lb-readvertiser
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-shoot-apiserver: allowed

--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: machine-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
     app: kubernetes
     role: machine-controller-manager
 spec:
@@ -24,6 +23,7 @@ spec:
 {{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         app: kubernetes
         role: machine-controller-manager
         networking.gardener.cloud/to-dns: allowed

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: cloud-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
     app: kubernetes
     role: cloud-controller-manager
 spec:
@@ -22,6 +21,7 @@ spec:
 {{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         app: kubernetes
         role: cloud-controller-manager
         networking.gardener.cloud/to-dns: allowed

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/service.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/service.yaml
@@ -4,7 +4,6 @@ metadata:
   name: cloud-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
     app: kubernetes
     role: cloud-controller-manager
 spec:

--- a/test/e2e/netpol-gen/app/aws.go
+++ b/test/e2e/netpol-gen/app/aws.go
@@ -38,8 +38,7 @@ func NewCloudAware() np.CloudAware {
 			Pod: np.Pod{
 				Name: "aws-lb-readvertiser",
 				Labels: labels.Set{
-					"app":                     "aws-lb-readvertiser",
-					"garden.sapcloud.io/role": "controlplane",
+					"app": "aws-lb-readvertiser",
 				},
 				SeedClusterConstraints: sets.NewString("aws"),
 			},

--- a/test/e2e/networkpolicies/networkpolicy_test.go
+++ b/test/e2e/networkpolicies/networkpolicy_test.go
@@ -138,8 +138,7 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "aws-lb-readvertiser",
 				Labels: labels.Set{
-					"app":                     "aws-lb-readvertiser",
-					"garden.sapcloud.io/role": "controlplane"},
+					"app": "aws-lb-readvertiser"},
 				ShootVersionConstraint: "",
 				SeedClusterConstraints: sets.String{
 					"aws": sets.Empty{}}},
@@ -153,8 +152,7 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "aws-lb-readvertiser",
 				Labels: labels.Set{
-					"app":                     "aws-lb-readvertiser",
-					"garden.sapcloud.io/role": "controlplane"},
+					"app": "aws-lb-readvertiser"},
 				ShootVersionConstraint: "",
 				SeedClusterConstraints: sets.String{
 					"aws": sets.Empty{}}},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal
/platform aws

**What this PR does / why we need it**:
Currently the shoot care controller of gardenlet is using the label selector `garden.sapcloud.io/role=controlplane` to health check the required controlplane components. Since longtime machine-controller-manager, cloud-controller-manager and aws-lb-readvertiser are not among the required controlplane deployments. Their health checks are now performed by the extension health check library. So we can now cleanup the `garden.sapcloud.io/role` label key to prevent unnecessary listing and computations from the gardenlet's shoot care controller.
On the other hand we need to keep the `garden.sapcloud.io/role=controlplane` label on the Pods as dependency-watchdog-endpoint component is currently using it to select Pods to restart in case the kube-apiserver is in CrashLoopBackOff and it recovers after it.

**Which issue(s) this PR fixes**:
Ref gardener/gardener#1649

**Special notes for your reviewer**:
This PR depends on:
- [x] https://github.com/gardener/gardener/pull/3241

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
