### PR TITLE
Fix csi-driver-controller Deployment

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-deployment.yaml
@@ -224,6 +224,8 @@ spec:
           mountPath: /csi
 
       volumes:
+      - name: socket-dir
+        emptyDir: {}
       {{- if .Values.global.useTokenRequestor }}
       - name: kubeconfig-csi-attacher
         projected:
@@ -290,8 +292,6 @@ spec:
                 name: shoot-access-csi-resizer
                 optional: false
       {{- else }}
-      - name: socket-dir
-        emptyDir: {}
       - name: csi-provisioner
         secret:
           secretName: csi-provisioner


### PR DESCRIPTION
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/kind regression
/platform aws

Regressed with https://github.com/gardener/gardener-extension-provider-aws/pull/467

The seed-controlplane chart fails to be applied with:
```
    lastError:
      description: 'Error reconciling controlplane: could not apply control plane
        chart for controlplane ''shoot--foo--testy/testy'': could not apply chart
        ''seed-controlplane'' in namespace ''shoot--foo--testy'': failed to apply
        manifests: 1 error occurred: could not apply object of kind "Deployment" "shoot--foo--testy/csi-driver-controller":
        Deployment.apps "csi-driver-controller" is invalid: [spec.template.spec.containers[0].volumeMounts[0].name:
        Not found: "socket-dir", spec.template.spec.containers[1].volumeMounts[0].name:
        Not found: "socket-dir", spec.template.spec.containers[2].volumeMounts[0].name:
        Not found: "socket-dir", spec.template.spec.containers[3].volumeMounts[0].name:
        Not found: "socket-dir", spec.template.spec.containers[4].volumeMounts[0].name:
        Not found: "socket-dir", spec.template.spec.containers[5].volumeMounts[0].name:
        Not found: "socket-dir"]'
      lastUpdateTime: "2022-02-17T15:39:12Z"
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
