### PR TITLE
Add object selector for provider type in the `gardener-extension-admission-aws` webhook

### DIFF
--- a/charts/gardener-extension-admission-aws/charts/application/templates/validatingwebhook-validator.yaml
+++ b/charts/gardener-extension-admission-aws/charts/application/templates/validatingwebhook-validator.yaml
@@ -18,7 +18,10 @@ webhooks:
     - shoots
   failurePolicy: Fail
   objectSelector:
-    {{- toYaml (default (dict) .Values.global.webhookConfig.objectSelector) | nindent 4 }}
+    {{- if .Values.global.webhookConfig.useObjectSelector }}
+    matchLabels:
+      provider.extensions.gardener.cloud/aws: "true"
+    {{- end }}
   namespaceSelector: {}
   sideEffects: None
   admissionReviewVersions:

--- a/charts/gardener-extension-admission-aws/charts/application/templates/validatingwebhook-validator.yaml
+++ b/charts/gardener-extension-admission-aws/charts/application/templates/validatingwebhook-validator.yaml
@@ -17,7 +17,8 @@ webhooks:
     - cloudprofiles
     - shoots
   failurePolicy: Fail
-  objectSelector: {}
+  objectSelector:
+    {{- toYaml (default (dict) .Values.global.webhookConfig.objectSelector) | nindent 4 }}
   namespaceSelector: {}
   sideEffects: None
   admissionReviewVersions:

--- a/charts/gardener-extension-admission-aws/values.yaml
+++ b/charts/gardener-extension-admission-aws/values.yaml
@@ -32,7 +32,8 @@ global:
         -----BEGIN RSA PRIVATE KEY-----
         ...
         -----END RSA PRIVATE KEY-----
-    # useObjectSelector: false
+    # Please make sure you are running `gardener@v1.42` or later before setting this to true.
+    useObjectSelector: false
   # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
   kubeconfig:
 

--- a/charts/gardener-extension-admission-aws/values.yaml
+++ b/charts/gardener-extension-admission-aws/values.yaml
@@ -32,6 +32,9 @@ global:
         -----BEGIN RSA PRIVATE KEY-----
         ...
         -----END RSA PRIVATE KEY-----
+    # objectSelector:
+    #   matchLabels:
+    #     provider.extensions.gardener.cloud/aws: "true"
   # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
   kubeconfig:
 

--- a/charts/gardener-extension-admission-aws/values.yaml
+++ b/charts/gardener-extension-admission-aws/values.yaml
@@ -32,9 +32,7 @@ global:
         -----BEGIN RSA PRIVATE KEY-----
         ...
         -----END RSA PRIVATE KEY-----
-    # objectSelector:
-    #   matchLabels:
-    #     provider.extensions.gardener.cloud/aws: "true"
+    # useObjectSelector: false
   # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
   kubeconfig:
 

--- a/example/40-validatingwebhookconfiguration.yaml
+++ b/example/40-validatingwebhookconfiguration.yaml
@@ -17,7 +17,10 @@ webhooks:
     - shoots
     - cloudprofiles
   failurePolicy: Fail
-  objectSelector: {}
+  # Please make sure you are running `gardener@v1.42` or later before enabling this object selector.
+  objectSelector:
+    matchLabels:
+      provider.extensions.gardener.cloud/aws: "true"
   namespaceSelector: {}
   sideEffects: None
   admissionReviewVersions:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR adds an object selector for provider type label in the `gardener-extension-admission-aws` webhook. This helps in filtering out only resources having provider type `aws` for validation,

**Which issue(s) this PR fixes**:
Fixes part of gardener/gardener#4932

**Special notes for your reviewer**:
Related to gardener/gardener#5472

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `gardener-extension-admission-aws` webhook now contains an object selector for provider type label. Please make sure you are running `gardener@v1.42` or later before enabling this.
```
