### PR TITLE
Stop using `github.com/pkg/errors`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/pierrec/lz4 v2.4.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/pkg/apis/aws/helper/scheme.go
+++ b/pkg/apis/aws/helper/scheme.go
@@ -26,7 +26,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -65,7 +64,7 @@ func CloudProfileConfigFromCluster(cluster *controller.Cluster) (*api.CloudProfi
 	if cluster != nil && cluster.CloudProfile != nil && cluster.CloudProfile.Spec.ProviderConfig != nil && cluster.CloudProfile.Spec.ProviderConfig.Raw != nil {
 		cloudProfileConfig = &api.CloudProfileConfig{}
 		if _, _, err := decoder.Decode(cluster.CloudProfile.Spec.ProviderConfig.Raw, nil, cloudProfileConfig); err != nil {
-			return nil, errors.Wrapf(err, "could not decode providerConfig of cloudProfile for '%s'", kutil.ObjectName(cluster.CloudProfile))
+			return nil, fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", kutil.ObjectName(cluster.CloudProfile), err)
 		}
 	}
 	return cloudProfileConfig, nil

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -36,7 +36,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
-	"github.com/pkg/errors"
 )
 
 // Client is a struct containing several clients for the different AWS services it needs to interact with.
@@ -375,16 +374,16 @@ func (c *Client) ListKubernetesELBsV2(ctx context.Context, vpcID, clusterName st
 func (c *Client) DeleteELBV2(ctx context.Context, arn string) error {
 	targetGroups, err := c.ELBv2.DescribeTargetGroups(&elbv2.DescribeTargetGroupsInput{LoadBalancerArn: &arn})
 	if err != nil {
-		return errors.Wrapf(err, "could not list loadbalancer target groups for arn %s", arn)
+		return fmt.Errorf("could not list loadbalancer target groups for arn %s: %w", arn, err)
 	}
 
 	if _, err := c.ELBv2.DeleteLoadBalancerWithContext(ctx, &elbv2.DeleteLoadBalancerInput{LoadBalancerArn: &arn}); ignoreNotFound(err) != nil {
-		return errors.Wrapf(err, "could not delete loadbalancer for arn %s", arn)
+		return fmt.Errorf("could not delete loadbalancer for arn %s: %w", arn, err)
 	}
 
 	for _, group := range targetGroups.TargetGroups {
 		if _, err := c.ELBv2.DeleteTargetGroup(&elbv2.DeleteTargetGroupInput{TargetGroupArn: group.TargetGroupArn}); err != nil {
-			return errors.Wrapf(err, "could not delete target groups after deleting loadbalancer for arn %s", arn)
+			return fmt.Errorf("could not delete target groups after deleting loadbalancer for arn %s: %w", arn, err)
 		}
 	}
 

--- a/pkg/controller/bastion/actuator.go
+++ b/pkg/controller/bastion/actuator.go
@@ -16,6 +16,7 @@ package bastion
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
 	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
@@ -29,7 +30,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -63,12 +63,12 @@ func (a *actuator) getAWSClient(ctx context.Context, bastion *extensionsv1alpha1
 	key := kubernetes.Key(bastion.Namespace, v1beta1constants.SecretNameCloudProvider)
 
 	if err := a.Client().Get(ctx, key, secret); err != nil {
-		return nil, errors.Wrapf(err, "failed to find %q Secret", v1beta1constants.SecretNameCloudProvider)
+		return nil, fmt.Errorf("failed to find %q Secret: %w", v1beta1constants.SecretNameCloudProvider, err)
 	}
 
 	credentials, err := aws.ReadCredentialsSecret(secret, false)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read credentials Secret")
+		return nil, fmt.Errorf("failed to read credentials Secret: %w", err)
 	}
 
 	return awsclient.NewClient(string(credentials.AccessKeyID), string(credentials.SecretAccessKey), shoot.Spec.Region)

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -16,6 +16,7 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -37,7 +38,6 @@ import (
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -354,7 +354,7 @@ func (vp *valuesProvider) GetConfigChartValues(
 	infraStatus := &apisaws.InfrastructureStatus{}
 	if cp.Spec.InfrastructureProviderStatus != nil {
 		if _, _, err := vp.Decoder().Decode(cp.Spec.InfrastructureProviderStatus.Raw, nil, infraStatus); err != nil {
-			return nil, errors.Wrapf(err, "could not decode infrastructureProviderStatus of controlplane '%s'", kutil.ObjectName(cp))
+			return nil, fmt.Errorf("could not decode infrastructureProviderStatus of controlplane '%s': %w", kutil.ObjectName(cp), err)
 		}
 	}
 
@@ -374,7 +374,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	cpConfig := &apisaws.ControlPlaneConfig{}
 	if cp.Spec.ProviderConfig != nil {
 		if _, _, err := vp.Decoder().Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {
-			return nil, errors.Wrapf(err, "could not decode providerConfig of controlplane '%s'", kutil.ObjectName(cp))
+			return nil, fmt.Errorf("could not decode providerConfig of controlplane '%s': %w", kutil.ObjectName(cp), err)
 		}
 	}
 
@@ -427,7 +427,7 @@ func (vp *valuesProvider) GetStorageClassesChartValues(
 		cpConfig := &apisaws.ControlPlaneConfig{}
 		_, _, err := vp.Decoder().Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig)
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not decode providerConfig of controlplane '%s'", kutil.ObjectName(cp))
+			return nil, fmt.Errorf("could not decode providerConfig of controlplane '%s': %w", kutil.ObjectName(cp), err)
 		}
 
 		// internal types should NOT be used when embeding.
@@ -458,7 +458,7 @@ func (vp *valuesProvider) GetControlPlaneExposureChartValues(
 		var err error
 		address, err = kutil.GetLoadBalancerIngress(ctx, vp.Client(), &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: cp.Namespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}})
 		if err != nil {
-			return nil, errors.Wrap(err, "could not get kube-apiserver service load balancer address")
+			return nil, fmt.Errorf("could not get kube-apiserver service load balancer address: %w", err)
 		}
 	}
 
@@ -479,7 +479,7 @@ func getConfigChartValues(
 	// Get the first subnet with purpose "public"
 	subnet, err := helper.FindSubnetForPurpose(infraStatus.VPC.Subnets, apisaws.PurposePublic)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not determine subnet from infrastructureProviderStatus of controlplane '%s'", kutil.ObjectName(cp))
+		return nil, fmt.Errorf("could not determine subnet from infrastructureProviderStatus of controlplane '%s': %w", kutil.ObjectName(cp), err)
 	}
 
 	// Collect config chart values

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -99,7 +98,7 @@ func Reconcile(
 			)).
 		Apply(ctx); err != nil {
 
-		return nil, nil, errors.Wrap(err, "failed to apply the terraform config")
+		return nil, nil, fmt.Errorf("failed to apply the terraform config: %w", err)
 	}
 
 	return computeProviderStatus(ctx, tf, infrastructureConfig)

