### PR TITLE
Remove awsmachineclass cleanup

### DIFF
--- a/charts/internal/machineclass/Chart.yaml
+++ b/charts/internal/machineclass/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
-description: A Helm chart for AWSMachineClasses controlled by the machine-controller-manager in the shoot cluster
+description: A Helm chart for MachineClasses controlled by the machine-controller-manager in the shoot cluster
 name: machineclass
 version: 0.1.0

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -61,11 +61,6 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 		}
 	}
 
-	// Delete any older version of AWSMachineClass CRs.
-	if err := w.Client().DeleteAllOf(ctx, &machinev1alpha1.AWSMachineClass{}, client.InNamespace(w.worker.Namespace)); err != nil {
-		return fmt.Errorf("cleaning up older version of AWS machine class CRs failed: %w", err)
-	}
-
 	return w.seedChartApplier.Apply(ctx, filepath.Join(aws.InternalChartsPath, "machineclass"), w.worker.Namespace, "machineclass", kubernetes.Values(map[string]interface{}{"machineClasses": w.machineClasses}))
 }
 

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -48,12 +48,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	ctx = context.TODO()
-)
+var ctx = context.TODO()
 
 var _ = Describe("Machines", func() {
 	var (
@@ -670,19 +667,12 @@ var _ = Describe("Machines", func() {
 					workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
 
 					// Test workerDelegate.DeployMachineClasses()
-
-					gomock.InOrder(
-						c.EXPECT().
-							DeleteAllOf(context.TODO(), &machinev1alpha1.AWSMachineClass{}, client.InNamespace(namespace)),
-						chartApplier.
-							EXPECT().
-							Apply(
-								ctx,
-								filepath.Join(aws.InternalChartsPath, "machineclass"),
-								namespace,
-								"machineclass",
-								kubernetes.Values(machineClasses),
-							),
+					chartApplier.EXPECT().Apply(
+						ctx,
+						filepath.Join(aws.InternalChartsPath, "machineclass"),
+						namespace,
+						"machineclass",
+						kubernetes.Values(machineClasses),
 					)
 
 					err := workerDelegate.DeployMachineClasses(ctx)
@@ -722,26 +712,6 @@ var _ = Describe("Machines", func() {
 					Expect(result).To(Equal(machineDeployments))
 				})
 
-				It("should delete the all old AWSMachineClasses", func() {
-					workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
-					gomock.InOrder(
-						c.EXPECT().
-							DeleteAllOf(context.TODO(), &machinev1alpha1.AWSMachineClass{}, client.InNamespace(namespace)),
-						chartApplier.
-							EXPECT().
-							Apply(
-								ctx,
-								filepath.Join(aws.InternalChartsPath, "machineclass"),
-								namespace,
-								"machineclass",
-								kubernetes.Values(machineClasses),
-							),
-					)
-
-					err := workerDelegate.DeployMachineClasses(context.TODO())
-					Expect(err).NotTo(HaveOccurred())
-				})
-
 				Context("using workerConfig.iamInstanceProfile", func() {
 					modifyExpectedMachineClasses := func(expectedIamInstanceProfile map[string]interface{}) {
 						newHash, err := worker.WorkerPoolHash(w.Spec.Pools[1], cluster)
@@ -771,18 +741,12 @@ var _ = Describe("Machines", func() {
 
 						workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
 
-						gomock.InOrder(
-							c.EXPECT().
-								DeleteAllOf(context.TODO(), &machinev1alpha1.AWSMachineClass{}, client.InNamespace(namespace)),
-							chartApplier.
-								EXPECT().
-								Apply(
-									ctx,
-									filepath.Join(aws.InternalChartsPath, "machineclass"),
-									namespace,
-									"machineclass",
-									kubernetes.Values(machineClasses),
-								),
+						chartApplier.EXPECT().Apply(
+							ctx,
+							filepath.Join(aws.InternalChartsPath, "machineclass"),
+							namespace,
+							"machineclass",
+							kubernetes.Values(machineClasses),
 						)
 
 						Expect(workerDelegate.DeployMachineClasses(context.TODO())).NotTo(HaveOccurred())
@@ -799,18 +763,12 @@ var _ = Describe("Machines", func() {
 
 						workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
 
-						gomock.InOrder(
-							c.EXPECT().
-								DeleteAllOf(context.TODO(), &machinev1alpha1.AWSMachineClass{}, client.InNamespace(namespace)),
-							chartApplier.
-								EXPECT().
-								Apply(
-									ctx,
-									filepath.Join(aws.InternalChartsPath, "machineclass"),
-									namespace,
-									"machineclass",
-									kubernetes.Values(machineClasses),
-								),
+						chartApplier.EXPECT().Apply(
+							ctx,
+							filepath.Join(aws.InternalChartsPath, "machineclass"),
+							namespace,
+							"machineclass",
+							kubernetes.Values(machineClasses),
 						)
 
 						Expect(workerDelegate.DeployMachineClasses(context.TODO())).NotTo(HaveOccurred())
@@ -821,17 +779,6 @@ var _ = Describe("Machines", func() {
 					// Deliberately setting InfrastructureProviderStatus to empty
 					w.Spec.InfrastructureProviderStatus = &runtime.RawExtension{}
 					workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
-
-					err := workerDelegate.DeployMachineClasses(context.TODO())
-					Expect(err).To(HaveOccurred())
-				})
-
-				It("should not delete the any of old AWSMachineClasses as DeleteAll call returns error", func() {
-					workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
-
-					c.EXPECT().
-						DeleteAllOf(context.TODO(), &machinev1alpha1.AWSMachineClass{}, client.InNamespace(namespace)).
-						Return(fmt.Errorf("fake error"))
 
 					err := workerDelegate.DeployMachineClasses(context.TODO())
 					Expect(err).To(HaveOccurred())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup
/platform aws

**What this PR does / why we need it**:
Removes AWSMachineClass cleanup

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Removes the cleanup for the older AWSMachineclasses during worker reconciliation.
```
