### PR TITLE
Enable to overwrite the Kubernetes version for CSI migration on Shoot level

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/frankban/quicktest v1.9.0 // indirect
 	github.com/gardener/etcd-druid v0.5.0
-	github.com/gardener/gardener v1.24.1-0.20210608063816-580010846480
+	github.com/gardener/gardener v1.24.1-0.20210611132013-a6aa5c0904a9
 	github.com/gardener/machine-controller-manager v0.36.0
 	github.com/go-logr/logr v0.3.0
 	github.com/golang/mock v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/gardener/gardener v1.3.1/go.mod h1:936P5tQbg6ViiW8BVC9ELM95sFrk4DgobK
 github.com/gardener/gardener v1.4.1-0.20200519155656-a8ccc6cc779a/go.mod h1:t9oESM37bAMIuezi9I0H0I8+++8jy8BUPitcf4ERRXY=
 github.com/gardener/gardener v1.11.3/go.mod h1:5DzqfOm+G8UftKu5zUbYJ+9Cnfd4XrvRNDabkM9AIp4=
 github.com/gardener/gardener v1.17.1/go.mod h1:uucRHq0xV46xd9MpJJjRswx/Slq3+ipbbJg09FVUtvM=
-github.com/gardener/gardener v1.24.1-0.20210608063816-580010846480 h1:wlZAGqkN7rr2sJM1BbhKxJ6F2G9YLXU8xtoPbxEUa4E=
-github.com/gardener/gardener v1.24.1-0.20210608063816-580010846480/go.mod h1:Ka66bCr/+tUwkf2Ov4JDMEEvdeeGtHsCfUqw46k7w5A=
+github.com/gardener/gardener v1.24.1-0.20210611132013-a6aa5c0904a9 h1:qG+if4P9kIRsvCFg0nRGoDSYumYD0JT167/lhz5Mqwk=
+github.com/gardener/gardener v1.24.1-0.20210611132013-a6aa5c0904a9/go.mod h1:Ka66bCr/+tUwkf2Ov4JDMEEvdeeGtHsCfUqw46k7w5A=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/gardener-resource-manager v0.13.1/go.mod h1:0No/XttYRUwDn5lSppq9EqlKdo/XJQ44aCZz5BVu3Vw=
 github.com/gardener/gardener-resource-manager v0.18.0 h1:bNB0yKhSqe8DnsvIp3xZr9nsFB4fm+AUAqj1EoIvWU8=

--- a/pkg/aws/csimigration.go
+++ b/pkg/aws/csimigration.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+// CSIMigrationKubernetesVersion is a constant for the Kubernetes version for which the Shoot's CSI migration will be
+// performed.
+const CSIMigrationKubernetesVersion = "1.18"
+
+// GetCSIMigrationKubernetesVersion returns the Kubernetes version for which CSI migration will be performed.
+func GetCSIMigrationKubernetesVersion(cluster *extensionscontroller.Cluster) string {
+	if cluster == nil || cluster.Shoot == nil {
+		return CSIMigrationKubernetesVersion
+	}
+
+	if val, ok := cluster.Shoot.Annotations[extensionsv1alpha1.ShootAlphaCSIMigrationKubernetesVersion]; ok {
+		return val
+	}
+
+	return CSIMigrationKubernetesVersion
+}

--- a/pkg/aws/csimigration_test.go
+++ b/pkg/aws/csimigration_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws_test
+
+import (
+	. "github.com/gardener/gardener-extension-provider-aws/pkg/aws"
+
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("CSIMigration", func() {
+	DescribeTable("#GetCSIMigrationKubernetesVersion",
+		func(cluster *extensionscontroller.Cluster, expectedVersion string) {
+			Expect(GetCSIMigrationKubernetesVersion(cluster)).To(Equal(expectedVersion))
+		},
+
+		Entry("cluster nil", nil, "1.18"),
+		Entry("shoot nil", &extensionscontroller.Cluster{}, "1.18"),
+		Entry("shoot w/o annotation", &extensionscontroller.Cluster{Shoot: &gardencorev1beta1.Shoot{}}, "1.18"),
+		Entry("shoot w/ annotation", &extensionscontroller.Cluster{Shoot: &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"alpha.csimigration.shoot.extensions.gardener.cloud/kubernetes-version": "1.24"}}}}, "1.24"),
+	)
+})

