### PR TITLE
Make the linter fail on missing or wrong doc comments

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,3 +5,15 @@ run:
 linters:
   disable:
   - unused
+  enable:
+  - revive
+
+issues:
+  exclude-use-default: false
+  exclude:
+  # revive
+  - var-naming # ((var|const|struct field|func) .* should be .*
+  - dot-imports # should not use dot imports
+  - package-comments # package comment should be of the form
+  - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
+  - "exported: (type|func) name will be used as .* by other packages, and that stutters;"

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+// SecretsValidatorName is the name of the secrets validator.
 const SecretsValidatorName = "secrets." + extensionswebhook.ValidatorName
 
 var logger = log.Log.WithName("aws-validator-webhook")

--- a/pkg/apis/config/loader/loader.go
+++ b/pkg/apis/config/loader/loader.go
@@ -27,16 +27,16 @@ import (
 )
 
 var (
-	Codec  runtime.Codec
-	Scheme *runtime.Scheme
+	codec  runtime.Codec
+	scheme *runtime.Scheme
 )
 
 func init() {
-	Scheme = runtime.NewScheme()
-	install.Install(Scheme)
-	yamlSerializer := json.NewYAMLSerializer(json.DefaultMetaFactory, Scheme, Scheme)
-	Codec = versioning.NewDefaultingCodecForScheme(
-		Scheme,
+	scheme = runtime.NewScheme()
+	install.Install(scheme)
+	yamlSerializer := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme, scheme)
+	codec = versioning.NewDefaultingCodecForScheme(
+		scheme,
 		yamlSerializer,
 		yamlSerializer,
 		schema.GroupVersion{Version: "v1alpha1"},
@@ -63,7 +63,7 @@ func Load(data []byte) (*config.ControllerConfiguration, error) {
 		return cfg, nil
 	}
 
-	decoded, _, err := Codec.Decode(data, &schema.GroupVersionKind{Version: "v1alpha1", Kind: "Config"}, cfg)
+	decoded, _, err := codec.Decode(data, &schema.GroupVersionKind{Version: "v1alpha1", Kind: "Config"}, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -419,6 +419,7 @@ func (c *Client) DeleteSecurityGroup(ctx context.Context, id string) error {
 	return ignoreNotFound(err)
 }
 
+// IsNotFoundError returns true if the given error is a awserr.Error indicating that a AWS resource was not found.
 func IsNotFoundError(err error) bool {
 	if aerr, ok := err.(awserr.Error); ok && (aerr.Code() == elb.ErrCodeAccessPointNotFoundException || aerr.Code() == "InvalidGroup.NotFound" || aerr.Code() == "InvalidVpcID.NotFound") {
 		return true

--- a/pkg/aws/matchers/iam_role_policy_document.go
+++ b/pkg/aws/matchers/iam_role_policy_document.go
@@ -23,6 +23,7 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
+// BeSemanticallyEqualToRolePolicyDocument returns a matcher that checks if a role policy document is semantically equal to the given one.
 func BeSemanticallyEqualToRolePolicyDocument(expected interface{}) types.GomegaMatcher {
 	return &rolePolicyDocumentMatcher{
 		expected: expected,

--- a/pkg/controller/dnsrecord/actuator.go
+++ b/pkg/controller/dnsrecord/actuator.go
@@ -48,6 +48,7 @@ type actuator struct {
 	logger           logr.Logger
 }
 
+// NewActuator creates a new dnsrecord.Actuator.
 func NewActuator(awsClientFactory awsclient.Factory, logger logr.Logger) dnsrecord.Actuator {
 	return &actuator{
 		awsClientFactory: awsClientFactory,

--- a/test/integration/vpc.go
+++ b/test/integration/vpc.go
@@ -187,7 +187,7 @@ func DestroyVPC(ctx context.Context, logger *logrus.Entry, awsClient *awsclient.
 		return err
 	}
 
-	if err := wait.PollUntil(5*time.Second, func() (bool, error) {
+	return wait.PollUntil(5*time.Second, func() (bool, error) {
 		entry.Infof("Waiting until vpc '%s' is deleted...", vpcID)
 
 		_, err := awsClient.EC2.DescribeVpcs(&ec2.DescribeVpcsInput{
@@ -203,9 +203,5 @@ func DestroyVPC(ctx context.Context, logger *logrus.Entry, awsClient *awsclient.
 		}
 
 		return false, nil
-	}, ctx.Done()); err != nil {
-		return err
-	}
-
-	return nil
+	}, ctx.Done())
 }

--- a/test/tm/generator.go
+++ b/test/tm/generator.go
@@ -38,11 +38,11 @@ const (
 )
 
 var (
-	cfg    *GeneratorConfig
+	cfg    *generatorConfig
 	logger logr.Logger
 )
 
-type GeneratorConfig struct {
+type generatorConfig struct {
 	networkVPCCidr                   string
 	networkInternalCidr              string
 	networkPublicCidr                string
@@ -53,7 +53,7 @@ type GeneratorConfig struct {
 }
 
 func addFlags() {
-	cfg = &GeneratorConfig{}
+	cfg = &generatorConfig{}
 	flag.StringVar(&cfg.zone, "zone", "", "cloudprovider zone fo the shoot")
 	flag.StringVar(&cfg.infrastructureProviderConfigPath, "infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
 	flag.StringVar(&cfg.controlplaneProviderConfigPath, "controlplane-provider-config-filepath", "", "filepath to the provider specific controlplane config")


### PR DESCRIPTION
**How to categorize this PR?**

/area quality, dev-productivity
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Makes the linter fail on missing or wrong doc comments and a few other common style errors, and fixes all such issues that already exist.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Making the linter fail on missing or wrong doc comments and a few other common style errors consists of enabling `revive` in the `golangci-lint` configuration and excluding certain `revive` errors that we are perhaps not interested in.

I have fixed the following `revive` errors (as regexes that could be included in the `golangci-lint` configuration if desired):

```
- "exported: comment on exported (var|const|type|method|function) .* should be of the form "
- "exported: exported (var|const|type|method|function) .* should have comment or be unexported"
- if-return # redundant if \.\.\.; err != nil check, just return error instead
```

I have disabled the following `revive` errors via the `golangci-lint` configuration:

```
- var-naming # ((var|const|struct field|func) .* should be .*
- dot-imports # should not use dot imports
- package-comments # package comment should be of the form
- indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
- "exported: (type|func) name will be used as .* by other packages, and that stutters;"
```

See also https://github.com/gardener/gardener/pull/4627.

**Release note**:

```other developer
Missing or wrong doc comments and a few other common style errors will now be reported by the linter.
```
