### PR TITLE
Revert "Upgrade terraformer #294"

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-aws
-  tag: "v2.4.0"
+  tag: "v2.3.0"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes


### PR DESCRIPTION
/kind bug

This reverts commit c57ddb75ab948788b13474d9c36d3d85137363d8.

The new version of terraformer comes with a new version of terraform-provider-aws - ref https://github.com/gardener/terraformer/pull/84. The new version of terraform-provider-aws requires permissions for `iam:ListRolePolicies` which is currently not part of our officially recommended IAM policy. So it is incompatible change:

```
* reading inline policies for IAM role shoot--foo--bar-nodes, error: AccessDenied: User: technical-user is not authorized to perform: iam:ListRolePolicies on resource: role shoot--foo--bar-nodes
	status code: 403, request id: <omitted>
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing Infrastructure reconciliation to fail because of insufficient privileges is now fixed.
```
