### PR TITLE
Fix the infrastructure-test TestDefinition

### DIFF
--- a/.test-defs/infrastructure-test.yaml
+++ b/.test-defs/infrastructure-test.yaml
@@ -16,4 +16,4 @@ spec:
     --secret-access-key=$SECRET_ACCESS_KEY
     --region=$REGION
 
-  image: golang:1.15.3
+  image: golang:1.16.3

--- a/.test-defs/provider-aws.yaml
+++ b/.test-defs/provider-aws.yaml
@@ -18,4 +18,4 @@ spec:
     --network-worker-cidr=$NETWORK_WORKER_CIDR
     --zone=$ZONE
 
-  image: golang:1.15.3
+  image: golang:1.16.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.16.2 AS builder
+FROM golang:1.16.3 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-aws
 COPY . .


### PR DESCRIPTION
/kind bug

After https://github.com/gardener/gardener-extension-provider-aws/pull/307, the test execution fails with:

```
# github.com/gardener/gardener-extension-provider-aws/test/integration/infrastructure
vendor/github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader.go:19:2: cannot find package "." in:
	/go/src/github.com/gardener/gardener-extension-provider-aws/vendor/embed
FAIL	github.com/gardener/gardener-extension-provider-aws/test/integration/infrastructure [setup failed]
FAIL
```

The embed pkg is only present in go@1.16, so we should also update the golang version in the TestDefinition.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
