### PR TITLE
upgrade csi snapshotter to v3.0.3

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -61,7 +61,7 @@ images:
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/csi-snapshotter
-  tag: "v2.1.5"
+  tag: "v3.0.3"
 - name: csi-resizer
   sourceRepository: github.com/kubernetes-csi/external-resizer
   repository: k8s.gcr.io/sig-storage/csi-resizer
@@ -69,7 +69,7 @@ images:
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/snapshot-controller
-  tag: "v2.1.5"
+  tag: "v3.0.3"
 - name: csi-node-driver-registrar
   sourceRepository: github.com/kubernetes-csi/node-driver-registrar
   repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar


### PR DESCRIPTION
**How to categorize this PR?**
/area storage
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Upgrade csi snapshotter (external-snapshotter controller) to v3 to acquire bug fixes and improvements.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-csi/external-snapshotter/issues/349
The fix is available in v3 of external-snapshotter controller.

**Release note**:
```other developer
Upgrade CSI Snapshotter controller to from v2.1.5 to v3.0.3
```
