### PR TITLE
[release-v1.19] Add in-tree volume plugin tags to CSI provisioned volumes

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-deployment.yaml
@@ -39,6 +39,7 @@ spec:
         args :
         - controller
         - --endpoint=$(CSI_ENDPOINT)
+        - --k8s-tag-cluster-id={{ .Release.Namespace }}
         - --logtostderr
         - --v=5
         env:
@@ -84,6 +85,7 @@ spec:
         - --kubeconfig=/var/lib/csi-provisioner/kubeconfig
         - --feature-gates=Topology=true
         - --volume-name-prefix=pv-{{ .Release.Namespace }}
+        - --extra-create-metadata=true
         - --enable-leader-election
         - --leader-election-type=leases
         - --leader-election-namespace=kube-system


### PR DESCRIPTION
Cherry pick of #256 on release-v1.19.

#256: Add in-tree volume plugin tags to CSI provisioned volumes

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Volumes provisioned with CSI will now have the in-tree volume plugin tags. Until now the CSI volumes had no tags at all. This is required to keep CSI plugin backwards-compatible with the in-tree volume plugin.
```
