### PR TITLE
Enhance validation of cloud provider secrets

### DIFF
--- a/pkg/apis/aws/validation/secrets.go
+++ b/pkg/apis/aws/validation/secrets.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
 	corev1 "k8s.io/api/core/v1"
@@ -27,30 +28,42 @@ const (
 	secretAccessKeyMinLen = 40
 )
 
+var (
+	accessKeyRegex       = regexp.MustCompile(`^\w+$`)
+	secretAccessKeyRegex = regexp.MustCompile(`^[A-Za-z0-9/+=]+$`)
+)
+
 // ValidateCloudProviderSecret checks whether the given secret contains a valid AWS access keys.
 func ValidateCloudProviderSecret(secret *corev1.Secret) error {
 	secretRef := fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)
 
+	// accessKeyID must have length between 16 and 128 and only contain alphanumeric characters,
+	// see https://docs.aws.amazon.com/IAM/latest/APIReference/API_AccessKey.html
 	accessKeyID, ok := secret.Data[aws.AccessKeyID]
 	if !ok {
 		return fmt.Errorf("missing %q field in secret %s", aws.AccessKeyID, secretRef)
 	}
-
 	if len(accessKeyID) < accessKeyMinLen {
 		return fmt.Errorf("field %q in secret %s must have at least %d characters", aws.AccessKeyID, secretRef, accessKeyMinLen)
 	}
-
 	if len(accessKeyID) > accessKeyMaxLen {
 		return fmt.Errorf("field %q in secret %s cannot be longer than %d characters", aws.AccessKeyID, secretRef, accessKeyMaxLen)
 	}
+	if !accessKeyRegex.Match(accessKeyID) {
+		return fmt.Errorf("field %q in secret %s must only contain alphanumeric characters", aws.AccessKeyID, secretRef)
+	}
 
+	// secretAccessKey must have a minimum length of 40 and only contain base64 characters,
+	// see https://docs.aws.amazon.com/IAM/latest/APIReference/API_AccessKey.html and https://aws.amazon.com/blogs/security/a-safer-way-to-distribute-aws-credentials-to-ec2/
 	secretAccessKey, ok := secret.Data[aws.SecretAccessKey]
 	if !ok {
 		return fmt.Errorf("missing %q field in secret %s", aws.SecretAccessKey, secretRef)
 	}
-
 	if len(secretAccessKey) < secretAccessKeyMinLen {
 		return fmt.Errorf("field %q in secret %s must have at least %d characters", aws.SecretAccessKey, secretRef, secretAccessKeyMinLen)
+	}
+	if !secretAccessKeyRegex.Match(secretAccessKey) {
+		return fmt.Errorf("field %q in secret %s must only contain base64 characters", aws.SecretAccessKey, secretRef)
 	}
 
 	return nil

--- a/pkg/apis/aws/validation/secrets_test.go
+++ b/pkg/apis/aws/validation/secrets_test.go
@@ -70,6 +70,14 @@ var _ = Describe("Secret validation", func() {
 			HaveOccurred(),
 		),
 
+		Entry("should return error when the access key does not contain only alphanumeric characters",
+			map[string][]byte{
+				aws.AccessKeyID:     []byte(strings.Repeat("a", 20) + " "),
+				aws.SecretAccessKey: []byte(strings.Repeat("b", 40)),
+			},
+			HaveOccurred(),
+		),
+
 		Entry("should return error when the secret access key field is missing",
 			map[string][]byte{
 				aws.AccessKeyID: []byte(strings.Repeat("a", 16)),
@@ -89,6 +97,14 @@ var _ = Describe("Secret validation", func() {
 			map[string][]byte{
 				aws.AccessKeyID:     []byte(strings.Repeat("a", 16)),
 				aws.SecretAccessKey: []byte(strings.Repeat("b", 39)),
+			},
+			HaveOccurred(),
+		),
+
+		Entry("should return error when the secret access key does not contain only base64 characters",
+			map[string][]byte{
+				aws.AccessKeyID:     []byte(strings.Repeat("a", 16)),
+				aws.SecretAccessKey: []byte(strings.Repeat("b", 40) + " "),
 			},
 			HaveOccurred(),
 		),


### PR DESCRIPTION
**How to categorize this PR?**

/area usability
/area ops-productivity
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Enhances the validation of AWS cloud provider secrets:
* `accessKeyID` must only contain alphanumeric characters, see https://docs.aws.amazon.com/IAM/latest/APIReference/API_AccessKey.html
* `secretAccessKey` must only contain base64 characters, see https://aws.amazon.com/blogs/security/a-safer-way-to-distribute-aws-credentials-to-ec2/

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The above AWS security blog is not authoritative documentation. On the other hand, all `secretAccessKeys` we have seen so far do indeed contain only base64 characters. I think the proposed validation will in practice always match valid keys while it will also reject values that have e.g. leading or trailing whitespace or other non-base64 characters due e.g. copy / paste mistakes.

**Release note**:

```other operator
Validation of AWS cloud provider secrets is enhanced to reject `accessKeyID` that does not only contain alphanumeric characters, and `secretAccessKey` that does not only contain base64 characters.
```
