### PR TITLE
Fix the erroneous pipeline definition

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -37,7 +37,7 @@ gardener-extension-provider-aws:
           execute:
           - test-integration.sh
           depends:
-          - publish
+          - build_oci_image_gardener-extension-provider-aws
           image: 'eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable'
       traits:
         version:


### PR DESCRIPTION
/kind bug

It seems that the publish step is no longer valid after https://github.com/gardener/gardener-extension-provider-aws/pull/281

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
