### PR TITLE
Adapt the IAM policy for terraformer-provider-aws >= 3.29.1

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -61,6 +61,7 @@ Please make sure that the provided credentials have the correct privileges. You 
           "iam:GetRole",
           "iam:GetRolePolicy",
           "iam:ListPolicyVersions",
+          "iam:ListRolePolicies",
           "iam:ListAttachedRolePolicies",
           "iam:ListInstanceProfilesForRole",
           "iam:CreateInstanceProfile",


### PR DESCRIPTION
/platform aws

Part of https://github.com/gardener/gardener-extension-provider-aws/issues/319

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The recommended AWS IAM policy does now contain additional permission (action) `iam:ListRolePolicies`. The addition of the new permission is a preparation for an upcoming breaking change that will require this permission (action) to be present. For more details, see the corresponding announcement [Upcoming change to AWS IAM policy](https://groups.google.com/g/gardener/c/sIwiQp6ak_4/m/y2mUd3_lAAAJ).
```
