### PR TITLE
Upgrade terraformer to a version that uses terraform 0.14

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-aws
-  tag: "v2.12.1"
+  tag: "v2.14.0"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Upgrades `terraformer` image to a version that uses `terraform` 0.14 (see gardener/terraformer/pull/106).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR has been created mainly to validate the new terraformer version before it's released.

**Release note**:

```other operator
The `terraformer` image has been upgraded to a version that uses `terraform` 0.14.
```
