### PR TITLE
Setting CSI AWS topology label on machine deployment creation to allow scale-up

### DIFF
--- a/pkg/controller/worker/helper.go
+++ b/pkg/controller/worker/helper.go
@@ -28,10 +28,6 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
-const (
-	awsCSIDriverTopologyKey = "topology.ebs.csi.aws.com/zone"
-)
-
 func (w *workerDelegate) decodeWorkerProviderStatus() (*api.WorkerStatus, error) {
 	workerStatus := &api.WorkerStatus{}
 
@@ -62,22 +58,4 @@ func (w *workerDelegate) updateWorkerProviderStatus(ctx context.Context, workerS
 		w.worker.Status.ProviderStatus = &runtime.RawExtension{Object: workerStatusV1alpha1}
 		return nil
 	})
-}
-
-func makeCopyOfMap(mp map[string]string) map[string]string {
-	var mpDeepCopy = make(map[string]string)
-	for k, v := range mp {
-		mpDeepCopy[k] = v
-	}
-	return mpDeepCopy
-}
-
-func addAwsCsiDriverTopologyLabel(poolLabels map[string]string, zone string) map[string]string {
-	if _, exists := poolLabels[AwsCsiDriverTopologyKey]; !exists {
-		var poolLabelsDeepCopy = makeCopyOfMap(poolLabels)
-		poolLabelsDeepCopy[AwsCsiDriverTopologyKey] = zone
-		return poolLabelsDeepCopy
-	}
-
-	return poolLabels
 }

--- a/pkg/controller/worker/helper.go
+++ b/pkg/controller/worker/helper.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	AwsCsiDriverTopologyKey = "topology.ebs.csi.aws.com/zone"
+	awsCSIDriverTopologyKey = "topology.ebs.csi.aws.com/zone"
 )
 
 func (w *workerDelegate) decodeWorkerProviderStatus() (*api.WorkerStatus, error) {

--- a/pkg/controller/worker/helper.go
+++ b/pkg/controller/worker/helper.go
@@ -28,6 +28,10 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
+const (
+	AwsCsiDriverTopologyKey = "topology.ebs.csi.aws.com/zone"
+)
+
 func (w *workerDelegate) decodeWorkerProviderStatus() (*api.WorkerStatus, error) {
 	workerStatus := &api.WorkerStatus{}
 
@@ -58,4 +62,22 @@ func (w *workerDelegate) updateWorkerProviderStatus(ctx context.Context, workerS
 		w.worker.Status.ProviderStatus = &runtime.RawExtension{Object: workerStatusV1alpha1}
 		return nil
 	})
+}
+
+func makeCopyOfMap(mp map[string]string) map[string]string {
+	var mpDeepCopy = make(map[string]string)
+	for k, v := range mp {
+		mpDeepCopy[k] = v
+	}
+	return mpDeepCopy
+}
+
+func addAwsCsiDriverTopologyLabel(poolLabels map[string]string, zone string) map[string]string {
+	if _, exists := poolLabels[AwsCsiDriverTopologyKey]; !exists {
+		var poolLabelsDeepCopy = makeCopyOfMap(poolLabels)
+		poolLabelsDeepCopy[AwsCsiDriverTopologyKey] = zone
+		return poolLabelsDeepCopy
+	}
+
+	return poolLabels
 }

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -186,12 +186,12 @@ func (w *workerDelegate) generateMachineConfig() error {
 				Maximum:        worker.DistributeOverZones(zoneIdx, pool.Maximum, zoneLen),
 				MaxSurge:       worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxSurge, zoneLen, pool.Maximum),
 				MaxUnavailable: worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxUnavailable, zoneLen, pool.Minimum),
