### PR TITLE
Skip explicit LB deletion for Kubernetes >= v1.16

### DIFF
--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -322,13 +322,17 @@ func runTest(ctx context.Context, logger *logrus.Entry, c client.Client, namespa
 		},
 		Spec: extensionsv1alpha1.ClusterSpec{
 			Shoot: runtime.RawExtension{
-				Raw: encode(&gardencorev1beta1.Shoot{
+				Object: &gardencorev1beta1.Shoot{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+						Kind:       "Shoot",
+					},
 					Spec: gardencorev1beta1.ShootSpec{
 						Kubernetes: gardencorev1beta1.Kubernetes{
 							Version: "1.15.5",
 						},
 					},
-				}),
+				},
 			},
 		},
 	}

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -255,24 +254,6 @@ var _ = Describe("Infrastructure tests", func() {
 })
 
 func runTest(ctx context.Context, logger *logrus.Entry, c client.Client, namespaceName string, providerConfig *awsv1alpha1.InfrastructureConfig, decoder runtime.Decoder, awsClient *awsclient.Client) error {
-	scheme := runtime.NewScheme()
-	Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
-	codec := serializer.NewCodecFactory(scheme, serializer.EnableStrict)
-
-	info, found := runtime.SerializerInfoForMediaType(codec.SupportedMediaTypes(), runtime.ContentTypeJSON)
-	Expect(found).To(BeTrue(), "should be able to decode")
-
-	encoder := codec.EncoderForVersion(info.Serializer, gardencorev1beta1.SchemeGroupVersion)
-	encode := func(obj runtime.Object) []byte {
-		b := &bytes.Buffer{}
-		Expect(encoder.Encode(obj, b)).To(Succeed())
-
-		data, err := ioutil.ReadAll(b)
-		Expect(err).ToNot(HaveOccurred())
-
-		return data
-	}
-
 	var (
 		namespace                 *corev1.Namespace
 		cluster                   *extensionsv1alpha1.Cluster


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity robustness scalability
/kind enhancement
/priority critical
/platform aws

**What this PR does / why we need it**:
We are now skipping the explicit LB deletion when the shoot is of at least Kubernetes v1.16

See also: https://github.com/gardener/gardener/issues/129

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The load balancers and security groups are no longer explicitly deleted by the AWS provider extension when a shoot cluster of at least Kubernetes v1.16 is being deleted. Instead, it now relies on the service-controller in the `cloud-controller-manager` to properly clean up.
```
