### PR TITLE
Update blueprint for component provider-aws 

### DIFF
--- a/.landscaper/blueprint/blueprint.yaml
+++ b/.landscaper/blueprint/blueprint.yaml
@@ -14,21 +14,20 @@ imports:
       machineImages:
         type: array
       regions:
-        type: object
-        properties:
-          name:
-            type: string
-          zones:
-            type: array
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+            zones:
+              type: array
 
 # data from landscape-*-setup/export/kubernetes/KUBERNETES_VERSIONS.yaml
 # versions of item with name 'aws'
 - name: kubernetesVersions
   schema:
-    type: object
-    properties:
-      versions:
-        type: array
+    type: array
 
 # data from landscape-*-setup/landscape.yaml section gardener-extension-provider-aws.values
 - name: controllerRegistration

--- a/.landscaper/blueprint/deploy-execution-manifests.yaml
+++ b/.landscaper/blueprint/deploy-execution-manifests.yaml
@@ -67,6 +67,8 @@ deployItems:
                 concurrentSyncs: 20
               controlplane:
                 concurrentSyncs: 20
+              dnsrecord:
+                concurrentSyncs: 20
               healthcheck:
                 concurrentSyncs: 20
               infrastructure:

--- a/.landscaper/blueprint/deploy-execution-manifests.yaml
+++ b/.landscaper/blueprint/deploy-execution-manifests.yaml
@@ -22,7 +22,7 @@ deployItems:
           chart: {{ resolve ( $chart.access ) | toString | b64enc }}
           values:
             image:
-              {{- $image := getResource .cd "name" "gardener-extension-provider-aws-image" }}
+              {{- $image := getResource .cd "name" "gardener-extension-provider-aws" }}
               repository: {{ ociRefRepo ( $image.access.imageReference ) }}
               tag: {{ ociRefVersion ( $image.access.imageReference ) }}
             images:
@@ -53,6 +53,8 @@ deployItems:
               backupentry:
                 concurrentSyncs: {{ .imports.controllerRegistration.concurrentSyncs }}
               controlplane:
+                concurrentSyncs: {{ .imports.controllerRegistration.concurrentSyncs }}
+              dnsrecord:
                 concurrentSyncs: {{ .imports.controllerRegistration.concurrentSyncs }}
               healthcheck:
                 concurrentSyncs: {{ .imports.controllerRegistration.concurrentSyncs }}
@@ -103,14 +105,16 @@ deployItems:
             type: aws
           - kind: ControlPlane
             type: aws
+          - kind: DNSRecord
+            type: aws-route53
           - kind: Infrastructure
             type: aws
           - kind: Worker
             type: aws
           {{- end}}
-        deployment:
-          deploymentRefs:
-            - name: provider-aws
+          deployment:
+            deploymentRefs:
+              - name: provider-aws
     - policy: manage
       manifest:
         apiVersion: core.gardener.cloud/v1beta1
@@ -136,48 +140,12 @@ deployItems:
           {{- toYaml .imports.cloudProfile.machineImages | nindent 10 }}
           kubernetes:
             versions:
-            {{- toYaml .imports.kubernetesVersions.versions | nindent 12 }}
+            {{- toYaml .imports.kubernetesVersions | nindent 12 }}
           # Note:
           # - Please don't add machine types that don't have at least 2 CPU cores and 3Gi of memory.
           #   The allocatable resources on such "small" machines are not enough to run the system components
           #   and addons without disruptions.
           machineTypes:
-            - name: m6i.large
-              cpu: "2"
-              gpu: "0"
-              memory: 8Gi
-            - name: m6i.xlarge
-              cpu: "4"
-              gpu: "0"
-              memory: 16Gi
-            - name: m6i.2xlarge
-              cpu: "8"
-              gpu: "0"
-              memory: 32Gi
-            - name: m6i.4xlarge
-              cpu: "16"
-              gpu: "0"
-              memory: 64Gi
-            - name: m6i.8xlarge
-              cpu: "32"
-              gpu: "0"
-              memory: 128Gi
-            - name: m6i.12xlarge
-              cpu: "48"
-              gpu: "0"
-              memory: 192Gi
-            - name: m6i.16xlarge
-              cpu: "64"
-              gpu: "0"
-              memory: 256Gi
-            - name: m6i.24xlarge
-              cpu: "96"
-              gpu: "0"
-              memory: 384Gi
-            - name: m6i.32xlarge
-              cpu: "128"
-              gpu: "0"
-              memory: 512Gi
             - name: m5.large
               cpu: "2"
               gpu: "0"