--- a/pkg/controller/worker/helper.go
+++ b/pkg/controller/worker/helper.go
@@ -16,13 +16,13 @@ package worker
 
 import (
 	"context"
+	"fmt"
 
 	api "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
@@ -36,7 +36,7 @@ func (w *workerDelegate) decodeWorkerProviderStatus() (*api.WorkerStatus, error)
 	}
 
 	if _, _, err := w.Decoder().Decode(w.worker.Status.ProviderStatus.Raw, nil, workerStatus); err != nil {
-		return nil, errors.Wrapf(err, "could not decode WorkerStatus '%s'", kutil.ObjectName(w.worker))
+		return nil, fmt.Errorf("could not decode WorkerStatus '%s': %w", kutil.ObjectName(w.worker), err)
 	}
 
 	return workerStatus, nil

--- a/pkg/controller/worker/machine_images.go
+++ b/pkg/controller/worker/machine_images.go
@@ -16,32 +16,31 @@ package worker
 
 import (
 	"context"
+	"fmt"
 
 	api "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-
-	"github.com/pkg/errors"
 )
 
 // UpdateMachineImagesStatus implements genericactuator.WorkerDelegate.
 func (w *workerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
 	if w.machineImages == nil {
 		if err := w.generateMachineConfig(); err != nil {
-			return errors.Wrapf(err, "unable to generate the machine config")
+			return fmt.Errorf("unable to generate the machine config: %w", err)
 		}
 	}
 
 	// Decode the current worker provider status.
 	workerStatus, err := w.decodeWorkerProviderStatus()
 	if err != nil {
-		return errors.Wrapf(err, "unable to decode the worker provider status")
+		return fmt.Errorf("unable to decode the worker provider status: %w", err)
 	}
 
 	workerStatus.MachineImages = w.machineImages
 	if err := w.updateWorkerProviderStatus(ctx, workerStatus); err != nil {
-		return errors.Wrapf(err, "unable to update worker provider status")
+		return fmt.Errorf("unable to update worker provider status: %w", err)
 	}
 
 	return nil
@@ -57,7 +56,7 @@ func (w *workerDelegate) findMachineImage(name, version, region string) (string,
 	if providerStatus := w.worker.Status.ProviderStatus; providerStatus != nil {
 		workerStatus := &api.WorkerStatus{}
 		if _, _, err := w.Decoder().Decode(providerStatus.Raw, nil, workerStatus); err != nil {
-			return "", errors.Wrapf(err, "could not decode worker status of worker '%s'", kutil.ObjectName(w.worker))
+			return "", fmt.Errorf("could not decode worker status of worker '%s': %w", kutil.ObjectName(w.worker), err)
 		}
 
 		machineImage, err := helper.FindMachineImage(workerStatus.MachineImages, name, version)

--- a/pkg/webhook/shoot/mutator.go
+++ b/pkg/webhook/shoot/mutator.go
@@ -16,10 +16,10 @@ package shoot
 
 import (
 	"context"
+	"fmt"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,7 +41,7 @@ func NewMutator() extensionswebhook.Mutator {
 func (m *mutator) Mutate(ctx context.Context, new, _ client.Object) error {
 	acc, err := meta.Accessor(new)
 	if err != nil {
-		return errors.Wrapf(err, "could not create accessor during webhook")
+		return fmt.Errorf("could not create accessor during webhook: %w", err)
 	}
 	// If the object does have a deletion timestamp then we don't want to mutate anything.
 	if acc.GetDeletionTimestamp() != nil {

--- a/test/tm/generator.go
+++ b/test/tm/generator.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"reflect"
 
@@ -24,7 +25,6 @@ import (
 
 	"github.com/gardener/gardener/extensions/test/tm/generator"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	log "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -113,13 +113,13 @@ func main() {
 
 func validate() error {
 	if err := generator.ValidateString(&cfg.infrastructureProviderConfigPath); err != nil {
-		return errors.Wrap(err, "error validating infrastructure provider config path")
+		return fmt.Errorf("error validating infrastructure provider config path: %w", err)
 	}
 	if err := generator.ValidateString(&cfg.controlplaneProviderConfigPath); err != nil {
-		return errors.Wrap(err, "error validating controlplane provider config path")
+		return fmt.Errorf("error validating controlplane provider config path: %w", err)
 	}
 	if err := generator.ValidateString(&cfg.zone); err != nil {
-		return errors.Wrap(err, "error validating zone")
+		return fmt.Errorf("error validating zone: %w", err)
 	}
 	//Optional Parameters
 	if err := generator.ValidateString(&cfg.networkVPCCidr); err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -472,7 +472,6 @@ github.com/pelletier/go-toml
 github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.11.0 => github.com/prometheus/client_golang v1.7.1
 github.com/prometheus/client_golang/prometheus


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform aws

**What this PR does / why we need it**:
Similar to gardener/gardener#4280 we should be using Go native error wrapping (available since GO 1.13).

**Which issue(s) this PR fixes**:
Fixes #375

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```NONE

```

/invite @vanjiii 