-				// TODO: remove when AWS CSI driver stops using the aws csi topology key - https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/899
-				// add aws csi driver topology label if its not specified
 				Labels: func() map[string]string {
 					if !csiEnabled {
 						return pool.Labels
 					}
+					// TODO: remove the csi topology label when AWS CSI driver stops using the aws csi topology key - https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/899
+					// add aws csi driver topology label if its not specified
 					return utils.MergeStringMaps(pool.Labels, map[string]string{awsCSIDriverTopologyKey: zone})
 				}(),
 				Annotations:          pool.Annotations,

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -24,6 +24,7 @@ import (
 	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	awsapihelper "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
+
 	"github.com/gardener/gardener/extensions/pkg/controller/csimigration"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	genericworkeractuator "github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -173,14 +173,16 @@ func (w *workerDelegate) generateMachineConfig() error {
 			)
 
 			machineDeployments = append(machineDeployments, worker.MachineDeployment{
-				Name:                 deploymentName,
-				ClassName:            className,
-				SecretName:           className,
-				Minimum:              worker.DistributeOverZones(zoneIdx, pool.Minimum, zoneLen),
-				Maximum:              worker.DistributeOverZones(zoneIdx, pool.Maximum, zoneLen),
-				MaxSurge:             worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxSurge, zoneLen, pool.Maximum),
-				MaxUnavailable:       worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxUnavailable, zoneLen, pool.Minimum),
-				Labels:               pool.Labels,
+				Name:           deploymentName,
+				ClassName:      className,
+				SecretName:     className,
+				Minimum:        worker.DistributeOverZones(zoneIdx, pool.Minimum, zoneLen),
+				Maximum:        worker.DistributeOverZones(zoneIdx, pool.Maximum, zoneLen),
+				MaxSurge:       worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxSurge, zoneLen, pool.Maximum),
+				MaxUnavailable: worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxUnavailable, zoneLen, pool.Minimum),
+				// TODO: remove when AWS CSI driver stops using the aws csi topology key - https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/899
+				// add aws csi driver topology label if its not specified
+				Labels:               addAwsCsiDriverTopologyLabel(pool.Labels, zone),
 				Annotations:          pool.Annotations,
 				Taints:               pool.Taints,
 				MachineConfiguration: genericworkeractuator.ReadMachineConfiguration(pool),

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -179,23 +179,26 @@ func (w *workerDelegate) generateMachineConfig() error {
 			)
 
 			machineDeployments = append(machineDeployments, worker.MachineDeployment{
-				Name:                 deploymentName,
-				ClassName:            className,
-				SecretName:           className,
-				Minimum:              worker.DistributeOverZones(zoneIdx, pool.Minimum, zoneLen),
-				Maximum:              worker.DistributeOverZones(zoneIdx, pool.Maximum, zoneLen),
-				MaxSurge:             worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxSurge, zoneLen, pool.Maximum),
-				MaxUnavailable:       worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxUnavailable, zoneLen, pool.Minimum),
-				Labels:               pool.Labels,
+				Name:           deploymentName,
+				ClassName:      className,
+				SecretName:     className,
+				Minimum:        worker.DistributeOverZones(zoneIdx, pool.Minimum, zoneLen),
+				Maximum:        worker.DistributeOverZones(zoneIdx, pool.Maximum, zoneLen),
+				MaxSurge:       worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxSurge, zoneLen, pool.Maximum),
+				MaxUnavailable: worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxUnavailable, zoneLen, pool.Minimum),
+				// TODO: remove when AWS CSI driver stops using the aws csi topology key - https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/899
+				// add aws csi driver topology label if its not specified
+				Labels: func() map[string]string {
+					if !csiEnabled {
+						return pool.Labels
+					}
+					return utils.MergeStringMaps(pool.Labels, map[string]string{awsCSIDriverTopologyKey: zone})
+				}(),
 				Annotations:          pool.Annotations,
 				Taints:               pool.Taints,
 				MachineConfiguration: genericworkeractuator.ReadMachineConfiguration(pool),
 			})
