### PR TITLE
Fix serviceaccount defaulting during helm upgrade

### DIFF
--- a/charts/gardener-extension-admission-aws/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-aws/charts/runtime/templates/deployment.yaml
@@ -24,9 +24,13 @@ spec:
       {{- if not .Values.global.virtualGarden.enabled }}
       serviceAccountName: {{ include "name" . }}
       {{- else if and .Values.global.virtualGarden.enabled .Values.global.virtualGarden.user.name }}
-      {{- if .Values.global.serviceAccountTokenVolumeProjection.enabled }}
+        {{- if .Values.global.serviceAccountTokenVolumeProjection.enabled }}
       serviceAccountName: {{ include "name" . }}
-      {{- end }}
+        {{- else }}
+      serviceAccountName: default
+        {{- end }}
+      {{- else }}
+      serviceAccountName: default
       {{- end }}
       {{- if .Values.global.kubeconfig }}
       automountServiceAccountToken: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/platform aws

**What this PR does / why we need it**:
This PR explicitly sets the `default` serviceaccount to the `admission` deployment when its own serviceaccount is not required.
Fixes a bug which occurs when the `admission` component is deployed with a serviceaccount and then upgraded with `helm upgrade` and `values.yaml` that do not require the serviceaccount anymore. What happens is that the serviceaccount is deleted and `helm` patches the deployment by sending `serviceAccountName: nil`, but there is a duplicate field named `serviceAccount` (deprecated by k8s) which holds the old `serviceAccountName` value and Kubernetes defaults `serviceAccountName` to it. This prevents the upgrade because the said serviceaccount does not exist in the cluster anymore but it is required by the deployment spec.

By explicitly defaulting the `serviceAccountName` field Kubernetes will use what is written there and not default implicitly to what is written in the `serviceAccount` field.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
