### PR TITLE
Reduce the verbosity of csi-driver-node logs

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -77,4 +77,4 @@ images:
 - name: csi-liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: k8s.gcr.io/sig-storage/livenessprobe
-  tag: "v2.2.0"
+  tag: "v2.3.0"

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
         - --volume-attach-limit={{ .Values.driver.volumeAttachLimit }}
         {{- end }}
         - --logtostderr
-        - --v=5
+        - --v=3
         env:
         - name: CSI_ENDPOINT
           value: unix:{{ .Values.socketPath }}


### PR DESCRIPTION
/kind enhancement

Similar to https://github.com/gardener/gardener-extension-provider-openstack/pull/287 and https://github.com/gardener/gardener-extension-provider-openstack/pull/288.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The following image is updated (see [CHANGELOG](https://github.com/kubernetes-csi/livenessprobe/blob/v2.3.0/CHANGELOG/CHANGELOG-2.3.md) for more details):
- k8s.gcr.io/sig-storage/livenessprobe: v2.2.0 -> v2.3.0
```
