### PR TITLE
Set minAllowed memory for csi-driver-node containers

### DIFF
--- a/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser-vpa.yaml
+++ b/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser-vpa.yaml
@@ -4,6 +4,11 @@ metadata:
   name: aws-lb-readvertiser-vpa
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        memory: 20Mi
   targetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
@@ -5,6 +5,11 @@ metadata:
   name: csi-driver-node
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        memory: 25Mi
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet


### PR DESCRIPTION
/area testing
/area storage
/kind bug
/platform aws

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/70

Currently we observe flakes in the `guestbook app` test that are related to the csi-driver-node component. We see that the corresponding Pod fails to start:

```
time="2021-07-05T10:09:22Z" level=info msg="Pod csi-driver-node-mg8l4 is Pending on Node ip-10-250-10-76.eu-west-1.compute.internal"
```

The reason is 

```
time="2021-07-05T10:09:22Z" level=info msg="At 2021-07-05 09:34:10 +0000 UTC - event for csi-driver-node-mg8l4: {kubelet ip-10-250-10-76.eu-west-1.compute.internal} Failed: Error: Error response from daemon: Minimum memory limit allowed is 6MB"
time="2021-07-05T10:09:22Z" level=info msg="At 2021-07-05 09:34:10 +0000 UTC - event for csi-driver-node-mg8l4: {kubelet ip-10-250-10-76.eu-west-1.compute.internal} Failed: Error: Error response from daemon: Minimum memory limit allowed is 6MB"
```

It seems that VPA provides too low memory recommendations (< 6MB) that are not supported by the docker daemon.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An issue preventing `csi-driver-node` Pod to start because of too low memory recommendation by VPA is now fixed.
```
