### PR TITLE
[release-v1.32] Automated cherry pick of #473: Increase aws_route_table creation timeout from 2m to 5m

### DIFF
--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -62,6 +62,10 @@ resource "aws_vpc_endpoint" "vpc_gwep_{{ $ep }}" {
 resource "aws_route_table" "routetable_main" {
   vpc_id = {{ .vpc.id }}
 
+  timeouts {
+    create = "5m"
+  }
+
 {{ commonTags .clusterName | indent 2 }}
 }
 
@@ -243,6 +247,10 @@ resource "aws_nat_gateway" "natgw_z{{ $index }}" {
 
 resource "aws_route_table" "routetable_private_utility_z{{ $index }}" {
   vpc_id = {{ $.vpc.id }}
+
+  timeouts {
+    create = "5m"
+  }
 
 {{ commonTagsWithSuffix $.clusterName (print "private-" $zone.name) | indent 2 }}
 }


### PR DESCRIPTION
/area/quality
/kind/bug

Cherry pick of #473 on release-v1.32.

#473: Increase aws_route_table creation timeout from 2m to 5m

**Release Notes:**
```bugfix operator
The creation timeouts of `aws_route_table`s are now increased from `2m` to `5m`.
```