### PR TITLE
Fix instance terminated check

### DIFF
--- a/pkg/controller/bastion/actuator_delete.go
+++ b/pkg/controller/bastion/actuator_delete.go
@@ -122,13 +122,13 @@ func instanceIsTerminated(ctx context.Context, awsClient *awsclient.Client, opt 
 
 	for _, reservation := range instances.Reservations {
 		for _, instance := range reservation.Instances {
-			if *instance.State.Code == InstanceStateTerminated {
-				return true, nil
+			if *instance.State.Code != InstanceStateTerminated {
+				return false, nil
 			}
 		}
 	}
 
-	return false, nil
+	return true, nil
 }
 
 func removeBastionInstance(ctx context.Context, logger logr.Logger, awsClient *awsclient.Client, opt *Options) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
This PR fixes an issue / edge case where the bastion instance is not considered terminated when it is already cleaned up. This causes the bastion resource to never be cleaned up and must be cleaned up by hand:
- delete the [bastion security group](https://github.com/gardener/gardener-extension-provider-aws/blob/be02e4cfa70af128a225491e0aed3458e75c99c9/pkg/controller/bastion/actuator_delete.go#L162-L183)
- remove the finalizer on the bastion extension resource on the seed
- confirm that also the bastion resource on the garden cluster is removed

Alternatively, run the `gardener-extension-provider-aws` that includes this fix which will then proceed with the cleanup.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bufix operator
Fixed an edge case where the bastion instance is not considered terminated in case it is already cleaned up
```
