### PR TITLE
[release-v1.22] Automated cherry pick of #301: Revert "Upgrade terraformer #294"

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-aws
-  tag: "v2.4.0"
+  tag: "v2.3.0"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes


### PR DESCRIPTION
/kind bug

Cherry pick of #301 on release-v1.22.

#301: Revert "Upgrade terraformer #294"

```bugfix user
An issue causing Infrastructure reconciliation to fail because of insufficient privileges is now fixed.
```