### PR TITLE
Add snaphot validation webhook

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -72,6 +72,10 @@ images:
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/csi-snapshotter
   tag: "v3.0.3"
+- name: csi-snapshot-validation-webhook
+  sourceRepository: github.com/kubernetes-csi/external-snapshotter
+  repository: k8s.gcr.io/sig-storage/snapshot-validation-webhook
+  tag: "v3.0.3"
 - name: csi-resizer
   sourceRepository: github.com/kubernetes-csi/external-resizer
   repository: k8s.gcr.io/sig-storage/csi-resizer

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: csi-snapshot-validation
   namespace: {{ .Release.Namespace }}
   labels:
-    app: snapshot-validationxs
+    app: snapshot-validation
 spec:
   replicas: {{ .Values.csiSnapshotValidationWebhook.replicas }}
   selector:

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-deployment.yaml
@@ -4,8 +4,7 @@ metadata:
   name: csi-snapshot-validation
   namespace: {{ .Release.Namespace }}
   labels:
-    app: snapshot-validation
-    role: webhook
+    app: snapshot-validationxs
 spec:
   replicas: {{ .Values.csiSnapshotValidationWebhook.replicas }}
   selector:

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-snapshot-validation
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: snapshot-validation
+    role: webhook
+spec:
+  replicas: {{ .Values.csiSnapshotValidationWebhook.replicas }}
+  selector:
+    matchLabels:
+      app: snapshot-validation
+  template:
+    metadata:
+      annotations:
+{{- if .Values.csiSnapshotValidationWebhook.podAnnotations }}
+{{ toYaml .Values.csiSnapshotValidationWebhook.podAnnotations | indent 8 }}
+{{- end }}
+      labels:
+        app: snapshot-validation
+        networking.gardener.cloud/from-shoot-apiserver: allowed
+    spec:
+      containers:
+      - name: csi-snapshot-validation
+        image: {{ index .Values.images "csi-snapshot-validation-webhook" }}
+        imagePullPolicy: IfNotPresent
+        args: ['--tls-cert-file=/etc/csi-snapshot-validation/csi-snapshot-validation.crt', '--tls-private-key-file=etc/csi-snapshot-validation/csi-snapshot-validation.key']
+        ports:
+        - containerPort: 443
+{{- if .Values.csiSnapshotValidationWebhook.resources }}
+        resources:
+{{ toYaml .Values.csiSnapshotValidationWebhook.resources | indent 10 }}
+{{- end }}
+        volumeMounts:
+          - name: csi-snapshot-validation
+            mountPath: /etc/csi-snapshot-validation
+            readOnly: true
+      volumes:
+        - name: csi-snapshot-validation
+          secret:
+            secretName: csi-snapshot-validation

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-networkpolicy.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: snapshot-validation
+    gardener.cloud/role: controlplane
+  name: allow-kube-apiserver-to-csi-snapshot-validation
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    gardener.cloud/description: "Allows Egress from shoot's kube-apiserver pods to csi-snapshot-validation pods."
+spec:
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app: snapshot-validation
+  podSelector:
+    matchLabels:
+      app: kubernetes
+      gardener.cloud/role: controlplane
+      role: apiserver
+  policyTypes:
+  - Egress

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-service.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: csi-snapshot-validation
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app: snapshot-validation
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 443

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-vpa.yaml
@@ -1,0 +1,17 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: csi-snapshot-webhook-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: csi-snapshot-validation
+      minAllowed:
+        memory: 25Mi
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: csi-snapshot-validation
+  updatePolicy:
+    updateMode: Auto

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
@@ -9,6 +9,7 @@ images:
   csi-resizer: image-repository:image-tag
   csi-liveness-probe: image-repository:image-tag
   csi-snapshot-controller: image-repository:image-tag
+  csi-snapshot-validation-webhook: image-repository:image-tag
 
 socketPath: /var/lib/csi/sockets/pluginproxy
 region: region
