### PR TITLE
Classify duplicate and overlapping zones as configuration errors

### DIFF
--- a/pkg/aws/client/client_route53.go
+++ b/pkg/aws/client/client_route53.go
@@ -17,7 +17,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -342,37 +341,4 @@ func ignoreHostedZoneNotFound(err error) error {
 		return nil
 	}
 	return err
-}
-
-func isValuesDoNotMatchError(err error) bool {
-	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == route53.ErrCodeInvalidChangeBatch && strings.Contains(aerr.Message(), "the values provided do not match the current values") {
-		return true
-	}
-	return false
-}
-
-// IsNoSuchHostedZoneError returns true if the error indicates a non-existing route53 hosted zone.
-func IsNoSuchHostedZoneError(err error) bool {
-	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == route53.ErrCodeNoSuchHostedZone {
-		return true
-	}
-	return false
-}
-
-var notPermittedInZoneRegex = regexp.MustCompile(`RRSet with DNS name [^\ ]+ is not permitted in zone [^\ ]+`)
-
-// IsNotPermittedInZoneError returns true if the error indicates that the DNS name is not permitted in the route53 hosted zone.
-func IsNotPermittedInZoneError(err error) bool {
-	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == route53.ErrCodeInvalidChangeBatch && notPermittedInZoneRegex.MatchString(aerr.Message()) {
-		return true
-	}
-	return false
-}
-
-// IsThrottlingError returns true if the error is a throttling error.
-func IsThrottlingError(err error) bool {
-	if aerr, ok := err.(awserr.Error); ok && strings.Contains(aerr.Message(), "Throttling") {
-		return true
-	}
-	return false
 }

--- a/pkg/aws/client/errors.go
+++ b/pkg/aws/client/errors.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/route53"
+)
+
+func isValuesDoNotMatchError(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == route53.ErrCodeInvalidChangeBatch && strings.Contains(aerr.Message(), "the values provided do not match the current values") {
+		return true
+	}
+	return false
+}
+
+// IsNoSuchHostedZoneError returns true if the error indicates a non-existing route53 hosted zone.
+func IsNoSuchHostedZoneError(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == route53.ErrCodeNoSuchHostedZone {
+		return true
+	}
+	return false
+}
+
+var notPermittedInZoneRegex = regexp.MustCompile(`RRSet with DNS name [^\ ]+ is not permitted in zone [^\ ]+`)
+
+// IsNotPermittedInZoneError returns true if the error indicates that the DNS name is not permitted in the route53 hosted zone.
+func IsNotPermittedInZoneError(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == route53.ErrCodeInvalidChangeBatch && notPermittedInZoneRegex.MatchString(aerr.Message()) {
+		return true
+	}
+	return false
+}
+
+// IsThrottlingError returns true if the error is a throttling error.
+func IsThrottlingError(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok && strings.Contains(aerr.Message(), "Throttling") {
+		return true
+	}
+	return false
+}
+
+// IsDuplicateZonesError returns true if the error indicates that the DNS hosted zones already exists.
+func IsDuplicateZonesError(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok && strings.Contains(aerr.Message(), "duplicate zones") {
+		return true
+	}
+	return false
+}
+
+// IsOverlappingZonesError returns true if the error indicates that there are overlapping DNS hosted zones.
+func IsOverlappingZonesError(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok && strings.Contains(aerr.Message(), "overlapping zones") {
+		return true
+	}
+	return false
+}

--- a/pkg/controller/dnsrecord/actuator.go
+++ b/pkg/controller/dnsrecord/actuator.go
@@ -173,7 +173,7 @@ func getRegion(dns *extensionsv1alpha1.DNSRecord, credentials *aws.Credentials) 
 
 func wrapAWSClientError(err error, message string) error {
 	wrappedErr := fmt.Errorf("%s: %+v", message, err)
-	if awsclient.IsNoSuchHostedZoneError(err) || awsclient.IsNotPermittedInZoneError(err) {
+	if isConfigurationError(err) {
 		wrappedErr = gardencorev1beta1helper.NewErrorWithCodes(wrappedErr.Error(), gardencorev1beta1.ErrorConfigurationProblem)
 	}
 	if _, ok := err.(*awsclient.Route53RateLimiterWaitError); ok || awsclient.IsThrottlingError(err) {
@@ -183,4 +183,11 @@ func wrapAWSClientError(err error, message string) error {
 		}
 	}
 	return wrappedErr
+}
+
+func isConfigurationError(err error) bool {
+	return awsclient.IsNoSuchHostedZoneError(err) ||
+		awsclient.IsNotPermittedInZoneError(err) ||
+		awsclient.IsDuplicateZonesError(err) ||
+		awsclient.IsOverlappingZonesError(err)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area ops-productivity
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR classifies DNS errors that have "duplicate zones" or "overlapping zones" in their error message as ERR_CONFIGURATION_PROBLEM

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/4844

**Special notes for your reviewer**:
I found out the following error codes that seem describe the duplicate and overlapping zones error but I'm currently testing if that is the case:

https://github.com/gardener/gardener-extension-provider-aws/blob/40348fe6cac55f97bb0051622a4bbd6cdfeb9bee/vendor/github.com/aws/aws-sdk-go/service/route53/errors.go#L14
https://github.com/gardener/gardener-extension-provider-aws/blob/40348fe6cac55f97bb0051622a4bbd6cdfeb9bee/vendor/github.com/aws/aws-sdk-go/service/route53/errors.go#L112

Additionally, they look like possible codes that could be caused by a configuration problem, so perhaps it makes sense to include them anyway.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Error messages containing `duplicate zones` and `overlapping zones` in their description that can happen when creating DNSRecords are now classified as ERR_CONFIGURATION_PROBLEM.
```
