### PR TITLE
Increase aws_route_table creation timeout from 2m to 5m

### DIFF
--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -62,6 +62,10 @@ resource "aws_vpc_endpoint" "vpc_gwep_{{ $ep }}" {
 resource "aws_route_table" "routetable_main" {
   vpc_id = {{ .vpc.id }}
 
+  timeouts {
+    create = "5m"
+  }
+
 {{ commonTags .clusterName | indent 2 }}
 }
 
@@ -243,6 +247,10 @@ resource "aws_nat_gateway" "natgw_z{{ $index }}" {
 
 resource "aws_route_table" "routetable_private_utility_z{{ $index }}" {
   vpc_id = {{ $.vpc.id }}
+
+  timeouts {
+    create = "5m"
+  }
 
 {{ commonTagsWithSuffix $.clusterName (print "private-" $zone.name) | indent 2 }}
 }


### PR DESCRIPTION
/area quality
/kind bug
/platform aws

For accounts that host large amount of Shoots the default aws_route_table creation timeout (`2m`) can be not enough in some cases. In such AWS accounts we see that the route table creation cannot complete for `2m` and this leads to consistency issues (the concrete upstream issue is https://github.com/hashicorp/terraform-provider-aws/issues/21829).
In terraform-provider-aws > 3.70.0 to mitigate/fix this consistency issue the default aws_route_table creation timeout was increased to `5m` (as done in this PR).
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html#eventual-consistency also mentions that the wait time should be up to 5m.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The creation timeouts of `aws_route_table`s are now increased from `2m` to `5m`.
```
