### PR TITLE
Update aws-ebs-csi-driver to v0.8.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -39,8 +39,8 @@ images:
 
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/aws-ebs-csi-driver
-  repository: amazon/aws-ebs-csi-driver
-  tag: "v0.7.0"
+  repository: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+  tag: "v0.8.0"
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: quay.io/k8scsi/csi-provisioner


### PR DESCRIPTION
/area storage
/platform aws

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The following image is updated:
- k8s.gcr.io/provider-aws/aws-ebs-csi-driver: v0.7.0 -> v0.8.0

aws-ebs-csi-driver@v0.8.0 adds support for EBS gp3 volumes. For more details, see the [CHANGELOG](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/v0.8.0/CHANGELOG-0.x.md#v080).
```
