### PR TITLE
[release-v1.24] Automated cherry pick of #339: [ci:component:github.com/gardener/machine-controller-manager-provider-aws:v0.5.0->v0.7.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -40,7 +40,7 @@ images:
 - name: machine-controller-manager-provider-aws
   sourceRepository: github.com/gardener/machine-controller-manager-provider-aws
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-aws
-  tag: "v0.5.0"
+  tag: "v0.7.0"
 - name: aws-lb-readvertiser
   sourceRepository: github.com/gardener/aws-lb-readvertiser
   repository: eu.gcr.io/gardener-project/gardener/aws-lb-readvertiser


### PR DESCRIPTION
Cherry pick of #339 on release-v1.24.

#339: [ci:component:github.com/gardener/machine-controller-manager-provider-aws:v0.6.0->v0.7.0]

**Special notes for reviewer**
This bumps MCM by 2 versions, however, the previous version only contained a minor change and should not affect this. Refer https://github.com/gardener/gardener-extension-provider-aws/pull/331. 


**Release Notes:**
``` other dependency github.com/gardener/machine-controller-manager-provider-aws #35 @prashanth26
Revendors MCM dependent libraries for `v0.39.0` version.
```