### PR TITLE
Upgrade terraformer to a version that uses terraform 0.15

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-aws
-  tag: "v2.13.0-dev-26820af821db1acb9bbc8086d6562c67babb472f"
+  tag: "v2.13.0-dev-45dd48fcb2ee896a0b21d32f72f7ce4dd87d78fa"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-aws
-  tag: "v2.13.0-dev-45dd48fcb2ee896a0b21d32f72f7ce4dd87d78fa"
+  tag: "v2.13.0-dev-29839f245b50f64835adaaf4b469a67b2e6bf5f1"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-aws
-  tag: "v2.12.0"
+  tag: "v2.13.0-dev-26820af821db1acb9bbc8086d6562c67babb472f"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Upgrades `terraformer` image to a version that uses `terraform` 0.15 (see gardener/terraformer/pull/107).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR has been created mainly to validate the new terraformer version before it's released.

**Release note**:

```other operator
The `terraformer` image has been upgraded to a version that uses `terraform` 0.15.
```
