### PR TITLE
Categorize certain aws-route53 errors as configuration problems

### DIFF
--- a/pkg/aws/client/client_route53.go
+++ b/pkg/aws/client/client_route53.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -311,6 +312,22 @@ func ignoreHostedZoneNotFound(err error) error {
 
 func isValuesDoNotMatchError(err error) bool {
 	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == route53.ErrCodeInvalidChangeBatch && strings.Contains(aerr.Message(), "the values provided do not match the current values") {
+		return true
+	}
+	return false
+}
+
+func IsNoSuchHostedZoneError(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == route53.ErrCodeNoSuchHostedZone {
+		return true
+	}
+	return false
+}
+
+var notPermittedInZoneRegex = regexp.MustCompile(`RRSet with DNS name [^\ ]+ is not permitted in zone [^\ ]+`)
+
+func IsNotPermittedInZoneError(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == route53.ErrCodeInvalidChangeBatch && notPermittedInZoneRegex.MatchString(aerr.Message()) {
 		return true
 	}
 	return false

--- a/pkg/aws/client/client_route53.go
+++ b/pkg/aws/client/client_route53.go
@@ -317,6 +317,7 @@ func isValuesDoNotMatchError(err error) bool {
 	return false
 }
 
+// IsNoSuchHostedZoneError returns true if the error indicates a non-existing route53 hosted zone.
 func IsNoSuchHostedZoneError(err error) bool {
 	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == route53.ErrCodeNoSuchHostedZone {
 		return true
@@ -326,6 +327,7 @@ func IsNoSuchHostedZoneError(err error) bool {
 
 var notPermittedInZoneRegex = regexp.MustCompile(`RRSet with DNS name [^\ ]+ is not permitted in zone [^\ ]+`)
 
+// IsNotPermittedInZoneError returns true if the error indicates that the DNS name is not permitted in the route53 hosted zone.
 func IsNotPermittedInZoneError(err error) bool {
 	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == route53.ErrCodeInvalidChangeBatch && notPermittedInZoneRegex.MatchString(aerr.Message()) {
 		return true


### PR DESCRIPTION
**How to categorize this PR?**

/area ops-productivity
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Categorizes certain aws-route53 errors as configuration problems as suggested in https://github.com/gardener/gardener/issues/4294.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/4294

**Special notes for your reviewer**:

**Release note**:

```other operator
Failures to reconcile `DNSRecords` due to a missing hosted zone or a DNS name not matching the zone name are now properly categorized as `ERR_CONFIGURATION_PROBLEM`.
```
