### PR TITLE
[GEP-15] fix wrong base64 encoding for bastion instance userdata

### DIFF
--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -16,6 +16,7 @@ package bastion
 
 import (
 	"context"
+	"encoding/base64"
 	"net"
 	"time"
 
@@ -274,7 +275,7 @@ func ensureBastionInstance(ctx context.Context, logger logr.Logger, bastion *ext
 	input := &ec2.RunInstancesInput{
 		ImageId:      aws.String(opt.ImageID),
 		InstanceType: aws.String(opt.InstanceType),
-		UserData:     aws.String(string(bastion.Spec.UserData)),
+		UserData:     aws.String(base64.StdEncoding.EncodeToString(bastion.Spec.UserData)),
 		MinCount:     aws.Int64(1),
 		MaxCount:     aws.Int64(1),
 		TagSpecifications: []*ec2.TagSpecification{

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -16,7 +16,6 @@ package bastion_test
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -437,7 +436,7 @@ func newBastion(namespace string) (*extensionsv1alpha1.Bastion, error) {
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type: aws.Type,
 			},
-			UserData: []byte(base64.StdEncoding.EncodeToString([]byte("echo hello world"))),
+			UserData: []byte("echo hello world"),
 			Ingress: []extensionsv1alpha1.BastionIngressPolicy{{
 				IPBlock: networkingv1.IPBlock{
 					CIDR: cidrv4,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/platform aws

**What this PR does / why we need it**:
The testcase wasn't representing what is actually stored in the Bastion. `[]byte` is already stored as base64.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