@@ -202,6 +170,10 @@ deployItems:
               cpu: "48"
               gpu: "0"
               memory: 192Gi
+            - name: m5.16xlarge
+              cpu: "64"
+              gpu: "0"
+              memory: 256Gi
             - name: m5.24xlarge
               cpu: "96"
               gpu: "0"
@@ -290,6 +262,34 @@ deployItems:
               cpu: "96"
               gpu: "0"
               memory: 384Gi
+            - name: m5zn.large
+              cpu: "2"
+              gpu: "0"
+              memory: 8Gi
+            - name: m5zn.xlarge
+              cpu: "4"
+              gpu: "0"
+              memory: 16Gi
+            - name: m5zn.2xlarge
+              cpu: "8"
+              gpu: "0"
+              memory: 32Gi
+            - name: m5zn.3xlarge
+              cpu: "12"
+              gpu: "0"
+              memory: 48Gi
+            - name: m5zn.6xlarge
+              cpu: "24"
+              gpu: "0"
+              memory: 96Gi
+            - name: m5zn.12xlarge
+              cpu: "48"
+              gpu: "0"
+              memory: 192Gi
+            - name: m5zn.metal
+              cpu: "48"
+              gpu: "0"
+              memory: 192Gi
             - name: m6g.2xlarge
               cpu: "8"
               gpu: "0"
@@ -403,6 +403,10 @@ deployItems:
               gpu: "0"
               memory: 96Gi
             - name: c5n.18xlarge
+              cpu: "72"
+              gpu: "0"
+              memory: 192Gi
+            - name: c5n.metal
               cpu: "72"
               gpu: "0"
               memory: 192Gi
@@ -584,6 +588,22 @@ deployItems:
               cpu: "96"
               gpu: "0"
               memory: 768Gi
+            - name: r5n.large
+              cpu: "2"
+              gpu: "0"
+              memory: 16Gi
+            - name: r5n.xlarge
+              cpu: "4"
+              gpu: "0"
+              memory: 32Gi
+            - name: r5n.2xlarge
+              cpu: "8"
+              gpu: "0"
+              memory: 64Gi
+            - name: r5n.4xlarge
+              cpu: "16"
+              gpu: "0"
+              memory: 128Gi
             - name: r5d.large
               cpu: "2"
               gpu: "0"
@@ -660,6 +680,26 @@ deployItems:
               cpu: "128"
               gpu: "0"
               memory: 3904Gi
+            - name: u-3tb1.56xlarge
+              cpu: "224"
+              gpu: "0"
+              memory: 3072Gi
+            - name: u-6tb1.56xlarge
+              cpu: "224"
+              gpu: "0"
+              memory: 6144Gi
+            - name: u-6tb1.112xlarge
+              cpu: "448"
+              gpu: "0"
+              memory: 6144Gi
+            - name: u-9tb1.112xlarge
+              cpu: "448"
+              gpu: "0"
+              memory: 9216Gi
+            - name: u-12tb1.112xlarge
+              cpu: "448"
+              gpu: "0"
+              memory: 12288Gi
             - name: u-6tb1.metal
               cpu: "448"
               gpu: "0"
@@ -726,6 +766,7 @@ deployItems:
             - name: io1
               class: standard
               usable: true
+              minSize: 4Gi
           regions:
           {{- if .imports.cloudProfile.regions }}
           {{- toYaml .imports.cloudProfile.regions | nindent 10 }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement
/platform aws

**What this PR does / why we need it**:

This pull request fixes and updates the blueprint of the provider-aws component.

The blueprint contains data, which in the current deployment are in the templates for the [cloud profile](https://github.wdf.sap.corp/kubernetes/landscape-setup/blob/master/components/gardener-extensions/provider-aws/resources/10-cloudprofile.yaml.tpl) and [controller deployment / registration](https://github.wdf.sap.corp/kubernetes/landscape-setup/blob/master/components/gardener-extensions/provider-aws/resources/controllerregistration.yaml.tpl). We have updated the blueprint so that it contains the last changes from there. 

We plan to activate the landscaper based deployment for provider-aws in the landscape-setup. Therefore it is mandatory, that the  blueprint in the latest release of provider-aws is in sync with the current state in the landscape-setup.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Currently, the landscaper based deployment is not yet activated for this component; therefore the blueprint is not yet used.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