@@ -67,3 +68,13 @@ csiSnapshotController:
     limits:
       cpu: 30m
       memory: 50Mi
+
+csiSnapshotValidationWebhook:
+  replica: 1
+  podAnnotations: {}
+  resources:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    cpu: 30m
+    memory: 50Mi

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/csi-snaphot-validation-webhook.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/csi-snaphot-validation-webhook.yaml
@@ -1,0 +1,19 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: csi-snapshot-validation
+webhooks:
+- name: "validation-webhook.snapshot.storage.k8s.io"
+  rules:
+  - apiGroups:   ["snapshot.storage.k8s.io"]
+    apiVersions: ["v1", "v1beta1"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["volumesnapshots", "volumesnapshotcontents"]
+    scope:       "*"
+  clientConfig:
+    url:  {{ required ".Values.webhookConfig.url is required" .Values.webhookConfig.url }}
+    caBundle: {{ required ".Values.webhookConfig.caBundle is required" .Values.webhookConfig.caBundle | b64enc }}
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  failurePolicy: Fail
+  timeoutSeconds: 10

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/csi-snaphot-validation-webhook.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/csi-snaphot-validation-webhook.yaml
@@ -5,13 +5,13 @@ metadata:
 webhooks:
 - name: "validation-webhook.snapshot.storage.k8s.io"
   rules:
-  - apiGroups:   ["snapshot.storage.k8s.io"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
     apiVersions: ["v1", "v1beta1"]
-    operations:  ["CREATE", "UPDATE"]
-    resources:   ["volumesnapshots", "volumesnapshotcontents"]
-    scope:       "*"
+    operations: ["CREATE", "UPDATE"]
+    resources: ["volumesnapshots", "volumesnapshotcontents"]
+    scope: "*"
   clientConfig:
-    url:  {{ required ".Values.webhookConfig.url is required" .Values.webhookConfig.url }}
+    url: {{ required ".Values.webhookConfig.url is required" .Values.webhookConfig.url }}
     caBundle: {{ required ".Values.webhookConfig.caBundle is required" .Values.webhookConfig.caBundle | b64enc }}
   admissionReviewVersions: ["v1", "v1beta1"]
   sideEffects: None

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -9,6 +9,13 @@ vpaEnabled: false
 driver: {}
   # volumeAttachLimit: -1
 
+webhookConfig:
+  url: https://service-name.service-namespace/volumesnapshot
+  caBundle: |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+
 resources:
   driver:
     requests:

--- a/pkg/aws/types.go
+++ b/pkg/aws/types.go
@@ -48,7 +48,7 @@ const (
 	CSINodeDriverRegistrarImageName = "csi-node-driver-registrar"
 	// CSILivenessProbeImageName is the name of the csi-liveness-probe image.
 	CSILivenessProbeImageName = "csi-liveness-probe"
-	//CSISnapshotValidationWebhookImageName is the name of the csi-snapshot-validation-webhook image.
+	// CSISnapshotValidationWebhookImageName is the name of the csi-snapshot-validation-webhook image.
 	CSISnapshotValidationWebhookImageName = "csi-snapshot-validation-webhook"
 
 	// MachineControllerManagerImageName is the name of the MachineControllerManager image.

--- a/pkg/aws/types.go
+++ b/pkg/aws/types.go
@@ -48,6 +48,8 @@ const (
 	CSINodeDriverRegistrarImageName = "csi-node-driver-registrar"
 	// CSILivenessProbeImageName is the name of the csi-liveness-probe image.
 	CSILivenessProbeImageName = "csi-liveness-probe"
+	//CSISnapshotValidationWebhookImageName is the name of the csi-snapshot-validation-webhook image.
+	CSISnapshotValidationWebhookImageName = "csi-snapshot-validation-webhook"
 
 	// MachineControllerManagerImageName is the name of the MachineControllerManager image.
 	MachineControllerManagerImageName = "machine-controller-manager"
@@ -122,6 +124,8 @@ const (
 	CSILivenessProbeName = "csi-liveness-probe"
 	// LBReadvertiserDeploymentName is the constant for the name of the AWS LB Readvertiser deployment
 	LBReadvertiserDeploymentName = "aws-lb-readvertiser"
+	// CSISnapshotValidation is the constant for the name of the csi-snapshot-validation-webhook component.
+	CSISnapshotValidation = "csi-snapshot-validation"
 )
 
 var (

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -24,6 +24,7 @@ import (
 	apisaws "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
@@ -38,8 +39,10 @@ import (
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/version"
 	"github.com/go-logr/logr"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -70,6 +73,15 @@ func getSecretConfigsFuncs(useTokenRequestor bool) secrets.Interface {
 						Name:       cloudControllerManagerServerName,
 						CommonName: aws.CloudControllerManagerName,
 						DNSNames:   kutil.DNSNamesForService(aws.CloudControllerManagerName, clusterName),
+						CertType:   secrets.ServerCert,
+						SigningCA:  cas[v1beta1constants.SecretNameCACluster],
+					},
+				},
+				&secrets.ControlPlaneSecretConfig{
+					CertificateSecretConfig: &secrets.CertificateSecretConfig{
+						Name:       aws.CSISnapshotValidation,
+						CommonName: aws.UsernamePrefix + aws.CSISnapshotValidation,
+						DNSNames:   kutil.DNSNamesForService(aws.CSISnapshotValidation, clusterName),
 						CertType:   secrets.ServerCert,
 						SigningCA:  cas[v1beta1constants.SecretNameCACluster],
 					},
@@ -269,6 +281,7 @@ var (
 					aws.CSIResizerImageName,
 					aws.CSILivenessProbeImageName,
 					aws.CSISnapshotControllerImageName,
+					aws.CSISnapshotValidationWebhookImageName,
 				},
 				Objects: []*chart.Object{
 					// csi-driver-controller
@@ -278,6 +291,10 @@ var (
 					// csi-snapshot-controller
 					{Type: &appsv1.Deployment{}, Name: aws.CSISnapshotControllerName},
 					{Type: &autoscalingv1beta2.VerticalPodAutoscaler{}, Name: aws.CSISnapshotControllerName + "-vpa"},
+					//csi-snapshot-validation-webhook
+					{Type: &appsv1.Deployment{}, Name: aws.CSISnapshotValidation},
+					{Type: &corev1.Service{}, Name: aws.CSISnapshotValidation},
+					{Type: &networkingv1.NetworkPolicy{}, Name: "allow-kube-apiserver-to-csi-snapshot-validation"},
 				},
 			},
 		},
@@ -336,6 +353,8 @@ var (
 					{Type: &rbacv1.ClusterRoleBinding{}, Name: aws.UsernamePrefix + aws.CSIResizerName},
 					{Type: &rbacv1.Role{}, Name: aws.UsernamePrefix + aws.CSIResizerName},
 					{Type: &rbacv1.RoleBinding{}, Name: aws.UsernamePrefix + aws.CSIResizerName},
+					//csi-snapshot-validation-webhook
+					{Type: &admissionregistrationv1.ValidatingWebhookConfiguration{}, Name: aws.CSISnapshotValidation},
 				},
 			},
 		},
@@ -429,12 +448,12 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by the generic actuator.
 func (vp *valuesProvider) GetControlPlaneShootChartValues(
-	_ context.Context,
-	_ *extensionsv1alpha1.ControlPlane,
+	c context.Context,
+	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	_ map[string]string,
 ) (map[string]interface{}, error) {
-	return getControlPlaneShootChartValues(cluster, vp.useTokenRequestor, vp.useProjectedTokenMount)
+	return getControlPlaneShootChartValues(c, cluster, cp, vp.Client(), vp.useTokenRequestor, vp.useProjectedTokenMount)
 }
 
 // GetControlPlaneShootCRDsChartValues returns the values for the control plane shoot CRDs chart applied by the generic actuator.
@@ -637,12 +656,21 @@ func getCSIControllerChartValues(
 				"checksum/secret-" + aws.CSISnapshotControllerName: checksums[aws.CSISnapshotControllerName],
 			},
 		},
+		"csiSnapshotValidationWebhook": map[string]interface{}{
+			"replicas": extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
+			"podAnnotations": map[string]interface{}{
+				"checksum/secret-" + aws.CSISnapshotValidation: checksums[aws.CSISnapshotValidation],
+			},
+		},
 	}, nil
 }
 
 // getControlPlaneShootChartValues collects and returns the control plane shoot chart values.
 func getControlPlaneShootChartValues(
+	c context.Context,
 	cluster *extensionscontroller.Cluster,
+	cp *extensionsv1alpha1.ControlPlane,
+	client client.Client,
 	useTokenRequestor bool,
 	useProjectedTokenMount bool,
 ) (
@@ -655,10 +683,20 @@ func getControlPlaneShootChartValues(
 		return nil, err
 	}
 
+	// get the ca.crt for caBundle of the snapshot-validation webhook
+	secret := &corev1.Secret{}
+	if err := client.Get(c, kutil.Key(cluster.ObjectMeta.Name, string(secrets.CACert)), secret); err != nil {
+		return nil, err
+	}
+
 	csiDriverNodeValues := map[string]interface{}{
 		"enabled":           csiEnabled,
 		"kubernetesVersion": kubernetesVersion,
 		"vpaEnabled":        gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot),
+		"webhookConfig": map[string]interface{}{
+			"url":      "https://" + aws.CSISnapshotValidation + "." + cluster.ObjectMeta.Name + "/volumesnapshot",
+			"caBundle": string(secret.Data["ca.crt"]),
+		},
 	}
 
 	if value, ok := cluster.Shoot.Annotations[aws.VolumeAttachLimit]; ok {

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -448,12 +448,12 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by the generic actuator.
 func (vp *valuesProvider) GetControlPlaneShootChartValues(
-	c context.Context,
+	ctx context.Context,
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	_ map[string]string,
 ) (map[string]interface{}, error) {
-	return getControlPlaneShootChartValues(c, cluster, cp, vp.Client(), vp.useTokenRequestor, vp.useProjectedTokenMount)
+	return getControlPlaneShootChartValues(ctx, cluster, cp, vp.Client(), vp.useTokenRequestor, vp.useProjectedTokenMount)
 }
 
 // GetControlPlaneShootCRDsChartValues returns the values for the control plane shoot CRDs chart applied by the generic actuator.
@@ -667,7 +667,7 @@ func getCSIControllerChartValues(
 
 // getControlPlaneShootChartValues collects and returns the control plane shoot chart values.
 func getControlPlaneShootChartValues(
-	c context.Context,
+	ctx context.Context,
 	cluster *extensionscontroller.Cluster,
 	cp *extensionsv1alpha1.ControlPlane,
 	client client.Client,
@@ -685,7 +685,7 @@ func getControlPlaneShootChartValues(
 
 	// get the ca.crt for caBundle of the snapshot-validation webhook
 	secret := &corev1.Secret{}
-	if err := client.Get(c, kutil.Key(cluster.ObjectMeta.Name, string(secrets.CACert)), secret); err != nil {
+	if err := client.Get(ctx, kutil.Key(cluster.ObjectMeta.Name, string(secrets.CACert)), secret); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -24,7 +24,6 @@ import (
 	apisaws "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
@@ -50,6 +49,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Object names
@@ -291,7 +291,7 @@ var (
 					// csi-snapshot-controller
 					{Type: &appsv1.Deployment{}, Name: aws.CSISnapshotControllerName},
 					{Type: &autoscalingv1beta2.VerticalPodAutoscaler{}, Name: aws.CSISnapshotControllerName + "-vpa"},
-					//csi-snapshot-validation-webhook
+					// csi-snapshot-validation-webhook
 					{Type: &appsv1.Deployment{}, Name: aws.CSISnapshotValidation},
 					{Type: &corev1.Service{}, Name: aws.CSISnapshotValidation},
 					{Type: &networkingv1.NetworkPolicy{}, Name: "allow-kube-apiserver-to-csi-snapshot-validation"},
@@ -353,7 +353,7 @@ var (
 					{Type: &rbacv1.ClusterRoleBinding{}, Name: aws.UsernamePrefix + aws.CSIResizerName},
 					{Type: &rbacv1.Role{}, Name: aws.UsernamePrefix + aws.CSIResizerName},
 					{Type: &rbacv1.RoleBinding{}, Name: aws.UsernamePrefix + aws.CSIResizerName},
-					//csi-snapshot-validation-webhook
+					// csi-snapshot-validation-webhook
 					{Type: &admissionregistrationv1.ValidatingWebhookConfiguration{}, Name: aws.CSISnapshotValidation},
 				},
 			},
@@ -453,7 +453,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 	cluster *extensionscontroller.Cluster,
 	_ map[string]string,
 ) (map[string]interface{}, error) {
-	return getControlPlaneShootChartValues(ctx, cluster, cp, vp.Client(), vp.useTokenRequestor, vp.useProjectedTokenMount)
+	return getControlPlaneShootChartValues(ctx, cluster, vp.Client(), vp.useTokenRequestor, vp.useProjectedTokenMount)
 }
 
 // GetControlPlaneShootCRDsChartValues returns the values for the control plane shoot CRDs chart applied by the generic actuator.
@@ -669,7 +669,6 @@ func getCSIControllerChartValues(
 func getControlPlaneShootChartValues(
 	ctx context.Context,
 	cluster *extensionscontroller.Cluster,
-	cp *extensionsv1alpha1.ControlPlane,
 	client client.Client,
 	useTokenRequestor bool,
 	useProjectedTokenMount bool,
@@ -685,7 +684,7 @@ func getControlPlaneShootChartValues(
 
 	// get the ca.crt for caBundle of the snapshot-validation webhook
 	secret := &corev1.Secret{}
-	if err := client.Get(ctx, kutil.Key(cluster.ObjectMeta.Name, string(secrets.CACert)), secret); err != nil {
+	if err := client.Get(ctx, kutil.Key(cluster.ObjectMeta.Name, string(v1beta1constants.SecretNameCACluster)), secret); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -300,7 +300,7 @@ var _ = Describe("ValuesProvider", func() {
 		})
 
 		It("should return correct shoot control plane chart values (k8s < 1.18)", func() {
-			c.EXPECT().Get(ctx, kutil.Key(cp.ClusterName, string(v1beta1constants.SecretNameCACluster)), gomock.AssignableToTypeOf(&corev1.Secret{}))
+			c.EXPECT().Get(ctx, kutil.Key(cp.Namespace, string(v1beta1constants.SecretNameCACluster)), gomock.AssignableToTypeOf(&corev1.Secret{}))
 			values, err := vp.GetControlPlaneShootChartValues(ctx, cp, clusterK8sLessThan118, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{
@@ -313,7 +313,7 @@ var _ = Describe("ValuesProvider", func() {
 					"kubernetesVersion": "1.15.4",
 					"vpaEnabled":        false,
 					"webhookConfig": map[string]interface{}{
-						"url":      "https://" + aws.CSISnapshotValidation + "." + cp.ClusterName + "/volumesnapshot",
+						"url":      "https://" + aws.CSISnapshotValidation + "." + cp.Namespace + "/volumesnapshot",
 						"caBundle": "",
 					},
 				}),
@@ -322,13 +322,13 @@ var _ = Describe("ValuesProvider", func() {
 
 		Context("shoot control plane chart values (k8s >= 1.18)", func() {
 			It("should return error when ca secret is not found", func() {
-				c.EXPECT().Get(ctx, kutil.Key(cp.ClusterName, string(v1beta1constants.SecretNameCACluster)), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
+				c.EXPECT().Get(ctx, kutil.Key(cp.Namespace, string(v1beta1constants.SecretNameCACluster)), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
 				_, err := vp.GetControlPlaneShootChartValues(ctx, cp, clusterK8sAtLeast118, nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should return correct shoot control plane chart when ca is secret found", func() {
-				c.EXPECT().Get(ctx, kutil.Key(cp.ClusterName, string(v1beta1constants.SecretNameCACluster)), gomock.AssignableToTypeOf(&corev1.Secret{}))
+				c.EXPECT().Get(ctx, kutil.Key(cp.Namespace, string(v1beta1constants.SecretNameCACluster)), gomock.AssignableToTypeOf(&corev1.Secret{}))
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, clusterK8sAtLeast118, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
@@ -344,7 +344,7 @@ var _ = Describe("ValuesProvider", func() {
 							"volumeAttachLimit": "42",
 						},
 						"webhookConfig": map[string]interface{}{
-							"url":      "https://" + aws.CSISnapshotValidation + "." + cp.ClusterName + "/volumesnapshot",
+							"url":      "https://" + aws.CSISnapshotValidation + "." + cp.Namespace + "/volumesnapshot",
 							"caBundle": "",
 						},
 					}),

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -79,6 +79,11 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 				PreCheckFunc:  csiEnabledPreCheckFunc,
 			},
 			{
+				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
+				HealthCheck:   general.NewSeedDeploymentHealthChecker(aws.CSISnapshotValidation),
+				PreCheckFunc:  csiEnabledPreCheckFunc,
+			},
+			{
 				ConditionType: string(gardencorev1beta1.ShootSystemComponentsHealthy),
 				HealthCheck:   general.CheckManagedResource(genericcontrolplaneactuator.ControlPlaneShootChartResourceName),
 			},

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -79,7 +79,7 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 				HealthCheck:   general.NewSeedDeploymentHealthChecker(aws.CSISnapshotControllerName),
 				PreCheckFunc:  csiEnabledPreCheckFunc,
 			},
-			// TODO(acumino): Enable this health check in future release
+			// TODO(acumino): Enable this health check in v1.36.
 			// {
 			// 	ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
 			// 	HealthCheck:   general.NewSeedDeploymentHealthChecker(aws.CSISnapshotValidation),

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -30,6 +30,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/version"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -78,11 +79,12 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 				HealthCheck:   general.NewSeedDeploymentHealthChecker(aws.CSISnapshotControllerName),
 				PreCheckFunc:  csiEnabledPreCheckFunc,
 			},
-			{
-				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
-				HealthCheck:   general.NewSeedDeploymentHealthChecker(aws.CSISnapshotValidation),
-				PreCheckFunc:  csiEnabledPreCheckFunc,
-			},
+			// TODO(acumino): Enable this health check in future release
+			// {
+			// 	ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
+			// 	HealthCheck:   general.NewSeedDeploymentHealthChecker(aws.CSISnapshotValidation),
+			// 	PreCheckFunc:  csiEnabledPreCheckFunc,
+			// },
 			{
 				ConditionType: string(gardencorev1beta1.ShootSystemComponentsHealthy),
 				HealthCheck:   general.CheckManagedResource(genericcontrolplaneactuator.ControlPlaneShootChartResourceName),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR adds the webhook to provide additional validation to volume snapshot objects i.e. `VolumeSnapshot` and `VolumeSnapshotContent`.

**Which issue(s) this PR fixes**:
Fixes #489

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The provider-aws extension now installs the external-snapshotter's validating webhook server for VolumeSnapshot and VolumeSnapshotContent objects. For more details check the corresponding [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1900-volume-snapshot-validation-webhook#kep-1900-add-additional-validation-to-volume-snapshot-objects).
```
