### PR TITLE
Move shoot webhook startup reconciliation into runnable

### DIFF
--- a/cmd/gardener-extension-provider-aws/app/app.go
+++ b/cmd/gardener-extension-provider-aws/app/app.go
@@ -20,21 +20,6 @@ import (
 	"os"
 	"time"
 
-	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	"github.com/gardener/gardener/extensions/pkg/controller"
-	controllercmd "github.com/gardener/gardener/extensions/pkg/controller/cmd"
-	genericcontrolplaneactuator "github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator"
-	"github.com/gardener/gardener/extensions/pkg/controller/worker"
-	"github.com/gardener/gardener/extensions/pkg/util"
-	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
-	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
 	awsinstall "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/install"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
 	awscmd "github.com/gardener/gardener-extension-provider-aws/pkg/cmd"
@@ -48,6 +33,23 @@ import (
 	awsinfrastructure "github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure"
 	awsworker "github.com/gardener/gardener-extension-provider-aws/pkg/controller/worker"
 	awscontrolplaneexposure "github.com/gardener/gardener-extension-provider-aws/pkg/webhook/controlplaneexposure"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	"github.com/gardener/gardener/extensions/pkg/controller"
+	controllercmd "github.com/gardener/gardener/extensions/pkg/controller/cmd"
+	genericcontrolplaneactuator "github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator"
+	"github.com/gardener/gardener/extensions/pkg/controller/worker"
+	"github.com/gardener/gardener/extensions/pkg/util"
+	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/spf13/cobra"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // NewControllerManagerCommand creates a new command for running a AWS provider controller.
@@ -230,12 +232,12 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			awscontrolplane.DefaultAddOptions.ShootWebhooks = shootWebhooks
 
 			// Update shoot webhook configuration in case the webhook server port has changed.
-			c, err := client.New(restOpts.Completed().Config, client.Options{})
-			if err != nil {
-				controllercmd.LogErrAndExit(err, "Error creating client for startup tasks")
-			}
-			if err := genericcontrolplaneactuator.ReconcileShootWebhooksForAllNamespaces(ctx, c, aws.Name, aws.Type, mgr.GetWebhookServer().Port, shootWebhooks); err != nil {
-				controllercmd.LogErrAndExit(err, "Error ensuring shoot webhooks in all namespaces")
+			if err := mgr.Add(&shootWebhookReconciler{
+				restConfig:        restOpts.Completed().Config,
+				webhookServerPort: mgr.GetWebhookServer().Port,
+				shootWebhooks:     shootWebhooks,
+			}); err != nil {
+				controllercmd.LogErrAndExit(err, "Error adding runnable for reconciling shoot webhooks in all namespaces")
 			}
 
 			if err := controllerSwitches.Completed().AddToManager(mgr); err != nil {
@@ -251,4 +253,23 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 	aggOption.AddFlags(cmd.Flags())
 
 	return cmd
+}
+
+type shootWebhookReconciler struct {
+	restConfig        *rest.Config
+	webhookServerPort int
+	shootWebhooks     []admissionregistrationv1.MutatingWebhook
+}
+
+func (s *shootWebhookReconciler) NeedLeaderElection() bool {
+	return true
+}
+
+func (s *shootWebhookReconciler) Start(ctx context.Context) error {
+	client, err := client.New(s.restConfig, client.Options{})
+	if err != nil {
+		return err
+	}
+
+	return genericcontrolplaneactuator.ReconcileShootWebhooksForAllNamespaces(ctx, client, aws.Name, aws.Type, s.webhookServerPort, s.shootWebhooks)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/platform aws

**What this PR does / why we need it**:
This PR moves the shoot webhook reconciliation during startup into a `Runnable` (as suggested in gardener/gardener#5358) and only executes it when the respective instance of the extension was elected as leader.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#5358

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A race condition preventing shoot namespaces from being cleaned up due to orphaned resources has been fixed.
```
