### PR TITLE
Upgrade terraformer to v2.13.0, a version that uses terraform 0.13

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-aws
-  tag: "v2.12.1"
+  tag: "v2.13.1"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -86,15 +86,16 @@ func NewClient(accessKeyID, secretAccessKey, region string) (*Client, error) {
 	}
 
 	return &Client{
-		EC2:                ec2.New(s, config),
-		ELB:                elb.New(s, config),
-		ELBv2:              elbv2.New(s, config),
-		IAM:                iam.New(s, config),
-		STS:                sts.New(s, config),
-		S3:                 s3.New(s, config),
-		Route53:            route53.New(s, config),
-		Route53RateLimiter: rate.NewLimiter(rate.Inf, 0),
-		Logger:             log.Log.WithName("aws-client"),
+		EC2:                           ec2.New(s, config),
+		ELB:                           elb.New(s, config),
+		ELBv2:                         elbv2.New(s, config),
+		IAM:                           iam.New(s, config),
+		STS:                           sts.New(s, config),
+		S3:                            s3.New(s, config),
+		Route53:                       route53.New(s, config),
+		Route53RateLimiter:            rate.NewLimiter(rate.Inf, 0),
+		Route53RateLimiterWaitTimeout: 1 * time.Second,
+		Logger:                        log.Log.WithName("aws-client"),
 	}, nil
 }
 

--- a/test/integration/dnsrecord/dnsrecord_test.go
+++ b/test/integration/dnsrecord/dnsrecord_test.go
@@ -139,7 +139,8 @@ var _ = Describe("DNSRecord tests", func() {
 
 		Expect(dnsrecordctrl.AddToManagerWithOptions(mgr, dnsrecordctrl.AddOptions{
 			RateLimiter: dnsrecordctrl.RateLimiterOptions{
-				Limit: rate.Inf,
+				Limit:       rate.Inf,
+				WaitTimeout: 1 * time.Second,
 			},
 		})).To(Succeed())
 


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Upgrades `terraformer` image to v2.13.0, a version that uses `terraform` 0.13.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:

``` other operator github.com/gardener/terraformer #105 @stoyanr
terraform has been upgraded to 0.13.7
```
