### PR TITLE
Prevent nil pointer dereference in admission-aws

### DIFF
--- a/pkg/apis/aws/validation/infrastructure.go
+++ b/pkg/apis/aws/validation/infrastructure.go
@@ -158,8 +158,12 @@ func ValidateInfrastructureConfig(infra *apisaws.InfrastructureConfig, nodesCIDR
 
 	// make sure that VPC cidrs don't overlap with each other
 	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(cidrs, false)...)
-	allErrs = append(allErrs, pods.ValidateNotOverlap(cidrs...)...)
-	allErrs = append(allErrs, services.ValidateNotOverlap(cidrs...)...)
+	if pods != nil {
+		allErrs = append(allErrs, pods.ValidateNotOverlap(cidrs...)...)
+	}
+	if services != nil {
+		allErrs = append(allErrs, services.ValidateNotOverlap(cidrs...)...)
+	}
 
 	allErrs = append(allErrs, ValidateIgnoreTags(field.NewPath("ignoreTags"), infra.IgnoreTags)...)
 

--- a/pkg/apis/aws/validation/infrastructure_test.go
+++ b/pkg/apis/aws/validation/infrastructure_test.go
@@ -163,6 +163,16 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				}))
 			})
 
+			It("should allow specifying valid config", func() {
+				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should allow specifying valid config with podsCIDR=nil and servicesCIDR=nil", func() {
+				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, nil, nil)
+				Expect(errorList).To(BeEmpty())
+			})
+
 			It("should allow adding the same zone", func() {
 				infrastructureConfig.Networks.Zones = append(infrastructureConfig.Networks.Zones, awsZone2)
 				infrastructureConfig.Networks.Zones[1].Name = zone


### PR DESCRIPTION
/area quality
/kind regression
/platform aws

Similar to https://github.com/gardener/gardener-extension-provider-alicloud/pull/400

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