--- a/pkg/controller/csimigration/add.go
+++ b/pkg/controller/csimigration/add.go
@@ -36,7 +36,7 @@ type AddOptions struct {
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return csimigration.Add(mgr, csimigration.AddArgs{
 		ControllerOptions:             opts.Controller,
-		CSIMigrationKubernetesVersion: "1.18",
+		CSIMigrationKubernetesVersion: aws.CSIMigrationKubernetesVersion,
 		Type:                          aws.Type,
 		StorageClassNameToLegacyProvisioner: map[string]string{
 			"default": "kubernetes.io/aws-ebs",

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -48,7 +48,7 @@ var (
 // HealthChecks are grouped by extension (e.g worker), extension.type (e.g aws) and  Health Check Type (e.g SystemComponentsHealthy)
 func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) error {
 	csiEnabledPreCheckFunc := func(_ client.Object, cluster *extensionscontroller.Cluster) bool {
-		csiEnabled, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", "1.18")
+		csiEnabled, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", aws.GetCSIMigrationKubernetesVersion(cluster))
 		if err != nil {
 			return false
 		}

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -38,8 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const csiMigrationVersion = "1.18"
-
 // NewEnsurer creates a new controlplane ensurer.
 func NewEnsurer(logger logr.Logger) genericmutator.Ensurer {
 	return &ensurer{
@@ -81,7 +79,7 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx gconte
 		return err
 	}
 
-	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, aws.GetCSIMigrationKubernetesVersion(cluster))
 	if err != nil {
 		return err
 	}
@@ -110,7 +108,7 @@ func (e *ensurer) EnsureKubeControllerManagerDeployment(ctx context.Context, gct
 		return err
 	}
 
-	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, aws.GetCSIMigrationKubernetesVersion(cluster))
 	if err != nil {
 		return err
 	}
@@ -140,7 +138,7 @@ func (e *ensurer) EnsureKubeSchedulerDeployment(ctx context.Context, gctx gconte
 		return err
 	}
 
-	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, aws.GetCSIMigrationKubernetesVersion(cluster))
 	if err != nil {
 		return err
 	}
@@ -395,7 +393,7 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx gcon
 		return nil, err
 	}
 
-	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, aws.GetCSIMigrationKubernetesVersion(cluster))
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +430,7 @@ func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, gctx gcontext.
 		return err
 	}
 
-	csiEnabled, err := versionutils.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", csiMigrationVersion)
+	csiEnabled, err := versionutils.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", aws.GetCSIMigrationKubernetesVersion(cluster))
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/gardener/gardener/charts/images.yaml
+++ b/vendor/github.com/gardener/gardener/charts/images.yaml
@@ -75,7 +75,7 @@ images:
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
-  tag: "v0.16.1"
+  tag: "v0.16.2"
   targetVersion: ">= 1.16"
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
@@ -212,7 +212,7 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/fluent/fluent-bit
   repository: fluent/fluent-bit
-  tag: "1.7.3"
+  tag: "1.7.8"
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/csimigration/controller.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/csimigration/controller.go
@@ -70,7 +70,7 @@ func Add(mgr manager.Manager, args AddArgs) error {
 		decoder           = extensionscontroller.NewGardenDecoder()
 		defaultPredicates = []predicate.Predicate{
 			extensionspredicate.ClusterShootProviderType(decoder, args.Type),
-			extensionspredicate.ClusterShootKubernetesVersionAtLeast(decoder, args.CSIMigrationKubernetesVersion),
+			extensionspredicate.ClusterShootKubernetesVersionForCSIMigrationAtLeast(decoder, args.CSIMigrationKubernetesVersion),
 			ClusterCSIMigrationControllerNotFinished(),
 		}
 	)

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/healthcheck/general/managed_resource.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/healthcheck/general/managed_resource.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gardener/gardener/extensions/pkg/controller/healthcheck"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
 	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
@@ -81,6 +82,7 @@ func (healthChecker *ManagedResourceHealthChecker) Check(ctx context.Context, re
 		return &healthcheck.SingleCheckResult{
 			Status: gardencorev1beta1.ConditionFalse,
 			Detail: err.Error(),
+			Codes:  gardencorev1beta1helper.DetermineErrorCodes(err),
 		}, nil
 	}
 

--- a/vendor/github.com/gardener/gardener/extensions/pkg/predicate/predicate.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/predicate/predicate.go
@@ -256,8 +256,8 @@ func GardenCoreProviderType(providerType string) predicate.Predicate {
 	}
 }
 
