### PR TITLE
Add controlplane label to csi-driver-controller

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-deployment.yaml
@@ -28,6 +28,8 @@ spec:
       labels:
         app: csi
         role: controller
+        garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-public-networks: allowed
         networking.gardener.cloud/to-shoot-apiserver: allowed


### PR DESCRIPTION
`csi-driver-controller` Deployment is now annotated with the controlplane labels to allow the `dependency-watchdog` to restart the csi-driver-controller when the apiserver recovers.
Ref https://github.com/gardener/gardener/blob/v1.18.0/docs/usage/seed_bootstrapping.md#endpoint

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
