### PR TITLE
Vendor gardener/gardener@v1.40.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.38.19
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/gardener/etcd-druid v0.7.0
-	github.com/gardener/gardener v1.40.1
+	github.com/gardener/gardener v1.40.2
 	github.com/gardener/machine-controller-manager v0.42.0
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/gardener/gardener v1.6.5/go.mod h1:w5IHIQDccvSxZJFOtBa8YConyyFgt07DBH
 github.com/gardener/gardener v1.11.3/go.mod h1:5DzqfOm+G8UftKu5zUbYJ+9Cnfd4XrvRNDabkM9AIp4=
 github.com/gardener/gardener v1.17.1/go.mod h1:uucRHq0xV46xd9MpJJjRswx/Slq3+ipbbJg09FVUtvM=
 github.com/gardener/gardener v1.23.0/go.mod h1:xS/sYyzYsq2W0C79mT98G/qoOTvy/hHTfApHIVF3v2o=
-github.com/gardener/gardener v1.40.1 h1:mmzp94Mo7W+CLUolXMjmMZJyosIC88OJHAy+Cj64cgY=
-github.com/gardener/gardener v1.40.1/go.mod h1:lIao8ImIqVztkLy7soQRZ/73+mvndN0XGhSfhaIU+Y8=
+github.com/gardener/gardener v1.40.2 h1:L5UZl/pu0gG8C14glckeOU4ChDvCE6m9RYLjVplqGuk=
+github.com/gardener/gardener v1.40.2/go.mod h1:lIao8ImIqVztkLy7soQRZ/73+mvndN0XGhSfhaIU+Y8=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/gardener-resource-manager v0.13.1/go.mod h1:0No/XttYRUwDn5lSppq9EqlKdo/XJQ44aCZz5BVu3Vw=
 github.com/gardener/gardener-resource-manager v0.18.0/go.mod h1:k53Yw2iDAIpTxnChQY9qFHrRtuPQWJDNnCP9eE6TnWQ=

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -143,7 +143,9 @@ func (a *genericActuator) restoreMachineSetsAndMachines(ctx context.Context, log
 			// Calling Update() would include the whole MachineStatus in the request - including fields of type metav1.Time causing the mentioned issues.
 			patch := client.MergeFrom(newMachine.DeepCopy())
 			newMachine.Status.Node = machine.Status.Node
-			return a.client.Status().Patch(ctx, newMachine, patch)
+			if err := a.client.Status().Patch(ctx, newMachine, patch); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -114,7 +114,7 @@ github.com/gardener/etcd-druid/api/v1alpha1
 # github.com/gardener/external-dns-management v0.7.18
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
-# github.com/gardener/gardener v1.40.1
+# github.com/gardener/gardener v1.40.2
 ## explicit
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE


### PR DESCRIPTION
/kind bug
/platform aws

Compared to `gardener/gardener@v1.40.1`, `gardener/gardener@v1.40.2` contains the following fix that is related to the extension library:
- https://github.com/gardener/gardener/pull/5474

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
