### PR TITLE
[release-v1.25] Automated cherry pick of #369: Set minAllowed memory for csi-driver-node containers

### DIFF
--- a/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser-vpa.yaml
+++ b/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser-vpa.yaml
@@ -4,6 +4,11 @@ metadata:
   name: aws-lb-readvertiser-vpa
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        memory: 20Mi
   targetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
@@ -5,6 +5,11 @@ metadata:
   name: csi-driver-node
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        memory: 25Mi
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet


### PR DESCRIPTION
/area/storage
/area/testing
/kind/bug

Cherry pick of #369 on release-v1.25.

#369: Set minAllowed memory for csi-driver-node containers

**Release Notes:**
```other operator
An issue preventing `csi-driver-node` Pod to start because of too low memory recommendation by VPA is now fixed.
```