### PR TITLE
Use projected token mount for terraformer

### DIFF
--- a/cmd/gardener-extension-provider-aws/app/app.go
+++ b/cmd/gardener-extension-provider-aws/app/app.go
@@ -198,6 +198,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				controllercmd.LogErrAndExit(err, "Could not determine whether service account token volume projection should be used")
 			}
 			awscontrolplane.DefaultAddOptions.UseProjectedTokenMount = useProjectedTokenMount
+			awsinfrastructure.DefaultAddOptions.UseProjectedTokenMount = useProjectedTokenMount
 			awsworker.DefaultAddOptions.UseProjectedTokenMount = useProjectedTokenMount
 
 			// add common meta types to schema for controller-runtime to use v1.ListOptions

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -37,7 +37,7 @@ import (
 
 func (a *actuator) Delete(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, _ *extensionscontroller.Cluster) error {
 	logger := a.logger.WithValues("infrastructure", client.ObjectKeyFromObject(infrastructure), "operation", "delete")
-	return Delete(ctx, logger, a.RESTConfig(), a.Client(), a.Decoder(), infrastructure)
+	return Delete(ctx, logger, a.RESTConfig(), a.Client(), a.Decoder(), infrastructure, a.useProjectedTokenMount)
 }
 
 // Delete deletes the given Infrastructure.
@@ -48,6 +48,7 @@ func Delete(
 	c client.Client,
 	decoder runtime.Decoder,
 	infrastructure *extensionsv1alpha1.Infrastructure,
+	useProjectedTokenMount bool,
 ) error {
 	infrastructureConfig := &awsapi.InfrastructureConfig{}
 	if _, _, err := decoder.Decode(infrastructure.Spec.ProviderConfig.Raw, nil, infrastructureConfig); err != nil {
@@ -58,7 +59,7 @@ func Delete(
 		infrastructureConfig = nil
 	}
 
-	tf, err := newTerraformer(logger, restConfig, aws.TerraformerPurposeInfra, infrastructure)
+	tf, err := newTerraformer(logger, restConfig, aws.TerraformerPurposeInfra, infrastructure, useProjectedTokenMount)
 	if err != nil {
 		return fmt.Errorf("could not create the Terraformer: %+v", err)
 	}

--- a/pkg/controller/infrastructure/actuator_migrate.go
+++ b/pkg/controller/infrastructure/actuator_migrate.go
@@ -30,17 +30,17 @@ import (
 // Migrate deletes only the ConfigMaps and Secrets of the Terraformer.
 func (a *actuator) Migrate(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, _ *extensionscontroller.Cluster) error {
 	logger := a.logger.WithValues("infrastructure", client.ObjectKeyFromObject(infrastructure), "operation", "migrate")
-	return migrate(ctx, logger, a.RESTConfig(), a.Client(), infrastructure)
+	return migrate(ctx, logger, a.RESTConfig(), infrastructure, a.useProjectedTokenMount)
 }
 
 func migrate(
 	ctx context.Context,
 	logger logr.Logger,
 	restConfig *rest.Config,
-	c client.Client,
 	infrastructure *extensionsv1alpha1.Infrastructure,
+	useProjectedTokenMount bool,
 ) error {
-	tf, err := newTerraformer(logger, restConfig, aws.TerraformerPurposeInfra, infrastructure)
+	tf, err := newTerraformer(logger, restConfig, aws.TerraformerPurposeInfra, infrastructure, useProjectedTokenMount)
 	if err != nil {
 		return fmt.Errorf("could not create the Terraformer: %+v", err)
 	}

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -38,7 +38,15 @@ import (
 
 func (a *actuator) Reconcile(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, _ *extensionscontroller.Cluster) error {
 	logger := a.logger.WithValues("infrastructure", client.ObjectKeyFromObject(infrastructure), "operation", "reconcile")
-	infrastructureStatus, state, err := Reconcile(ctx, logger, a.RESTConfig(), a.Client(), a.Decoder(), infrastructure, terraformer.StateConfigMapInitializerFunc(terraformer.CreateState))
+	infrastructureStatus, state, err := Reconcile(
+		ctx,
+		logger,
+		a.RESTConfig(),
+		a.Client(),
+		a.Decoder(),
+		infrastructure, terraformer.StateConfigMapInitializerFunc(terraformer.CreateState),
+		a.useProjectedTokenMount,
+	)
 	if err != nil {
 		return err
 	}
@@ -54,6 +62,7 @@ func Reconcile(
 	decoder runtime.Decoder,
 	infrastructure *extensionsv1alpha1.Infrastructure,
 	stateInitializer terraformer.StateConfigMapInitializer,
+	useProjectedTokenMount bool,
 ) (
 	*awsv1alpha1.InfrastructureStatus,
 	*terraformer.RawState,
@@ -79,7 +88,7 @@ func Reconcile(
 		return nil, nil, fmt.Errorf("could not render Terraform template: %+v", err)
 	}
 
-	tf, err := newTerraformer(logger, restConfig, aws.TerraformerPurposeInfra, infrastructure)
+	tf, err := newTerraformer(logger, restConfig, aws.TerraformerPurposeInfra, infrastructure, useProjectedTokenMount)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not create terraformer object: %+v", err)
 	}

--- a/pkg/controller/infrastructure/actuator_restore.go
+++ b/pkg/controller/infrastructure/actuator_restore.go
@@ -31,7 +31,16 @@ func (a *actuator) Restore(ctx context.Context, infrastructure *extensionsv1alph
 	}
 
 	logger := a.logger.WithValues("infrastructure", client.ObjectKeyFromObject(infrastructure), "operation", "restore")
-	infrastructureStatus, state, err := Reconcile(ctx, logger, a.RESTConfig(), a.Client(), a.Decoder(), infrastructure, terraformer.CreateOrUpdateState{State: &terraformState.Data})
+	infrastructureStatus, state, err := Reconcile(
+		ctx,
+		logger,
+		a.RESTConfig(),
+		a.Client(),
+		a.Decoder(),
+		infrastructure,
+		terraformer.CreateOrUpdateState{State: &terraformState.Data},
+		a.useProjectedTokenMount,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/infrastructure/add.go
+++ b/pkg/controller/infrastructure/add.go
@@ -35,13 +35,15 @@ type AddOptions struct {
 	Controller controller.Options
 	// IgnoreOperationAnnotation specifies whether to ignore the operation annotation or not.
 	IgnoreOperationAnnotation bool
+	// UseProjectedTokenMount specifies whether the projected token mount shall be used for the terraformer.
+	UseProjectedTokenMount bool
 }
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.
 // The opts.Reconciler is being set with a newly instantiated actuator.
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return infrastructure.Add(mgr, infrastructure.AddArgs{
-		Actuator:          NewActuator(),
+		Actuator:          NewActuator(opts.UseProjectedTokenMount),
 		ConfigValidator:   NewConfigValidator(awsclient.FactoryFunc(awsclient.NewInterface), log.Log),
 		ControllerOptions: opts.Controller,
 		Predicates:        infrastructure.DefaultPredicates(opts.IgnoreOperationAnnotation),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR enables projected token mounts for the `terraformer` pods.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#4659
Part of gardener/gardener#4878

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `terraformer` pod deployed as part of shoot control planes is now using auto-rotated `ServiceAccount` tokens when communicating with the seed cluster.
```
