### PR TITLE
Fix the infrastructure integration test

### DIFF
--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -343,7 +343,7 @@ var _ = Describe("Infrastructure tests", func() {
 			Expect(err).To(MatchError(ContainSubstring("error validating provider credentials")))
 			var errorWithCode *gardencorev1beta1helper.ErrorWithCodes
 			Expect(errors.As(err, &errorWithCode)).To(BeTrue())
-			Expect(errorWithCode.Codes()).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthorized))
+			Expect(errorWithCode.Codes()).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthorized, gardencorev1beta1.ErrorInfraInsufficientPrivileges))
 		})
 	})
 })


### PR DESCRIPTION
/area testing
/kind regression
/platform aws

```
• Failure [40.112 seconds]
Infrastructure tests
/go/src/github.com/gardener/gardener-extension-provider-aws/test/integration/infrastructure/infrastructure_test.go:95
  with invalid credentials
  /go/src/github.com/gardener/gardener-extension-provider-aws/test/integration/infrastructure/infrastructure_test.go:253
    should fail creation but succeed deletion [It]
    /go/src/github.com/gardener/gardener-extension-provider-aws/test/integration/infrastructure/infrastructure_test.go:254

    Expected
        <[]v1beta1.ErrorCode | len:2, cap:2>: [
            "ERR_INFRA_INSUFFICIENT_PRIVILEGES",
            "ERR_INFRA_UNAUTHORIZED",
        ]
    to consist of
        <[]v1beta1.ErrorCode | len:1, cap:1>: [
            "ERR_INFRA_UNAUTHORIZED",
        ]
    the extra elements were
        <[]v1beta1.ErrorCode | len:1, cap:1>: [
            "ERR_INFRA_INSUFFICIENT_PRIVILEGES",
        ]
```

Regressed after https://github.com/gardener/gardener-extension-provider-aws/pull/478

Related to https://github.com/gardener/gardener/pull/5221.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
