### PR TITLE
Update .ci/pipeline_definitions

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -36,8 +36,8 @@ gardener-extension-provider-aws:
         test-integration:
           execute:
           - test-integration.sh
-          depends:
-          - build_oci_image_gardener-extension-provider-aws
+          trait_depends:
+          - publish
           image: 'eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable'
       traits:
         version:


### PR DESCRIPTION
Remove the ugly workaround introduced with https://github.com/gardener/gardener-extension-provider-aws/pull/283.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
