### PR TITLE
[release-v1.25] Automated cherry pick of #354: Enable to overwrite the Kubernetes version for CSI migration on Shoot level

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/frankban/quicktest v1.9.0 // indirect
 	github.com/gardener/etcd-druid v0.5.0
-	github.com/gardener/gardener v1.23.1
+	github.com/gardener/gardener v1.23.3
 	github.com/gardener/machine-controller-manager v0.36.0
 	github.com/go-logr/logr v0.3.0
 	github.com/golang/mock v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/gardener/gardener v1.3.1/go.mod h1:936P5tQbg6ViiW8BVC9ELM95sFrk4DgobK
 github.com/gardener/gardener v1.4.1-0.20200519155656-a8ccc6cc779a/go.mod h1:t9oESM37bAMIuezi9I0H0I8+++8jy8BUPitcf4ERRXY=
 github.com/gardener/gardener v1.11.3/go.mod h1:5DzqfOm+G8UftKu5zUbYJ+9Cnfd4XrvRNDabkM9AIp4=
 github.com/gardener/gardener v1.17.1/go.mod h1:uucRHq0xV46xd9MpJJjRswx/Slq3+ipbbJg09FVUtvM=
-github.com/gardener/gardener v1.23.1 h1:vLMW0VaqhiRwKvQ+c2uPpyk7Ddk+mZ5xcnL6TvNgOYE=
-github.com/gardener/gardener v1.23.1/go.mod h1:xS/sYyzYsq2W0C79mT98G/qoOTvy/hHTfApHIVF3v2o=
+github.com/gardener/gardener v1.23.3 h1:OmnrQmLbxuBJ2ateoyj/aWtDFD9Cpn76nV99N6lWHwE=
+github.com/gardener/gardener v1.23.3/go.mod h1:xS/sYyzYsq2W0C79mT98G/qoOTvy/hHTfApHIVF3v2o=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/gardener-resource-manager v0.13.1/go.mod h1:0No/XttYRUwDn5lSppq9EqlKdo/XJQ44aCZz5BVu3Vw=
 github.com/gardener/gardener-resource-manager v0.18.0 h1:bNB0yKhSqe8DnsvIp3xZr9nsFB4fm+AUAqj1EoIvWU8=

--- a/pkg/aws/csimigration.go
+++ b/pkg/aws/csimigration.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+// CSIMigrationKubernetesVersion is a constant for the Kubernetes version for which the Shoot's CSI migration will be
+// performed.
+const CSIMigrationKubernetesVersion = "1.18"
+
+// GetCSIMigrationKubernetesVersion returns the Kubernetes version for which CSI migration will be performed.
+func GetCSIMigrationKubernetesVersion(cluster *extensionscontroller.Cluster) string {
+	if cluster == nil || cluster.Shoot == nil {
+		return CSIMigrationKubernetesVersion
+	}
+
+	if val, ok := cluster.Shoot.Annotations[extensionsv1alpha1.ShootAlphaCSIMigrationKubernetesVersion]; ok {
+		return val
+	}
+
+	return CSIMigrationKubernetesVersion
+}

--- a/pkg/aws/csimigration_test.go
+++ b/pkg/aws/csimigration_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws_test
+
+import (
+	. "github.com/gardener/gardener-extension-provider-aws/pkg/aws"
+
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("CSIMigration", func() {
+	DescribeTable("#GetCSIMigrationKubernetesVersion",
+		func(cluster *extensionscontroller.Cluster, expectedVersion string) {
+			Expect(GetCSIMigrationKubernetesVersion(cluster)).To(Equal(expectedVersion))
+		},
+
+		Entry("cluster nil", nil, "1.18"),
+		Entry("shoot nil", &extensionscontroller.Cluster{}, "1.18"),
+		Entry("shoot w/o annotation", &extensionscontroller.Cluster{Shoot: &gardencorev1beta1.Shoot{}}, "1.18"),
+		Entry("shoot w/ annotation", &extensionscontroller.Cluster{Shoot: &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"alpha.csimigration.shoot.extensions.gardener.cloud/kubernetes-version": "1.24"}}}}, "1.24"),
+	)
+})