-			// TODO: remove when AWS CSI driver stops using the aws csi topology key - https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/899
-			// add aws csi driver topology label if its not specified
-			if csiEnabled {
-				machineDeployments[len(machineDeployments)-1].Labels = utils.MergeStringMaps(pool.Labels, map[string]string{awsCSIDriverTopologyKey: zone})
-			}
+
 			machineClassSpec["name"] = className
 			machineClassSpec["labels"] = map[string]string{corev1.LabelZoneFailureDomain: zone}
 			machineClassSpec["secret"].(map[string]interface{})["labels"] = map[string]string{v1beta1constants.GardenerPurpose: genericworkeractuator.GardenPurposeMachineClass}

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -141,9 +141,7 @@ var _ = Describe("Machines", func() {
 				zone1       string
 				zone2       string
 
-				labels                               map[string]string
-				labelsWithAwsCsiDriverTopologyLabel1 map[string]string
-				labelsWithAwsCsiDriverTopologyLabel2 map[string]string
+				labels map[string]string
 
 				machineConfiguration *machinev1alpha1.MachineConfiguration
 
@@ -211,8 +209,6 @@ var _ = Describe("Machines", func() {
 				zone2 = region + "b"
 
 				labels = map[string]string{"component": "TiDB"}
-				labelsWithAwsCsiDriverTopologyLabel1 = makeCopyOfMap(labels)
-				labelsWithAwsCsiDriverTopologyLabel2 = makeCopyOfMap(labels)
 
 				machineConfiguration = &machinev1alpha1.MachineConfiguration{}
 
@@ -537,9 +533,6 @@ var _ = Describe("Machines", func() {
 						machineClassPool2Zone2,
 					}}
 
-					labelsWithAwsCsiDriverTopologyLabel1[AwsCsiDriverTopologyKey] = zone1
-					labelsWithAwsCsiDriverTopologyLabel2[AwsCsiDriverTopologyKey] = zone2
-
 					machineDeployments = worker.MachineDeployments{
 						{
 							Name:                 machineClassNamePool1Zone1,
@@ -549,7 +542,7 @@ var _ = Describe("Machines", func() {
 							Maximum:              worker.DistributeOverZones(0, maxPool1, 2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(0, maxSurgePool1, 2, maxPool1),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(0, maxUnavailablePool1, 2, minPool1),
-							Labels:               labelsWithAwsCsiDriverTopologyLabel1,
+							Labels:               labels,
 							MachineConfiguration: machineConfiguration,
 						},
 						{
@@ -560,7 +553,7 @@ var _ = Describe("Machines", func() {
 							Maximum:              worker.DistributeOverZones(1, maxPool1, 2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(1, maxSurgePool1, 2, maxPool1),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(1, maxUnavailablePool1, 2, minPool1),
-							Labels:               labelsWithAwsCsiDriverTopologyLabel2,
+							Labels:               labels,
 							MachineConfiguration: machineConfiguration,
 						},
 						{
@@ -571,7 +564,7 @@ var _ = Describe("Machines", func() {
 							Maximum:              worker.DistributeOverZones(0, maxPool2, 2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(0, maxSurgePool2, 2, maxPool2),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(0, maxUnavailablePool2, 2, minPool2),
-							Labels:               labelsWithAwsCsiDriverTopologyLabel1,
+							Labels:               labels,
 							MachineConfiguration: machineConfiguration,
 						},
 						{
@@ -582,7 +575,7 @@ var _ = Describe("Machines", func() {
 							Maximum:              worker.DistributeOverZones(1, maxPool2, 2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(1, maxSurgePool2, 2, maxPool2),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(1, maxUnavailablePool2, 2, minPool2),
-							Labels:               labelsWithAwsCsiDriverTopologyLabel2,
+							Labels:               labels,
 							MachineConfiguration: machineConfiguration,
 						},
 					}
@@ -917,12 +910,4 @@ func addNameAndSecretToMachineClass(class map[string]interface{}, name string, c
 		"namespace": credentialsSecretRef.Namespace,
 	}
 	class["secret"].(map[string]interface{})["labels"] = map[string]string{v1beta1constants.GardenerPurpose: genericworkeractuator.GardenPurposeMachineClass}
-}
-
-func makeCopyOfMap(mp map[string]string) map[string]string {
-	var mpDeepCopy = make(map[string]string)
-	for k, v := range mp {
-		mpDeepCopy[k] = v
-	}
-	return mpDeepCopy
 }

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -141,7 +141,9 @@ var _ = Describe("Machines", func() {
 				zone1       string
 				zone2       string
 
-				labels map[string]string
+				labels                               map[string]string
+				labelsWithAwsCsiDriverTopologyLabel1 map[string]string
+				labelsWithAwsCsiDriverTopologyLabel2 map[string]string
 
 				machineConfiguration *machinev1alpha1.MachineConfiguration
 
@@ -209,6 +211,8 @@ var _ = Describe("Machines", func() {
 				zone2 = region + "b"
 
 				labels = map[string]string{"component": "TiDB"}
+				labelsWithAwsCsiDriverTopologyLabel1 = makeCopyOfMap(labels)
+				labelsWithAwsCsiDriverTopologyLabel2 = makeCopyOfMap(labels)
 
 				machineConfiguration = &machinev1alpha1.MachineConfiguration{}
 
@@ -533,6 +537,9 @@ var _ = Describe("Machines", func() {
 						machineClassPool2Zone2,
 					}}
 
+					labelsWithAwsCsiDriverTopologyLabel1[AwsCsiDriverTopologyKey] = zone1
+					labelsWithAwsCsiDriverTopologyLabel2[AwsCsiDriverTopologyKey] = zone2
+
 					machineDeployments = worker.MachineDeployments{
 						{
 							Name:                 machineClassNamePool1Zone1,
@@ -542,7 +549,7 @@ var _ = Describe("Machines", func() {
 							Maximum:              worker.DistributeOverZones(0, maxPool1, 2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(0, maxSurgePool1, 2, maxPool1),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(0, maxUnavailablePool1, 2, minPool1),
-							Labels:               labels,
+							Labels:               labelsWithAwsCsiDriverTopologyLabel1,
 							MachineConfiguration: machineConfiguration,
 						},
 						{
@@ -553,7 +560,7 @@ var _ = Describe("Machines", func() {
 							Maximum:              worker.DistributeOverZones(1, maxPool1, 2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(1, maxSurgePool1, 2, maxPool1),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(1, maxUnavailablePool1, 2, minPool1),
-							Labels:               labels,
+							Labels:               labelsWithAwsCsiDriverTopologyLabel2,
 							MachineConfiguration: machineConfiguration,
 						},
 						{
@@ -564,7 +571,7 @@ var _ = Describe("Machines", func() {
 							Maximum:              worker.DistributeOverZones(0, maxPool2, 2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(0, maxSurgePool2, 2, maxPool2),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(0, maxUnavailablePool2, 2, minPool2),
-							Labels:               labels,
+							Labels:               labelsWithAwsCsiDriverTopologyLabel1,
 							MachineConfiguration: machineConfiguration,
 						},
 						{
@@ -575,7 +582,7 @@ var _ = Describe("Machines", func() {
 							Maximum:              worker.DistributeOverZones(1, maxPool2, 2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(1, maxSurgePool2, 2, maxPool2),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(1, maxUnavailablePool2, 2, minPool2),
-							Labels:               labels,
+							Labels:               labelsWithAwsCsiDriverTopologyLabel2,
 							MachineConfiguration: machineConfiguration,
 						},
 					}
@@ -910,4 +917,12 @@ func addNameAndSecretToMachineClass(class map[string]interface{}, name string, c
 		"namespace": credentialsSecretRef.Namespace,
 	}
 	class["secret"].(map[string]interface{})["labels"] = map[string]string{v1beta1constants.GardenerPurpose: genericworkeractuator.GardenPurposeMachineClass}
+}
+
+func makeCopyOfMap(mp map[string]string) map[string]string {
+	var mpDeepCopy = make(map[string]string)
+	for k, v := range mp {
+		mpDeepCopy[k] = v
+	}
+	return mpDeepCopy
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform aws

**What this PR does / why we need it**:
adds driver specific CSI label `topology.ebs.csi.aws.com/zone` during machineDeployment creation 
**Which issue(s) this PR fixes**:
Fixes #364 

**Special notes for your reviewer**:
also made changes to unit test written for machineDeployment generation by adding relevant variables
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
AWS CSI driver specific topology label  "topology.ebs.csi.aws.com/zone" is set as a label on machine deployments to allow the proper working of cluster-autoscaler during scale-up. 
```
