### PR TITLE
Remove the "garden.sapcloud.io/role" label from control plane components

### DIFF
--- a/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser.yaml
+++ b/charts/internal/aws-lb-readvertiser/templates/aws-lb-readvertiser.yaml
@@ -14,7 +14,6 @@ spec:
   template:
     metadata:
       labels:
-        garden.sapcloud.io/role: controlplane
         gardener.cloud/role: controlplane
         app: aws-lb-readvertiser
         networking.gardener.cloud/to-dns: allowed

--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -22,7 +22,6 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
-        garden.sapcloud.io/role: controlplane
         gardener.cloud/role: controlplane
         app: kubernetes
         role: machine-controller-manager

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
@@ -20,7 +20,6 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
-        garden.sapcloud.io/role: controlplane
         gardener.cloud/role: controlplane
         app: kubernetes
         role: cloud-controller-manager

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-deployment.yaml
@@ -28,7 +28,6 @@ spec:
       labels:
         app: csi
         role: controller
-        garden.sapcloud.io/role: controlplane
         gardener.cloud/role: controlplane
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-public-networks: allowed


### PR DESCRIPTION
/kind cleanup
/platform aws

We were maintaining both `garden.sapcloud.io/role` and `gardener.cloud/role` on extension control plane Pods mainly because of the dependency-watchdog. Since gardener/gardener@v1.21.0 the dependency-watchdog config is updated to use the new role key - ref https://github.com/gardener/gardener/commit/def656b853f33e1a1fbf54803c67ecfc18088b70. So we no longer need to maintain the deprecated role label key.

Ref https://github.com/gardener/gardener/issues/1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
