### PR TITLE
Upgrade github.com/gardener/cloud-provider-aws

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -11,22 +11,22 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-aws
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
-  tag: "v1.17.15"
+  tag: "v1.17.17"
   targetVersion: "1.17.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-aws
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
-  tag: "v1.18.13"
+  tag: "v1.18.17"
   targetVersion: "1.18.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-aws
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
-  tag: "v1.19.5"
+  tag: "v1.19.9"
   targetVersion: "1.19.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-aws
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
-  tag: "v1.20.0"
+  tag: "v1.20.5"
   targetVersion: ">= 1.20"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
*Release Notes*:
``` other operator github.com/gardener/cloud-provider-aws $badfa8d6cd1e39bdf75aca3236d93178aeb2a22c
`k8s.io/legacy-cloud-providers` is now updated to `v0.17.17`.
```

``` other operator github.com/gardener/cloud-provider-aws $b9e00262f73f59bb02dffb806a495a249cd4861b
`k8s.io/legacy-cloud-providers` is now updated to `v0.18.17`.
```

``` other operator github.com/gardener/cloud-provider-aws $9f9e093baaee7ec7250a5054065d19f388df539d
`k8s.io/legacy-cloud-providers` is now updated to `v0.19.9`.
```

``` other operator github.com/gardener/cloud-provider-aws $adf069ce68d7e0ad79d62905db5ef4bf3ff442e1
`k8s.io/legacy-cloud-providers` is now updated to `v0.20.5`.
```