### PR TITLE
Add validation for non-existing and already wrongly-associated EIPs

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -154,7 +154,6 @@ func (c *Client) GetElasticIPsAssociationIDForAllocationIDs(ctx context.Context,
 	result := make(map[string]*string, len(describeAddressesOutput.Addresses))
 	for _, addr := range describeAddressesOutput.Addresses {
 		if addr.AllocationId == nil {
-			// this should not happen
 			continue
 		}
 		result[*addr.AllocationId] = addr.AssociationId

--- a/pkg/aws/client/mock/mocks.go
+++ b/pkg/aws/client/mock/mocks.go
@@ -10,6 +10,7 @@ import (
 
 	client "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
 	gomock "github.com/golang/mock/gomock"
+	sets "k8s.io/apimachinery/pkg/util/sets"
 )
 
 // MockInterface is a mock of Interface interface.
@@ -175,6 +176,36 @@ func (m *MockInterface) GetDNSHostedZones(arg0 context.Context) (map[string]stri
 func (mr *MockInterfaceMockRecorder) GetDNSHostedZones(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDNSHostedZones", reflect.TypeOf((*MockInterface)(nil).GetDNSHostedZones), arg0)
+}
+
+// GetElasticIPsAssociationIDForAllocationIDs mocks base method.
+func (m *MockInterface) GetElasticIPsAssociationIDForAllocationIDs(arg0 context.Context, arg1 []string) (map[string]*string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetElasticIPsAssociationIDForAllocationIDs", arg0, arg1)
+	ret0, _ := ret[0].(map[string]*string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetElasticIPsAssociationIDForAllocationIDs indicates an expected call of GetElasticIPsAssociationIDForAllocationIDs.
+func (mr *MockInterfaceMockRecorder) GetElasticIPsAssociationIDForAllocationIDs(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetElasticIPsAssociationIDForAllocationIDs", reflect.TypeOf((*MockInterface)(nil).GetElasticIPsAssociationIDForAllocationIDs), arg0, arg1)
+}
+
+// GetNATGatewayAddressAllocations mocks base method.
+func (m *MockInterface) GetNATGatewayAddressAllocations(arg0 context.Context, arg1 string) (sets.String, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNATGatewayAddressAllocations", arg0, arg1)
+	ret0, _ := ret[0].(sets.String)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNATGatewayAddressAllocations indicates an expected call of GetNATGatewayAddressAllocations.
+func (mr *MockInterfaceMockRecorder) GetNATGatewayAddressAllocations(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNATGatewayAddressAllocations", reflect.TypeOf((*MockInterface)(nil).GetNATGatewayAddressAllocations), arg0, arg1)
 }
 
 // GetVPCAttribute mocks base method.

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -16,6 +16,8 @@ package client
 
 import (
 	"context"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -34,6 +36,8 @@ type Interface interface {
 	GetAccountID(ctx context.Context) (string, error)
 	GetVPCInternetGateway(ctx context.Context, vpcID string) (string, error)
 	GetVPCAttribute(ctx context.Context, vpcID string, attribute string) (bool, error)
+	GetElasticIPsAssociationIDForAllocationIDs(ctx context.Context, allocationIDs []string) (map[string]*string, error)
+	GetNATGatewayAddressAllocations(ctx context.Context, shootNamespace string) (sets.String, error)
 
 	// S3 wrappers
 	DeleteObjectsWithPrefix(ctx context.Context, bucket, prefix string) error

--- a/pkg/controller/infrastructure/configvalidator.go
+++ b/pkg/controller/infrastructure/configvalidator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
 	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/common"
 	"github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
@@ -76,6 +77,22 @@ func (c *configValidator) Validate(ctx context.Context, infra *extensionsv1alpha
 		allErrs = append(allErrs, c.validateVPC(ctx, awsClient, *config.Networks.VPC.ID, field.NewPath("networks", "vpc", "id"))...)
 	}
 
+	var (
+		eips      []string
+		eipToZone = make(map[string]string)
+	)
+
+	for _, zone := range config.Networks.Zones {
+		if zone.ElasticIPAllocationID != nil {
+			eips = append(eips, *zone.ElasticIPAllocationID)
+			eipToZone[*zone.ElasticIPAllocationID] = zone.Name
+		}
+	}
+
+	if len(eips) > 0 {
+		allErrs = append(allErrs, c.validateEIPS(ctx, awsClient, infra.Namespace, eips, eipToZone, field.NewPath("networks", "zones[]", "elasticIPAllocationID"))...)
+	}
+
 	return allErrs
 }
 
@@ -106,6 +123,59 @@ func (c *configValidator) validateVPC(ctx context.Context, awsClient awsclient.I
 	}
 	if internetGatewayID == "" {
 		allErrs = append(allErrs, field.Invalid(fldPath, vpcID, "no attached internet gateway found"))
+	}
+
+	return allErrs
+}
+
+// validateEIP validates if the given elastic IP exists and can be associated by the Shoot's NAT gateway
+// An EIP can be associated with the Shoot when
+//  - it is not associated yet (new)
+//  - it is already associated to any Gardener-created NAT Gateway of the Shoot cluster (identified by tag `kubernetes.io/cluster/<shoot-name>`)
+func (c *configValidator) validateEIPS(ctx context.Context, awsClient awsclient.Interface, shootNamespace string, elasticIPAllocationIDs []string, elasticIPAllocationIDToZone map[string]string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	mapping, err := awsClient.GetElasticIPsAssociationIDForAllocationIDs(ctx, elasticIPAllocationIDs)
+	if err != nil {
+		allErrs = append(allErrs, field.InternalError(fldPath, fmt.Errorf("failed to list Elastic IPs: %w", err)))
+		return allErrs
+	}
+
+	var associatedEips []string
+	for _, allocationID := range elasticIPAllocationIDs {
+		associationId, ok := mapping[allocationID]
+		if !ok {
+			allErrs = append(allErrs, field.Invalid(fldPath, allocationID, fmt.Sprintf("elastic IP in zone %q cannot be used as it does not exist. Please make sure the elastic IPs configured in the Infrastructure configuration (field: `elasticIPAllocationID`) exist.", elasticIPAllocationIDToZone[allocationID])))
+			continue
+		}
+
+		// EIP found, but not associated to any resource yet --> new.
+		// no further checks needed as this Elastic IPs is freely available to be associated with the NAT Gateway of the Shoot
+		if associationId == nil {
+			continue
+		}
+
+		associatedEips = append(associatedEips, allocationID)
+	}
+
+	if len(associatedEips) == 0 {
+		return allErrs
+	}
+
+	// check if the existing and already associated Elastic IPs are associated with NAT Gateways in the VPC of the Shoot
+	allocationIDsNATGateway, err := awsClient.GetNATGatewayAddressAllocations(ctx, shootNamespace)
+	if err != nil {
+		allErrs = append(allErrs, field.InternalError(fldPath, fmt.Errorf("failed to list existing address allocations for NAT Gateways: %w", err)))
+		return allErrs
+	}
+
+	diff := sets.NewString(associatedEips...).Difference(allocationIDsNATGateway)
+	if diff.Len() == 0 {
+		return allErrs
+	}
+
+	for _, allocationID := range diff.List() {
+		allErrs = append(allErrs, field.Invalid(fldPath, allocationID, fmt.Sprintf("elastic IP in zone %q cannot be attached to the clusters NAT Gateway(s) as it is already associated. Please make sure the elastic IPs configured in the Infrastructure configuration (field: `elasticIPAllocationID`) are not already attached to another AWS resource.", elasticIPAllocationIDToZone[allocationID])))
 	}
 
 	return allErrs

--- a/pkg/controller/infrastructure/configvalidator_test.go
+++ b/pkg/controller/infrastructure/configvalidator_test.go
@@ -190,7 +190,6 @@ var _ = Describe("ConfigValidator", func() {
 
 		Describe("validate Elastic IP addresses", func() {
 			BeforeEach(func() {
-				infra.ClusterName = "cluster-1"
 				infra.Spec.ProviderConfig.Raw = encode(&apisaws.InfrastructureConfig{
 					Networks: apisaws.Networks{
 						VPC: apisaws.VPC{},
@@ -226,7 +225,7 @@ var _ = Describe("ConfigValidator", func() {
 					"eipalloc-0e2669d4b46150ee6": pointer.String("eipassoc-0f8ff66536587824d"),
 				}
 				awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, gomock.Any()).Return(mapping, nil)
-				awsClient.EXPECT().GetNATGatewayAddressAllocations(ctx, infra.ClusterName).Return(sets.NewString("eipalloc-0e2669d4b46150ee4", "eipalloc-0e2669d4b46150ee5", "eipalloc-0e2669d4b46150ee6"), nil)
+				awsClient.EXPECT().GetNATGatewayAddressAllocations(ctx, infra.Namespace).Return(sets.NewString("eipalloc-0e2669d4b46150ee4", "eipalloc-0e2669d4b46150ee5", "eipalloc-0e2669d4b46150ee6"), nil)
 
 				errorList := cv.Validate(ctx, infra)
 				Expect(errorList).To(BeEmpty())
@@ -245,7 +244,7 @@ var _ = Describe("ConfigValidator", func() {
 			})
 
 			It("should fail - the Elastic IP Address for the given allocation ID does not exist", func() {
-				empty := make(map[string]*string, 0)
+				empty := make(map[string]*string)
 				awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, []string{"eipalloc-0e2669d4b46150ee4", "eipalloc-0e2669d4b46150ee5", "eipalloc-0e2669d4b46150ee6"}).Return(empty, nil)
 
 				errorList := cv.Validate(ctx, infra)
@@ -274,7 +273,7 @@ var _ = Describe("ConfigValidator", func() {
 					"eipalloc-0e2669d4b46150ee5": pointer.String("eipassoc-0f8ff66536587824c"),
 				}
 				awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, gomock.Any()).Return(mapping, nil)
-				awsClient.EXPECT().GetNATGatewayAddressAllocations(ctx, infra.ClusterName).Return(sets.NewString("eipalloc-0e2669d4b46150ee4", "eipalloc-0e2669d4b46150ee5"), nil)
+				awsClient.EXPECT().GetNATGatewayAddressAllocations(ctx, infra.Namespace).Return(sets.NewString("eipalloc-0e2669d4b46150ee4", "eipalloc-0e2669d4b46150ee5"), nil)
 
 				errorList := cv.Validate(ctx, infra)
 				Expect(errorList).To(ConsistOfFields(Fields{
@@ -292,7 +291,7 @@ var _ = Describe("ConfigValidator", func() {
 					"eipalloc-0e2669d4b46150ee6": pointer.String("eipassoc-0f8ff66536587824d"),
 				}
 				awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, gomock.Any()).Return(mapping, nil)
-				awsClient.EXPECT().GetNATGatewayAddressAllocations(ctx, infra.ClusterName).Return(sets.NewString("eipalloc-0e2669d4b46150ee4", "eipalloc-0e2669d4b46150ee5"), nil)
+				awsClient.EXPECT().GetNATGatewayAddressAllocations(ctx, infra.Namespace).Return(sets.NewString("eipalloc-0e2669d4b46150ee4", "eipalloc-0e2669d4b46150ee5"), nil)
 
 				errorList := cv.Validate(ctx, infra)
 				Expect(errorList).To(ConsistOfFields(Fields{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/platform aws

**What this PR does / why we need it**:
- checks if the specified EIPs exist
- checks if the EIP is already associated to another AWS resource and thus cannot be associated with the NAT Gateway of the Cluster

**Which issue(s) this PR fixes**:
Fixes #429

**Special notes for your reviewer**:

I tried to test all scenarios locally (with / without EIP, reconcile, add invalid EIP, update EIP).
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Specified Elastic IP addresses are now validated: must exist & must not be already associated with another AWS resource.
```
