### PR TITLE
Allow projected volumes in PSP

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
@@ -8,6 +8,7 @@ spec:
   allowPrivilegeEscalation: true
   volumes:
   - hostPath
+  - projected
   - secret
   hostNetwork: true
   hostPorts:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug
/platform aws

**What this PR does / why we need it**:
This PR fixes an issue with the CSI-Driver-Controller `DaemonSet` when `shoot.kubernetes.allowPrivilegedContainers: false` is set:

```
Error creating: pods "csi-driver-node-" is forbidden: unable to validate against any pod security policy: [spec.volumes[4]: Invalid value: "projected": projected volumes are not allowed to be used spec.
```

**Special notes for your reviewer**:
/cc @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An issue has been fixed with the `csi-driver-node` PodSecurityPolicy which blocked the creation of new CSI-Driver pods because `projected` volumes are not permitted.
```
