### PR TITLE
Update the admission-aws RBAC after cloud provider Secrets validation feature

### DIFF
--- a/charts/gardener-extension-admission-aws/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-aws/charts/application/templates/rbac.yaml
@@ -9,10 +9,19 @@ rules:
 - apiGroups:
   - core.gardener.cloud
   resources:
+  - shoots
   - cloudprofiles
+  - secretbindings
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
/kind bug

Currently admission-aws fails to start with:

```
E0526 11:58:45.881288       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:137: Failed to watch *v1beta1.SecretBinding: failed to list *v1beta1.SecretBinding: secretbindings.core.gardener.cloud is forbidden: User "system:serviceaccount:garden:gardener-extension-admission-aws" cannot list resource "secretbindings" in API group "core.gardener.cloud" at the cluster scope
```

Follow-up after https://github.com/gardener/gardener-extension-provider-aws/pull/336

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
