### PR TITLE
Clean up the stale target build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,3 @@ FROM base as gardener-extension-admission-aws
 
 COPY --from=builder /go/bin/gardener-extension-admission-aws /gardener-extension-admission-aws
 ENTRYPOINT ["/gardener-extension-admission-aws"]
-
-# Duplicate {admission,validator} targets due to https://github.com/gardener/gardener-extension-provider-gcp/pull/69/files#r421264085
-############# gardener-extension-validator-aws
-FROM base AS gardener-extension-validator-aws
-
-COPY --from=builder /go/bin/gardener-extension-admission-aws /gardener-extension-admission-aws
-ENTRYPOINT ["/gardener-extension-admission-aws"]


### PR DESCRIPTION
/kind cleanup

No longer needed after the merge of https://github.com/gardener/gardener-extension-provider-aws/pull/250

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
