### PR TITLE
Update kubernetes-csi/external-provisioner to v3.0.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -53,7 +53,13 @@ images:
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner
+  tag: "v2.1.2"
+  targetVersion: "< 1.20"
+- name: csi-provisioner
+  sourceRepository: github.com/kubernetes-csi/external-provisioner
+  repository: k8s.gcr.io/sig-storage/csi-provisioner
   tag: "v3.0.0"
+  targetVersion: ">= 1.20"
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
   repository: k8s.gcr.io/sig-storage/csi-attacher

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -53,7 +53,7 @@ images:
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner
-  tag: "v2.1.2"
+  tag: "v3.0.0"
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
   repository: k8s.gcr.io/sig-storage/csi-attacher


### PR DESCRIPTION
**How to categorize this PR?**
/area storage
/kind enhancement
/platform aws

**What this PR does / why we need it**:

Upgrade external-provisioner to v3  for being aligned with this pr: https://github.com/gardener/gardener-extension-provider-aws/pull/405

**Which issue(s) this PR fixes**:
We have a csi-provision driver that fails because of this issue:
kubernetes-csi/external-provisioner#582

**Special notes for your reviewer**:

**Release note**:
```other operator
The following images are updated:
- k8s.gcr.io/sig-storage/csi-provisioner v2.1.2 -> v3.0.0

```
