### PR TITLE
[release-v1.28] Automated cherry pick of #411: Update aws-ebs-csi-driver

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -49,7 +49,7 @@ images:
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/aws-ebs-csi-driver
   repository: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-  tag: "v1.1.1"
+  tag: "v1.1.4"
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner


### PR DESCRIPTION
/area/storage
/kind/bug

Cherry pick of #411 on release-v1.28.

#411: Update aws-ebs-csi-driver

**Release Notes:**
```other user
The following image is updated:
- k8s.gcr.io/provider-aws/aws-ebs-csi-driver: v1.1.1 -> v1.1.4 (see [CHANGELOG](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/release-1.1/CHANGELOG-0.x.md#v114))
```