--- a/pkg/controller/csimigration/add.go
+++ b/pkg/controller/csimigration/add.go
@@ -36,7 +36,7 @@ type AddOptions struct {
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return csimigration.Add(mgr, csimigration.AddArgs{
 		ControllerOptions:             opts.Controller,
-		CSIMigrationKubernetesVersion: "1.18",
+		CSIMigrationKubernetesVersion: aws.CSIMigrationKubernetesVersion,
 		Type:                          aws.Type,
 		StorageClassNameToLegacyProvisioner: map[string]string{
 			"default": "kubernetes.io/aws-ebs",

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -48,7 +48,7 @@ var (
 // HealthChecks are grouped by extension (e.g worker), extension.type (e.g aws) and  Health Check Type (e.g SystemComponentsHealthy)
 func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) error {
 	csiEnabledPreCheckFunc := func(_ client.Object, cluster *extensionscontroller.Cluster) bool {
-		csiEnabled, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", "1.18")
+		csiEnabled, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", aws.GetCSIMigrationKubernetesVersion(cluster))
 		if err != nil {
 			return false
 		}

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -38,8 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const csiMigrationVersion = "1.18"
-
 // NewEnsurer creates a new controlplane ensurer.
 func NewEnsurer(logger logr.Logger) genericmutator.Ensurer {
 	return &ensurer{
@@ -81,7 +79,7 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx gconte
 		return err
 	}
 
-	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, aws.GetCSIMigrationKubernetesVersion(cluster))
 	if err != nil {
 		return err
 	}
@@ -110,7 +108,7 @@ func (e *ensurer) EnsureKubeControllerManagerDeployment(ctx context.Context, gct
 		return err
 	}
 
-	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, aws.GetCSIMigrationKubernetesVersion(cluster))
 	if err != nil {
 		return err
 	}
@@ -140,7 +138,7 @@ func (e *ensurer) EnsureKubeSchedulerDeployment(ctx context.Context, gctx gconte
 		return err
 	}
 
-	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, aws.GetCSIMigrationKubernetesVersion(cluster))
 	if err != nil {
 		return err
 	}
@@ -395,7 +393,7 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx gcon
 		return nil, err
 	}
 
-	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, aws.GetCSIMigrationKubernetesVersion(cluster))
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +430,7 @@ func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, gctx gcontext.
 		return err
 	}
 
-	csiEnabled, err := versionutils.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", csiMigrationVersion)
+	csiEnabled, err := versionutils.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", aws.GetCSIMigrationKubernetesVersion(cluster))
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/gardener/gardener/charts/images.yaml
+++ b/vendor/github.com/gardener/gardener/charts/images.yaml
@@ -20,7 +20,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.5.1"
+  tag: "v0.5.2"
 - name: gardener-resource-manager
   sourceRepository: github.com/gardener/gardener-resource-manager
   repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/csimigration/controller.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/csimigration/controller.go
@@ -70,7 +70,7 @@ func Add(mgr manager.Manager, args AddArgs) error {
 		decoder           = extensionscontroller.NewGardenDecoder()
 		defaultPredicates = []predicate.Predicate{
 			extensionspredicate.ClusterShootProviderType(decoder, args.Type),
-			extensionspredicate.ClusterShootKubernetesVersionAtLeast(decoder, args.CSIMigrationKubernetesVersion),
+			extensionspredicate.ClusterShootKubernetesVersionForCSIMigrationAtLeast(decoder, args.CSIMigrationKubernetesVersion),
 			ClusterCSIMigrationControllerNotFinished(),
 		}
 	)

--- a/vendor/github.com/gardener/gardener/extensions/pkg/predicate/predicate.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/predicate/predicate.go
@@ -256,8 +256,8 @@ func GardenCoreProviderType(providerType string) predicate.Predicate {
 	}
 }
 
