### PR TITLE
Update aws-ebs-csi-driver

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -49,7 +49,7 @@ images:
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/aws-ebs-csi-driver
   repository: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-  tag: "v1.1.0"
+  tag: "v1.1.1"
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner


### PR DESCRIPTION
/area storage
/platform aws

Adopts the fix for https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/918

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The following image is updated:
- k8s.gcr.io/provider-aws/aws-ebs-csi-driver: v1.1.0 -> v1.1.1 (see [CHANGELOG](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG-0.x.md#v111))
```
