### PR TITLE
Enable `srcAndDstChecksEnabled` field from k8s >= v1.22

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -206,7 +206,7 @@ func (w *workerDelegate) generateMachineConfig() error {
 			machineClassSpec["secret"].(map[string]interface{})["labels"] = map[string]string{v1beta1constants.GardenerPurpose: genericworkeractuator.GardenPurposeMachineClass}
 
 			// if the shoot K8s version is greater than or equal to 1.22 then
-			// enable source destination check on AWS instances by default
+			// disable source destination check on AWS instances by default
 			shootK8sVersion := w.cluster.Shoot.Spec.Kubernetes.Version
 
 			k8sVersionGreaterOrEqualThan122, err := versionutils.CompareVersions(shootK8sVersion, ">=", "1.22")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR introduces a new field in the `providerSpec` of `MachineClass` for AWS called `srcAndDstChecksEnabled ` which is `true` by default and when set to `false` will disable the source destination check on the AWS Instance (NAT instance in this case). This field shall be used by default from K8s >= v1.22

**Which issue(s) this PR fixes**:
Fixes [#36](https://github.com/gardener/machine-controller-manager-provider-aws/issues/36)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Introducing a new field in the `providerSpec` of `MachineClass` for AWS called `srcAndDstChecksEnabled ` which is `true` by default and when set to `false` will disable the source destination check on the AWS Instance 
```
