### PR TITLE
Update aws-ebs-csi-driver to `v1.5.0`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -54,7 +54,7 @@ images:
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/aws-ebs-csi-driver
   repository: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-  tag: "v1.1.4"
+  tag: "v1.5.0"
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/platform aws

I tested ews-ebs-cs-driver `v1.5.0` with:
1. Dynamic Provisioning
2. CSI Migration
3. Volume Snapshot
4. Volume Resizing
5. Raw block volume

and did not encounter any error.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following image is updated:
- k8s.gcr.io/provider-aws/aws-ebs-csi-driver: v1.1.4 -> v1.5.0 (see [CHANGELOG](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/release-1.5/CHANGELOG-0.x.md))
```