-// ClusterShootKubernetesVersionAtLeast is a predicate for the kubernetes version of the shoot in the cluster resource.
-func ClusterShootKubernetesVersionAtLeast(decoder runtime.Decoder, kubernetesVersion string) predicate.Predicate {
+// ClusterShootKubernetesVersionForCSIMigrationAtLeast is a predicate for the kubernetes version of the shoot in the cluster resource.
+func ClusterShootKubernetesVersionForCSIMigrationAtLeast(decoder runtime.Decoder, kubernetesVersion string) predicate.Predicate {
 	f := func(obj client.Object) bool {
 		if obj == nil {
 			return false
@@ -273,7 +273,12 @@ func ClusterShootKubernetesVersionAtLeast(decoder runtime.Decoder, kubernetesVer
 			return false
 		}
 
-		constraint, err := version.CompareVersions(shoot.Spec.Kubernetes.Version, ">=", kubernetesVersion)
+		kubernetesVersionForCSIMigration := kubernetesVersion
+		if overwrite, ok := shoot.Annotations[extensionsv1alpha1.ShootAlphaCSIMigrationKubernetesVersion]; ok {
+			kubernetesVersionForCSIMigration = overwrite
+		}
+
+		constraint, err := version.CompareVersions(shoot.Spec.Kubernetes.Version, ">=", kubernetesVersionForCSIMigration)
 		if err != nil {
 			return false
 		}

--- a/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/config.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/config.go
@@ -63,6 +63,12 @@ func (t *terraformer) SetDeadlinePod(d time.Duration) Terraformer {
 	return t
 }
 
+// SetDeadlinePodCreation configures the deadline while waiting for the creation of the Terraformer apply/destroy pod.
+func (t *terraformer) SetDeadlinePodCreation(d time.Duration) Terraformer {
+	t.deadlinePodCreation = d
+	return t
+}
+
 // SetOwnerRef configures the resource that will be used as owner of the secrets and configmaps
 func (t *terraformer) SetOwnerRef(owner *metav1.OwnerReference) Terraformer {
 	t.ownerRef = owner

--- a/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/terraformer.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/terraformer.go
@@ -121,8 +121,9 @@ func New(
 		logLevel:                      "info",
 		terminationGracePeriodSeconds: int64(3600),
 
-		deadlineCleaning: 20 * time.Minute,
-		deadlinePod:      20 * time.Minute,
+		deadlineCleaning:    20 * time.Minute,
+		deadlinePod:         20 * time.Minute,
+		deadlinePodCreation: 5 * time.Minute,
 	}
 }
 
@@ -243,12 +244,13 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 		}
 
 		// Wait for the Terraform apply/destroy Pod to be completed
-		exitCode, terminationMessage := t.waitForPod(ctx, logger, pod, t.deadlinePod)
-		succeeded := exitCode == 0
-		if succeeded {
+		status, terminationMessage := t.waitForPod(ctx, logger, pod)
+		if status == podStatusSucceeded {
 			podLogger.Info("Terraformer pod finished successfully")
+		} else if status == podStatusCreationTimeout {
+			podLogger.Info("Terraformer pod creation timed out")
 		} else {
-			podLogger.Info("Terraformer pod finished with error", "exitCode", exitCode)
+			podLogger.Info("Terraformer pod finished with error")
 
 			if terminationMessage != "" {
 				podLogger.V(1).Info("Termination message of Terraformer pod: " + terminationMessage)
@@ -269,7 +271,7 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 			return err
 		}
 
-		if !succeeded {
+		if status != podStatusSucceeded {
 			errorMessage := fmt.Sprintf("Terraform execution for command '%s' could not be completed", command)
 			if terraformErrors := findTerraformErrors(terminationMessage); terraformErrors != "" {
 				errorMessage += fmt.Sprintf(":\n\n%s", terraformErrors)

--- a/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/types.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/types.go
@@ -70,8 +70,9 @@ type terraformer struct {
 	logLevel                      string
 	terminationGracePeriodSeconds int64
 
-	deadlineCleaning time.Duration
-	deadlinePod      time.Duration
+	deadlineCleaning    time.Duration
+	deadlinePod         time.Duration
+	deadlinePodCreation time.Duration
 }
 
 // RawState represent the terraformer state's raw data
@@ -107,6 +108,7 @@ type Terraformer interface {
 	SetTerminationGracePeriodSeconds(int64) Terraformer
 	SetDeadlineCleaning(time.Duration) Terraformer
 	SetDeadlinePod(time.Duration) Terraformer
+	SetDeadlinePodCreation(time.Duration) Terraformer
 	SetOwnerRef(*metav1.OwnerReference) Terraformer
 	InitializeWith(ctx context.Context, initializer Initializer) Terraformer
 	Apply(ctx context.Context) error

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -216,7 +216,7 @@ const (
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.
 	ShootAlphaScalingAPIServerClass = "alpha.kube-apiserver.scaling.shoot.gardener.cloud/class"
-	// ShootAlphaControlPlaneScaleDownDisabled is a constant for an annotation on the Shoot resource staiting that the
+	// ShootAlphaControlPlaneScaleDownDisabled is a constant for an annotation on the Shoot resource stating that the
 	// automatic scale-down shall be disabled for the etcd, kube-apiserver, kube-controller-manager.
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/errors.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/errors.go
@@ -51,17 +51,20 @@ func (e *ErrorWithCodes) Error() string {
 
 var (
 	unauthorizedRegexp                  = regexp.MustCompile(`(?i)(Unauthorized|InvalidClientTokenId|InvalidAuthenticationTokenTenant|SignatureDoesNotMatch|Authentication failed|AuthFailure|AuthorizationFailed|invalid character|invalid_grant|invalid_client|Authorization Profile was not found|cannot fetch token|no active subscriptions|InvalidAccessKeyId|InvalidSecretAccessKey|query returned no results|UnauthorizedOperation|not authorized|InvalidSubscriptionId)`)
-	quotaExceededRegexp                 = regexp.MustCompile(`(?i)(LimitExceeded|Quotas)`)
+	quotaExceededRegexp                 = regexp.MustCompile(`(?i)(LimitExceeded|Quotas|Quota exceeded|exceeded quota|Quota has been met)`)
 	rateLimitsExceededRegexp            = regexp.MustCompile(`(?i)(Throttling|Too many requests)`)
 	insufficientPrivilegesRegexp        = regexp.MustCompile(`(?i)(AccessDenied|OperationNotAllowed|Error 403)`)
 	dependenciesRegexp                  = regexp.MustCompile(`(?i)(PendingVerification|Access Not Configured|accessNotConfigured|DependencyViolation|OptInRequired|DeleteConflict|Conflict|inactive billing state|ReadOnlyDisabledSubscription|is already being used|InUseSubnetCannotBeDeleted|VnetInUse|InUseRouteTableCannotBeDeleted|timeout while waiting for state to become|InvalidCidrBlock|already busy for|InsufficientFreeAddressesInSubnet|InternalServerError|internalerror|internal server error|A resource with the ID|VnetAddressSpaceCannotChangeDueToPeerings|InternalBillingError)`)
 	retryableDependenciesRegexp         = regexp.MustCompile(`(?i)(RetryableError)`)
 	resourcesDepletedRegexp             = regexp.MustCompile(`(?i)(not available in the current hardware cluster|InsufficientInstanceCapacity|SkuNotAvailable|ZonalAllocationFailed|out of stock)`)
-	configurationProblemRegexp          = regexp.MustCompile(`(?i)(AzureBastionSubnet|not supported in your requested Availability Zone|InvalidParameter|InvalidParameterValue|notFound|NetcfgInvalidSubnet|InvalidSubnet|Invalid value|KubeletHasInsufficientMemory|KubeletHasDiskPressure|KubeletHasInsufficientPID|violates constraint|no attached internet gateway found|Your query returned no results|PrivateEndpointNetworkPoliciesCannotBeEnabledOnPrivateEndpointSubnet|invalid VPC attributes|PrivateLinkServiceNetworkPoliciesCannotBeEnabledOnPrivateLinkServiceSubnet|unrecognized feature gate|runtime-config invalid key|LoadBalancingRuleMustDisableSNATSinceSameFrontendIPConfigurationIsReferencedByOutboundRule|strict decoder error|not allowed to configure an unsupported)`)
+	configurationProblemRegexp          = regexp.MustCompile(`(?i)(AzureBastionSubnet|not supported in your requested Availability Zone|InvalidParameter|InvalidParameterValue|notFound|NetcfgInvalidSubnet|InvalidSubnet|Invalid value|KubeletHasInsufficientMemory|KubeletHasDiskPressure|KubeletHasInsufficientPID|violates constraint|no attached internet gateway found|Your query returned no results|PrivateEndpointNetworkPoliciesCannotBeEnabledOnPrivateEndpointSubnet|invalid VPC attributes|PrivateLinkServiceNetworkPoliciesCannotBeEnabledOnPrivateLinkServiceSubnet|unrecognized feature gate|runtime-config invalid key|LoadBalancingRuleMustDisableSNATSinceSameFrontendIPConfigurationIsReferencedByOutboundRule|strict decoder error|not allowed to configure an unsupported|error during apply of object .* is invalid:)`)
 	retryableConfigurationProblemRegexp = regexp.MustCompile(`(?i)(is misconfigured and requires zero voluntary evictions)`)
 )
 
 // DetermineError determines the Garden error code for the given error and creates a new error with the given message.
+// TODO(timebertt): this is should be improved: clean up the usages to not pass the error twice (once as an error and
+// once as a string) and properly wrap the given error instead of creating a new one from the given error message,
+// so we can use errors.As up the call stack.
 func DetermineError(err error, message string) error {
 	if err == nil {
 		return errors.New(message)

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/validation/cloudprofile.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/validation/cloudprofile.go
@@ -339,8 +339,8 @@ func validateContainerRuntimesInterfaces(cris []core.CRI, fldPath *field.Path) f
 		}
 		duplicateCRI.Insert(string(cri.Name))
 
-		if !avaliableWorkerCRINames.Has(string(cri.Name)) {
-			allErrs = append(allErrs, field.NotSupported(criPath, cri, avaliableWorkerCRINames.List()))
+		if !availableWorkerCRINames.Has(string(cri.Name)) {
+			allErrs = append(allErrs, field.NotSupported(criPath, cri, availableWorkerCRINames.List()))
 		}
 		allErrs = append(allErrs, validateContainerRuntimes(cri.ContainerRuntimes, criPath.Child("containerRuntimes"))...)
 	}

--- a/vendor/github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/types.go
@@ -91,3 +91,9 @@ var ExtensionKinds = sets.NewString(
 	OperatingSystemConfigResource,
 	WorkerResource,
 )
+
+// ShootAlphaCSIMigrationKubernetesVersion is a constant for an annotation on the Shoot resource stating the Kubernetes
+// version for which the CSI migration shall be enabled.
+// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
+// what you do.
+const ShootAlphaCSIMigrationKubernetesVersion = "alpha.csimigration.shoot.extensions.gardener.cloud/kubernetes-version"

--- a/vendor/github.com/gardener/gardener/pkg/extensions/customresources.go
+++ b/vendor/github.com/gardener/gardener/pkg/extensions/customresources.go
@@ -20,24 +20,25 @@ import (
 	"fmt"
 	"time"
 
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/flow"
-	gutil "github.com/gardener/gardener/pkg/utils/gardener"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
-	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/sirupsen/logrus"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	unstructuredutils "github.com/gardener/gardener/pkg/utils/kubernetes/unstructured"
+	"github.com/gardener/gardener/pkg/utils/retry"
 )
 
 // TimeNow returns the current time. Exposed for testing.
@@ -57,24 +58,11 @@ func WaitUntilExtensionObjectReady(
 	timeout time.Duration,
 	postReadyFunc func() error,
 ) error {
-	var healthFuncs []health.Func
-
-	// If the extension object has been reconciled successfully before we triggered a new reconciliation and our cache
-	// is not updated fast enough with our reconciliation trigger (i.e. adding the reconcile annotation), we might
-	// falsy return early from waiting for the extension object to be ready (as the last state already was "ready").
-	// Use the timestamp annotation on the object as an ensurance, that once we see it in our cache, we are observing
-	// a version of the object that is fresh enough.
-	if expectedTimestamp, ok := obj.GetAnnotations()[v1beta1constants.GardenerTimestamp]; ok {
-		healthFuncs = append(healthFuncs, health.ObjectHasAnnotationWithValue(v1beta1constants.GardenerTimestamp, expectedTimestamp))
-	}
-
-	healthFuncs = append(healthFuncs, health.CheckExtensionObject)
-
 	return WaitUntilObjectReadyWithHealthFunction(
 		ctx,
 		c,
 		logger,
-		health.And(healthFuncs...),
+		health.CheckExtensionObject,
 		obj,
 		kind,
 		interval,
@@ -109,6 +97,15 @@ func WaitUntilObjectReadyWithHealthFunction(
 		namespace = obj.GetNamespace()
 	)
 
+	// If the object has been reconciled successfully before we triggered a new reconciliation and our cache
+	// is not updated fast enough with our reconciliation trigger (i.e. adding the reconcile annotation), we might
+	// falsy return early from waiting for the object to be ready (as the last state already was "ready").
+	// Use the timestamp annotation on the object as an ensurance, that once we see it in our cache, we are observing
+	// a version of the object that is fresh enough.
+	if expectedTimestamp, ok := obj.GetAnnotations()[v1beta1constants.GardenerTimestamp]; ok {
+		healthFunc = health.And(health.ObjectHasAnnotationWithValue(v1beta1constants.GardenerTimestamp, expectedTimestamp), healthFunc)
+	}
+
 	resetObj, err := kutil.CreateResetObjectFunc(obj, c.Scheme())
 	if err != nil {
 		return err
@@ -118,7 +115,9 @@ func WaitUntilObjectReadyWithHealthFunction(
 		retryCountUntilSevere++
 
 		resetObj()
-		if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj); err != nil {
+		obj.SetName(name)
+		obj.SetNamespace(namespace)
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 			if apierrors.IsNotFound(err) {
 				return retry.MinorError(err)
 			}
@@ -144,9 +143,9 @@ func WaitUntilObjectReadyWithHealthFunction(
 	}); err != nil {
 		message := fmt.Sprintf("Error while waiting for %s to become ready", extensionKey(kind, namespace, name))
 		if lastObservedError != nil {
-			return gardencorev1beta1helper.NewErrorWithCodes(formatErrorMessage(message, lastObservedError.Error()), gardencorev1beta1helper.ExtractErrorCodes(lastObservedError)...)
+			return fmt.Errorf("%s: %w", message, lastObservedError)
 		}
-		return errors.New(formatErrorMessage(message, err.Error()))
+		return fmt.Errorf("%s: %w", message, err)
 	}
 
 	return nil
@@ -269,7 +268,9 @@ func WaitUntilExtensionObjectDeleted(
 
 	if err := retry.UntilTimeout(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
 		resetObj()
-		if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj); err != nil {
+		obj.SetName(name)
+		obj.SetNamespace(namespace)
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 			if apierrors.IsNotFound(err) {
 				return retry.Ok()
 			}
@@ -289,9 +290,9 @@ func WaitUntilExtensionObjectDeleted(
 	}); err != nil {
 		message := fmt.Sprintf("Failed to delete %s", extensionKey(kind, namespace, name))
 		if lastObservedError != nil {
-			return gardencorev1beta1helper.NewErrorWithCodes(formatErrorMessage(message, lastObservedError.Error()), gardencorev1beta1helper.ExtractErrorCodes(lastObservedError)...)
+			return fmt.Errorf("%s: %w", message, lastObservedError)
 		}
-		return errors.New(formatErrorMessage(message, err.Error()))
+		return fmt.Errorf("%s: %w", message, err)
 	}
 
 	return nil
@@ -355,7 +356,7 @@ func RestoreExtensionObjectState(
 				if err != nil {
 					return err
 				}
-				if err := utils.CreateOrUpdateObjectByRef(ctx, c, &resourceRef, extensionObj.GetNamespace(), obj); err != nil {
+				if err := unstructuredutils.CreateOrPatchObjectByRef(ctx, c, &resourceRef, extensionObj.GetNamespace(), obj); err != nil {
 					return err
 				}
 			}
@@ -414,7 +415,9 @@ func WaitUntilExtensionObjectMigrated(
 
 	return retry.UntilTimeout(ctx, interval, timeout, func(ctx context.Context) (done bool, err error) {
 		resetObj()
-		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj); err != nil {
+		obj.SetName(name)
+		obj.SetNamespace(namespace)
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 			if client.IgnoreNotFound(err) == nil {
 				return retry.Ok()
 			}
@@ -508,8 +511,4 @@ func applyFuncToExtensionObjects(
 
 func extensionKey(kind, namespace, name string) string {
 	return fmt.Sprintf("%s %s/%s", kind, namespace, name)
-}
-
-func formatErrorMessage(message, description string) string {
-	return fmt.Sprintf("%s: %s", message, description)
 }

--- a/vendor/github.com/gardener/gardener/pkg/operation/common/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/common/types.go
@@ -152,4 +152,7 @@ const (
 	// MonitoringIngressCredentialsUsers is a constant for the name of a secret containing the monitoring credentials
 	// for users monitoring for shoots.
 	MonitoringIngressCredentialsUsers = "monitoring-ingress-credentials-users"
+
+	// NodeLocalIPVSAddress is the IPv4 address used by node local dns when IPVS is used.
+	NodeLocalIPVSAddress = "169.254.20.10"
 )

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/health/health.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/health/health.go
@@ -38,9 +38,7 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/retry"
 )
 
 func requiredConditionMissing(conditionType string) error {
@@ -372,19 +370,28 @@ func ExtensionOperationHasBeenUpdatedSince(lastUpdateTime metav1.Time) Func {
 	}
 }
 
-// CheckBackupBucket checks if an backup bucket Object is healthy or not.
-func CheckBackupBucket(bb client.Object) error {
-	obj, ok := bb.(*gardencorev1beta1.BackupBucket)
+// CheckBackupBucket checks if an backup bucket object is healthy or not.
+func CheckBackupBucket(obj client.Object) error {
+	bb, ok := obj.(*gardencorev1beta1.BackupBucket)
 	if !ok {
-		return fmt.Errorf("expected gardencorev1beta1.BackupBucket but got %T", bb)
+		return fmt.Errorf("expected *gardencorev1beta1.BackupBucket but got %T", obj)
 	}
-	return checkExtensionObject(obj.Generation, obj.Status.ObservedGeneration, obj.Annotations, obj.Status.LastError, obj.Status.LastOperation)
+	return checkExtensionObject(bb.Generation, bb.Status.ObservedGeneration, bb.Annotations, bb.Status.LastError, bb.Status.LastOperation)
+}
+
+// CheckBackupEntry checks if an backup entry object is healthy or not.
+func CheckBackupEntry(obj client.Object) error {
+	be, ok := obj.(*gardencorev1beta1.BackupEntry)
+	if !ok {
+		return fmt.Errorf("expected *gardencorev1beta1.BackupEntry but got %T", obj)
+	}
+	return checkExtensionObject(be.Generation, be.Status.ObservedGeneration, be.Annotations, be.Status.LastError, be.Status.LastOperation)
 }
 
 // checkExtensionObject checks if an extension Object is healthy or not.
 func checkExtensionObject(generation int64, observedGeneration int64, annotations map[string]string, lastError *gardencorev1beta1.LastError, lastOperation *gardencorev1beta1.LastOperation) error {
 	if lastError != nil {
-		return gardencorev1beta1helper.NewErrorWithCodes(fmt.Sprintf("extension encountered error during reconciliation: %s", lastError.Description), lastError.Codes...)
+		return gardencorev1beta1helper.NewErrorWithCodes(fmt.Sprintf("error during reconciliation: %s", lastError.Description), lastError.Codes...)
 	}
 
 	if observedGeneration != generation {
@@ -479,33 +486,4 @@ func getManagedResourceCondition(conditions []resourcesv1alpha1.ManagedResourceC
 		}
 	}
 	return nil
-}
-
-// CheckTunnelConnection checks if the tunnel connection between the control plane and the shoot networks
-// is established.
-func CheckTunnelConnection(ctx context.Context, shootClient kubernetes.Interface, logger logrus.FieldLogger, tunnelName string) (bool, error) {
-	podList := &corev1.PodList{}
-	if err := shootClient.Client().List(ctx, podList, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"app": tunnelName}); err != nil {
-		return retry.SevereError(err)
-	}
-
-	var tunnelPod *corev1.Pod
-	for _, pod := range podList.Items {
-		if pod.Status.Phase == corev1.PodRunning {
-			tunnelPod = &pod
-			break
-		}
-	}
-
-	if tunnelPod == nil {
-		logger.Infof("Waiting until a running %s pod exists in the Shoot cluster...", tunnelName)
-		return retry.MinorError(fmt.Errorf("no running %s pod found yet in the shoot cluster", tunnelName))
-	}
-	if err := shootClient.CheckForwardPodPort(tunnelPod.Namespace, tunnelPod.Name, 0, 22); err != nil {
-		logger.Info("Waiting until the tunnel connection has been established...")
-		return retry.MinorError(fmt.Errorf("could not forward to %s pod: %v", tunnelName, err))
-	}
-
-	logger.Info("Tunnel connection has been established.")
-	return retry.Ok()
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -114,7 +114,7 @@ github.com/gardener/etcd-druid/api/v1alpha1
 # github.com/gardener/external-dns-management v0.7.18
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
-# github.com/gardener/gardener v1.24.1-0.20210608063816-580010846480
+# github.com/gardener/gardener v1.24.1-0.20210611132013-a6aa5c0904a9
 ## explicit
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE
@@ -267,6 +267,7 @@ github.com/gardener/gardener/pkg/utils/imagevector
 github.com/gardener/gardener/pkg/utils/infodata
 github.com/gardener/gardener/pkg/utils/kubernetes
 github.com/gardener/gardener/pkg/utils/kubernetes/health
+github.com/gardener/gardener/pkg/utils/kubernetes/unstructured
 github.com/gardener/gardener/pkg/utils/managedresources
 github.com/gardener/gardener/pkg/utils/retry
 github.com/gardener/gardener/pkg/utils/secrets


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR adds support for overwriting the Kubernetes version for which CSI migration shall be performed on `Shoot` level.

⚠️ This feature is to be considered alpha/experimental and usage is on your own risk.

**Special notes for your reviewer**:
/squash
✅ Depends on gardener/gardener#4202

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Support for overwriting the CSI migration version was added.
```
