### PR TITLE
Add m6i AWS machine types

### DIFF
--- a/.landscaper/blueprint/deploy-execution-manifests.yaml
+++ b/.landscaper/blueprint/deploy-execution-manifests.yaml
@@ -142,6 +142,42 @@ deployItems:
           #   The allocatable resources on such "small" machines are not enough to run the system components
           #   and addons without disruptions.
           machineTypes:
+            - name: m6i.large
+              cpu: "2"
+              gpu: "0"
+              memory: 8Gi
+            - name: m6i.xlarge
+              cpu: "4"
+              gpu: "0"
+              memory: 16Gi
+            - name: m6i.2xlarge
+              cpu: "8"
+              gpu: "0"
+              memory: 32Gi
+            - name: m6i.4xlarge
+              cpu: "16"
+              gpu: "0"
+              memory: 64Gi
+            - name: m6i.8xlarge
+              cpu: "32"
+              gpu: "0"
+              memory: 128Gi
+            - name: m6i.12xlarge
+              cpu: "48"
+              gpu: "0"
+              memory: 192Gi
+            - name: m6i.16xlarge
+              cpu: "64"
+              gpu: "0"
+              memory: 256Gi
+            - name: m6i.24xlarge
+              cpu: "96"
+              gpu: "0"
+              memory: 384Gi
+            - name: m6i.32xlarge
+              cpu: "128"
+              gpu: "0"
+              memory: 512Gi
             - name: m5.large
               cpu: "2"
               gpu: "0"


### PR DESCRIPTION
**How to categorize this PR?**
/area usability
/kind task
/platform aws

**What this PR does / why we need it**:  Add AWS m6i type machines. These are the next generation of Intel based AWS general purpose compute machines. They are like `m5` but better. See https://aws.amazon.com/ec2/instance-types/m6i/

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added AWS m6i machine type family
```