-// ClusterShootKubernetesVersionAtLeast is a predicate for the kubernetes version of the shoot in the cluster resource.
-func ClusterShootKubernetesVersionAtLeast(decoder runtime.Decoder, kubernetesVersion string) predicate.Predicate {
+// ClusterShootKubernetesVersionForCSIMigrationAtLeast is a predicate for the kubernetes version of the shoot in the cluster resource.
+func ClusterShootKubernetesVersionForCSIMigrationAtLeast(decoder runtime.Decoder, kubernetesVersion string) predicate.Predicate {
 	f := func(obj client.Object) bool {
 		if obj == nil {
 			return false
@@ -273,7 +273,12 @@ func ClusterShootKubernetesVersionAtLeast(decoder runtime.Decoder, kubernetesVer
 			return false
 		}
 
-		constraint, err := version.CompareVersions(shoot.Spec.Kubernetes.Version, ">=", kubernetesVersion)
+		kubernetesVersionForCSIMigration := kubernetesVersion
+		if overwrite, ok := shoot.Annotations[extensionsv1alpha1.ShootAlphaCSIMigrationKubernetesVersion]; ok {
+			kubernetesVersionForCSIMigration = overwrite
+		}
+
+		constraint, err := version.CompareVersions(shoot.Spec.Kubernetes.Version, ">=", kubernetesVersionForCSIMigration)
 		if err != nil {
 			return false
 		}

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -212,7 +212,7 @@ const (
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.
 	ShootAlphaScalingAPIServerClass = "alpha.kube-apiserver.scaling.shoot.gardener.cloud/class"
-	// ShootAlphaControlPlaneScaleDownDisabled is a constant for an annotation on the Shoot resource staiting that the
+	// ShootAlphaControlPlaneScaleDownDisabled is a constant for an annotation on the Shoot resource stating that the
 	// automatic scale-down shall be disabled for the etcd, kube-apiserver, kube-controller-manager.
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/errors.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/errors.go
@@ -51,7 +51,7 @@ func (e *ErrorWithCodes) Error() string {
 
 var (
 	unauthorizedRegexp                  = regexp.MustCompile(`(?i)(Unauthorized|InvalidClientTokenId|InvalidAuthenticationTokenTenant|SignatureDoesNotMatch|Authentication failed|AuthFailure|AuthorizationFailed|invalid character|invalid_grant|invalid_client|Authorization Profile was not found|cannot fetch token|no active subscriptions|InvalidAccessKeyId|InvalidSecretAccessKey|query returned no results|UnauthorizedOperation|not authorized|InvalidSubscriptionId)`)
-	quotaExceededRegexp                 = regexp.MustCompile(`(?i)(LimitExceeded|Quotas)`)
+	quotaExceededRegexp                 = regexp.MustCompile(`(?i)(LimitExceeded|Quotas|Quota exceeded|exceeded quota|Quota has been met)`)
 	rateLimitsExceededRegexp            = regexp.MustCompile(`(?i)(Throttling|Too many requests)`)
 	insufficientPrivilegesRegexp        = regexp.MustCompile(`(?i)(AccessDenied|OperationNotAllowed|Error 403)`)
 	dependenciesRegexp                  = regexp.MustCompile(`(?i)(PendingVerification|Access Not Configured|accessNotConfigured|DependencyViolation|OptInRequired|DeleteConflict|Conflict|inactive billing state|ReadOnlyDisabledSubscription|is already being used|InUseSubnetCannotBeDeleted|VnetInUse|InUseRouteTableCannotBeDeleted|timeout while waiting for state to become|InvalidCidrBlock|already busy for|InsufficientFreeAddressesInSubnet|InternalServerError|Future#WaitForCompletion: context has been cancelled|internalerror|internal server error|A resource with the ID|VnetAddressSpaceCannotChangeDueToPeerings|InternalBillingError)`)

--- a/vendor/github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/types.go
@@ -91,3 +91,9 @@ var ExtensionKinds = sets.NewString(
 	OperatingSystemConfigResource,
 	WorkerResource,
 )
+
+// ShootAlphaCSIMigrationKubernetesVersion is a constant for an annotation on the Shoot resource stating the Kubernetes
+// version for which the CSI migration shall be enabled.
+// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
+// what you do.
+const ShootAlphaCSIMigrationKubernetesVersion = "alpha.csimigration.shoot.extensions.gardener.cloud/kubernetes-version"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -114,7 +114,7 @@ github.com/gardener/etcd-druid/api/v1alpha1
 # github.com/gardener/external-dns-management v0.7.18
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
-# github.com/gardener/gardener v1.23.1
+# github.com/gardener/gardener v1.23.3
 ## explicit
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE


### PR DESCRIPTION
/area/storage
/kind/enhancement

Cherry pick of #354 on release-v1.25.

#354: Enable to overwrite the Kubernetes version for CSI migration on Shoot level

**Release Notes:**
```other operator
Support for overwriting the CSI migration version was added.
```