### PR TITLE
Activate explicit LB/SG deletion again and improve code to reduce API calls

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -283,6 +283,10 @@ func (c *Client) ListKubernetesELBs(ctx context.Context, vpcID, clusterName stri
 		return nil, err
 	}
 
+	if len(loadBalancerNamesInVPC) == 0 {
+		return nil, nil
+	}
+
 	tags, err := c.ELB.DescribeTagsWithContext(ctx, &elb.DescribeTagsInput{LoadBalancerNames: loadBalancerNamesInVPC})
 	if err != nil {
 		return nil, err
@@ -325,6 +329,10 @@ func (c *Client) ListKubernetesELBsV2(ctx context.Context, vpcID, clusterName st
 		return !lastPage
 	}); err != nil {
 		return nil, err
+	}
+
+	if len(loadBalancerARNsInVPC) == 0 {
+		return nil, nil
 	}
 
 	tags, err := c.ELBv2.DescribeTagsWithContext(ctx, &elbv2.DescribeTagsInput{ResourceArns: loadBalancerARNsInVPC})

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -42,9 +42,9 @@ type Interface interface {
 
 	// The following functions are only temporary needed due to https://github.com/gardener/gardener/issues/129.
 	ListKubernetesELBs(ctx context.Context, vpcID, clusterName string) ([]string, error)
-	ListKubernetesELBsV2(ctx context.Context, vpcID, clusterName string) ([]LoadBalancer, error)
+	ListKubernetesELBsV2(ctx context.Context, vpcID, clusterName string) ([]string, error)
 	ListKubernetesSecurityGroups(ctx context.Context, vpcID, clusterName string) ([]string, error)
 	DeleteELB(ctx context.Context, name string) error
-	DeleteELBV2(ctx context.Context, arn *string) error
+	DeleteELBV2(ctx context.Context, arn string) error
 	DeleteSecurityGroup(ctx context.Context, id string) error
 }

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -68,14 +68,9 @@ func Delete(
 		return fmt.Errorf("error while checking whether terraform config exists: %+v", err)
 	}
 
-	credentials, err := aws.GetCredentialsFromSecretRef(ctx, c, infrastructure.Spec.SecretRef)
+	awsClient, err := aws.NewClientFromSecretRef(ctx, c, infrastructure.Spec.SecretRef, infrastructure.Spec.Region)
 	if err != nil {
-		return err
-	}
-
-	awsClient, err := awsclient.NewClient(string(credentials.AccessKeyID), string(credentials.SecretAccessKey), infrastructure.Spec.Region)
-	if err != nil {
-		return err
+		return fmt.Errorf("failed to create new AWS client: %+v", err)
 	}
 
 	var (

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -27,35 +27,15 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (a *actuator) Delete(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) error {
+func (a *actuator) Delete(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, _ *extensionscontroller.Cluster) error {
 	logger := a.logger.WithValues("infrastructure", client.ObjectKeyFromObject(infrastructure), "operation", "delete")
-
-	// Prior to Kubernetes v1.16 there was no finalizer support for `Service` objects. This is especially painful for
-	// `Service`s of type `LoadBalancer` because infrastructure artefacts are created. An deletion of the `Service`
-	// object leads to immediate disappearance from the system/cluster while the service-controller is still processing
-	// the deletion of the infrastructure artefacts in the background. Consequently, as an end-user you cannot know when
-	// the service-controller finished its work and cleaned up properly.
-	// If it didn't finish the destruction fast enough then the infrastructure deletion (trying to destroy the subnets,
-	// VPC, etc.) will fail due to the fact that there are still resources (load balancers, security groups) that we
-	// are not aware of. As a result, manual intervention is required to cleanup those artefacts to allow our infrastructure
-	// deletion to properly proceed.
-	// To mitigate this, we are explicitly deletion load balancers and security groups for Kubernetes versions lower
-	// than v1.16 (in fact, we are duplicating the logic of the service-controller here (at least parts of it)).
-	// See more details: https://github.com/kubernetes/enhancements/issues/980
-	// TODO: Remove all this code when the extension does only support clusters with at least Kubernetes v1.16.
-	needsExplicitLoadBalancerDeletion, err := versionutils.CheckVersionMeetsConstraint(cluster.Shoot.Spec.Kubernetes.Version, "< 1.16")
-	if err != nil {
-		return err
-	}
-
-	return Delete(ctx, logger, a.RESTConfig(), a.Client(), infrastructure, needsExplicitLoadBalancerDeletion)
+	return Delete(ctx, logger, a.RESTConfig(), a.Client(), infrastructure)
 }
 
 // Delete deletes the given Infrastructure.
@@ -65,7 +45,6 @@ func Delete(
 	restConfig *rest.Config,
 	c client.Client,
 	infrastructure *extensionsv1alpha1.Infrastructure,
-	needsExplicitLoadBalancerDeletion bool,
 ) error {
 	tf, err := newTerraformer(logger, restConfig, aws.TerraformerPurposeInfra, infrastructure)
 	if err != nil {
@@ -94,12 +73,9 @@ func Delete(
 		return err
 	}
 
-	var awsClient *awsclient.Client
-	if needsExplicitLoadBalancerDeletion {
-		awsClient, err = awsclient.NewClient(string(credentials.AccessKeyID), string(credentials.SecretAccessKey), infrastructure.Spec.Region)
-		if err != nil {
-			return err
-		}
+	awsClient, err := awsclient.NewClient(string(credentials.AccessKeyID), string(credentials.SecretAccessKey), infrastructure.Spec.Region)
+	if err != nil {
+		return err
 	}
 
 	var (
@@ -121,7 +97,7 @@ func Delete(
 					return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("Failed to destroy load balancers and security groups: %+v", err.Error()))
 				}
 				return nil
-			}).RetryUntilTimeout(10*time.Second, 5*time.Minute).DoIf(needsExplicitLoadBalancerDeletion && configExists),
+			}).RetryUntilTimeout(10*time.Second, 5*time.Minute).DoIf(configExists),
 		})
 
 		_ = g.Add(flow.Task{

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/common"
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
@@ -300,21 +299,6 @@ func runTest(ctx context.Context, logger *logrus.Entry, c client.Client, namespa
 	cluster = &extensionsv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespaceName,
-		},
-		Spec: extensionsv1alpha1.ClusterSpec{
-			Shoot: runtime.RawExtension{
-				Object: &gardencorev1beta1.Shoot{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
-						Kind:       "Shoot",
-					},
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.15.5",
-						},
-					},
-				},
-			},
 		},
 	}
 	if err := c.Create(ctx, cluster); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability robustness ops-productivity
/kind enhancement
/priority 3
/platform aws

**What this PR does / why we need it**:
With https://github.com/gardener/gardener-extension-provider-aws/pull/290 we had disabled the explicit deletion for clusters >= 1.16. However, we see some occasional issues with leaked LB/SG, so let's reactivate it again and improve the code to reduce the number of API calls.

**Special notes for your reviewer**:
/assign @ialidzhikov 
/invite @ialidzhikov 
/squash

Earlier, we listed all LBs and executed a `DescribeTags` call for each load balancer. Now, we first list LB and execute only one `DescribeTags` call with all the found LB names. This should significantly improve the overall number of API calls (especially, when many clusters in the same AWS account are deleted in parallel).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The load balancers and security groups are again explicitly deleted by the AWS provider extension (independent of the Kubernetes version used by the shoot cluster). The number of API calls have been reduced to the absolute minimum.
```
