### PR TITLE
[ci:component:github.com/gardener/terraformer:v2.12.0->v2.12.1]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-aws
-  tag: "v2.12.0"
+  tag: "v2.12.1"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes


### PR DESCRIPTION
**Release Notes**:
``` other operator github.com/gardener/terraformer #110 @ialidzhikov
The following terraform provider plugins are updated:
- hashicorp/terraform-provider-aws: 3.63.0 -> 3.66.0
```