### PR TITLE
allow gateway endpoints for domain names

### DIFF
--- a/pkg/apis/aws/validation/infrastructure.go
+++ b/pkg/apis/aws/validation/infrastructure.go
@@ -29,6 +29,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+// valid values for networks.vpc.gatewayEndpoints
+var gatewayEndpointPattern = regexp.MustCompile(`^\w+(\.\w+)*$`)
+
 // ValidateInfrastructureConfigAgainstCloudProfile validates the given `InfrastructureConfig` against the given `CloudProfile`.
 func ValidateInfrastructureConfigAgainstCloudProfile(oldInfra, infra *apisaws.InfrastructureConfig, shoot *core.Shoot, cloudProfile *gardencorev1beta1.CloudProfile, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -93,10 +96,9 @@ func ValidateInfrastructureConfig(infra *apisaws.InfrastructureConfig, nodesCIDR
 
 	if len(infra.Networks.VPC.GatewayEndpoints) > 0 {
 		epsPath := networksPath.Child("vpc", "gatewayEndpoints")
-		re := regexp.MustCompile(`^\w+$`)
 		for i, svc := range infra.Networks.VPC.GatewayEndpoints {
-			if !re.MatchString(svc) {
-				allErrs = append(allErrs, field.Invalid(epsPath.Index(i), svc, "must be alphanumeric"))
+			if !gatewayEndpointPattern.MatchString(svc) {
+				allErrs = append(allErrs, field.Invalid(epsPath.Index(i), svc, "must be a valid domain name"))
 			}
 		}
 	}

--- a/pkg/apis/aws/validation/infrastructure_test.go
+++ b/pkg/apis/aws/validation/infrastructure_test.go
@@ -389,12 +389,12 @@ var _ = Describe("InfrastructureConfig validation", func() {
 					"Type":     Equal(field.ErrorTypeInvalid),
 					"Field":    Equal("networks.vpc.gatewayEndpoints[1]"),
 					"BadValue": Equal("my-endpoint"),
-					"Detail":   Equal("must be alphanumeric"),
+					"Detail":   Equal("must be a valid domain name"),
 				}))
 			})
 
 			It("should accept all-valid lists", func() {
-				infrastructureConfig.Networks.VPC.GatewayEndpoints = []string{"myservice", "s3"}
+				infrastructureConfig.Networks.VPC.GatewayEndpoints = []string{"myservice", "s3", "my.other.service"}
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
 				Expect(errorList).To(BeEmpty())
 			})


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/kind api-change
/platform aws

**What this PR does / why we need it**:

Currently the extension allows defining gateway endpoints as single identifiers suffixes only, e..g `com.amazonaws.eu-central-1.s3`, although AWS allows the gateway endpoint suffix to be a general subdomain.

This change allows defining VPC Gateway Endpoint for general subdomains, e.g. CodeArtifact endpoints like
`com.amazonaws.eu-central-1.codeartifact.api`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Allow defining VPC Gateway Endpoints for subdomains with dots, e.g. com.amazonaws.eu-central-1.codeartifact.api
```
