### PR TITLE
Use VPC ID from InfrastructureConfig if possible

### DIFF
--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -99,7 +99,7 @@ func Delete(
 					stateVariables, err := tf.GetStateOutputVariables(ctx, aws.VPCIDKey)
 					if err == nil {
 						vpcID = stateVariables[aws.VPCIDKey]
-					} else if err != nil && !apierrors.IsNotFound(err) && !terraformer.IsVariablesNotFoundError(err) {
+					} else if !apierrors.IsNotFound(err) && !terraformer.IsVariablesNotFoundError(err) {
 						return err
 					}
 				}

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
 	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
 
@@ -29,13 +30,14 @@ import (
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (a *actuator) Delete(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, _ *extensionscontroller.Cluster) error {
 	logger := a.logger.WithValues("infrastructure", client.ObjectKeyFromObject(infrastructure), "operation", "delete")
-	return Delete(ctx, logger, a.RESTConfig(), a.Client(), infrastructure)
+	return Delete(ctx, logger, a.RESTConfig(), a.Client(), a.Decoder(), infrastructure)
 }
 
 // Delete deletes the given Infrastructure.
@@ -44,8 +46,14 @@ func Delete(
 	logger logr.Logger,
 	restConfig *rest.Config,
 	c client.Client,
+	decoder runtime.Decoder,
 	infrastructure *extensionsv1alpha1.Infrastructure,
 ) error {
+	infrastructureConfig := &awsapi.InfrastructureConfig{}
+	if _, _, err := decoder.Decode(infrastructure.Spec.ProviderConfig.Raw, nil, infrastructureConfig); err != nil {
+		return fmt.Errorf("could not decode provider config: %+v", err)
+	}
+
 	tf, err := newTerraformer(logger, restConfig, aws.TerraformerPurposeInfra, infrastructure)
 	if err != nil {
 		return fmt.Errorf("could not create the Terraformer: %+v", err)
@@ -79,16 +87,23 @@ func Delete(
 		destroyLoadBalancersAndSecurityGroups = g.Add(flow.Task{
 			Name: "Destroying Kubernetes load balancers and security groups",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				stateVariables, err := tf.GetStateOutputVariables(ctx, aws.VPCIDKey)
-				if err != nil {
-					if apierrors.IsNotFound(err) || terraformer.IsVariablesNotFoundError(err) {
-						logger.Info("Skipping explicit AWS load balancer and security group deletion because not all variables have been found in the Terraform state.")
-						return nil
+				var vpcID string
+				if id := infrastructureConfig.Networks.VPC.ID; id != nil {
+					vpcID = *id
+				} else {
+					stateVariables, err := tf.GetStateOutputVariables(ctx, aws.VPCIDKey)
+					if err != nil {
+						if apierrors.IsNotFound(err) || terraformer.IsVariablesNotFoundError(err) {
+							logger.Info("Skipping explicit AWS load balancer and security group deletion because not all variables have been found in the Terraform state.")
+							return nil
+						}
+						return err
 					}
-					return err
+
+					vpcID = stateVariables[aws.VPCIDKey]
 				}
 
-				if err := destroyKubernetesLoadBalancersAndSecurityGroups(ctx, awsClient, stateVariables[aws.VPCIDKey], infrastructure.Namespace); err != nil {
+				if err := destroyKubernetesLoadBalancersAndSecurityGroups(ctx, awsClient, vpcID, infrastructure.Namespace); err != nil {
 					return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("Failed to destroy load balancers and security groups: %+v", err.Error()))
 				}
 				return nil

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -270,7 +270,7 @@ func runTest(ctx context.Context, logger *logrus.Entry, c client.Client, namespa
 			c,
 			logger,
 			func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Infrastructure{} },
-			"Infrastructure",
+			extensionsv1alpha1.InfrastructureResource,
 			infra.Namespace,
 			infra.Name,
 			10*time.Second,
@@ -471,7 +471,7 @@ func prepareNewVPC(ctx context.Context, logger *logrus.Entry, awsClient *awsclie
 	vpcID := createVpcOutput.Vpc.VpcId
 
 	if err := wait.PollUntil(5*time.Second, func() (bool, error) {
-		entry.Infof("Waiting until vpc '%s' is avaiable...", *vpcID)
+		entry.Infof("Waiting until vpc '%s' is available...", *vpcID)
 
 		describeVpcOutput, err := awsClient.EC2.DescribeVpcs(&ec2.DescribeVpcsInput{
 			VpcIds: []*string{vpcID},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/platform aws

**What this PR does / why we need it**:
Today, the explicit LB/SG deletion relies on the Terraform output variable for the VPC ID. However, in case an existing VPC is used (`.networks.vpc.id != nil`), during `terraform destroy`, the first successfully deleted resource by Terraform removes this output variable and never puts it back. If the destruction now fails and the deletion flow is re-invocated, the explicit LG/SG deletion is skipped and never executed again.

With this PR, we no longer rely on the Terraform output variable if `.networks.vpc.id != nil`. Hence, the explicit LB/SG deletion will be properly retried for each invocation as long as the Terraform job did not succeed. This helps to destroy LB/SG resources which were created after the first invocation.

**Special notes for your reviewer**:
/invite @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
When deleting an `Infrastructure`, the explicit load balancer and security group deletion is now properly retried in case an existing VPC is used.
```
