### PR TITLE
Add --version flag for components

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 **
 
 # Exclude folders relevant for build
+!.git/
+!.dockerignore
 !charts/
 !cmd/
 !docs/

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ IMAGE_PREFIX                := $(REGISTRY)/extensions
 REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 HACK_DIR                    := $(REPO_ROOT)/hack
 VERSION                     := $(shell cat "$(REPO_ROOT)/VERSION")
-LD_FLAGS                    := "-w -X github.com/gardener/$(EXTENSION_PREFIX)-$(NAME)/pkg/version.Version=$(IMAGE_TAG)"
+LD_FLAGS                    := "-w $(shell $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION $(EXTENSION_PREFIX))"
 LEADER_ELECTION             := false
 IGNORE_OPERATION_ANNOTATION := true
 
@@ -80,7 +80,7 @@ start-admission:
 
 .PHONY: install
 install:
-	@LD_FLAGS="-w -X github.com/gardener/$(EXTENSION_PREFIX)-$(NAME)/pkg/version.Version=$(VERSION)" \
+	@LD_FLAGS=$(LD_FLAGS) \
 	$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/install.sh ./...
 
 .PHONY: docker-login

--- a/cmd/gardener-extension-admission-aws/app/app.go
+++ b/cmd/gardener-extension-admission-aws/app/app.go
@@ -30,6 +30,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/spf13/cobra"
 	componentbaseconfig "k8s.io/component-base/config"
+	"k8s.io/component-base/version/verflag"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -57,6 +58,8 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 		Use: fmt.Sprintf("admission-%s", provideraws.Type),
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			verflag.PrintAndExitIfRequested()
+
 			if err := aggOption.Complete(); err != nil {
 				return fmt.Errorf("error completing options: %w", err)
 			}
@@ -98,6 +101,7 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 
+	verflag.AddFlags(cmd.Flags())
 	aggOption.AddFlags(cmd.Flags())
 
 	return cmd

--- a/cmd/gardener-extension-provider-aws/app/app.go
+++ b/cmd/gardener-extension-provider-aws/app/app.go
@@ -48,6 +48,7 @@ import (
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -155,6 +156,8 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 		Use: fmt.Sprintf("%s-controller-manager", aws.Name),
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			verflag.PrintAndExitIfRequested()
+
 			if err := aggOption.Complete(); err != nil {
 				return fmt.Errorf("error completing options: %w", err)
 			}
@@ -252,6 +255,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 
+	verflag.AddFlags(cmd.Flags())
 	aggOption.AddFlags(cmd.Flags())
 
 	return cmd

--- a/vendor/k8s.io/component-base/version/verflag/verflag.go
+++ b/vendor/k8s.io/component-base/version/verflag/verflag.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package verflag defines utility functions to handle command line flags
+// related to version of Kubernetes.
+package verflag
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	flag "github.com/spf13/pflag"
+
+	"k8s.io/component-base/version"
+)
+
+type versionValue int
+
+const (
+	VersionFalse versionValue = 0
+	VersionTrue  versionValue = 1
+	VersionRaw   versionValue = 2
+)
+
+const strRawVersion string = "raw"
+
+func (v *versionValue) IsBoolFlag() bool {
+	return true
+}
+
+func (v *versionValue) Get() interface{} {
+	return versionValue(*v)
+}
+
+func (v *versionValue) Set(s string) error {
+	if s == strRawVersion {
+		*v = VersionRaw
+		return nil
+	}
+	boolVal, err := strconv.ParseBool(s)
+	if boolVal {
+		*v = VersionTrue
+	} else {
+		*v = VersionFalse
+	}
+	return err
+}
+
+func (v *versionValue) String() string {
+	if *v == VersionRaw {
+		return strRawVersion
+	}
+	return fmt.Sprintf("%v", bool(*v == VersionTrue))
+}
+
+// The type of the flag as required by the pflag.Value interface
+func (v *versionValue) Type() string {
+	return "version"
+}
+
+func VersionVar(p *versionValue, name string, value versionValue, usage string) {
+	*p = value
+	flag.Var(p, name, usage)
+	// "--version" will be treated as "--version=true"
+	flag.Lookup(name).NoOptDefVal = "true"
+}
+
+func Version(name string, value versionValue, usage string) *versionValue {
+	p := new(versionValue)
+	VersionVar(p, name, value, usage)
+	return p
+}
+
+const versionFlagName = "version"
+
+var (
+	versionFlag = Version(versionFlagName, VersionFalse, "Print version information and quit")
+	programName = "Kubernetes"
+)
+
+// AddFlags registers this package's flags on arbitrary FlagSets, such that they point to the
+// same value as the global flags.
+func AddFlags(fs *flag.FlagSet) {
+	fs.AddFlag(flag.Lookup(versionFlagName))
+}
+
+// PrintAndExitIfRequested will check if the -version flag was passed
+// and, if so, print the version and exit.
+func PrintAndExitIfRequested() {
+	if *versionFlag == VersionRaw {
+		fmt.Printf("%#v\n", version.Get())
+		os.Exit(0)
+	} else if *versionFlag == VersionTrue {
+		fmt.Printf("%s %s\n", programName, version.Get())
+		os.Exit(0)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -925,6 +925,7 @@ k8s.io/code-generator/third_party/forked/golang/reflect
 k8s.io/component-base/config
 k8s.io/component-base/config/v1alpha1
 k8s.io/component-base/version
+k8s.io/component-base/version/verflag
 # k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c
 k8s.io/gengo/args
 k8s.io/gengo/examples/deepcopy-gen/generators


### PR DESCRIPTION
/kind enhancement
/platform aws

For the motivation about this change, see https://github.com/gardener/gardener/issues/2703.

Part of https://github.com/gardener/gardener/issues/2703

**Special notes for your reviewer**:
This change does not support an effective version handling (https://github.com/gardener/gardener/pull/2500), hence `--version` flag on a released docker image won't return the correct version. For example:
```
$ docker run eu.gcr.io/gardener-project/gardener/extensions/provider-alicloud:v1.34.0 --version=raw
version.Info{Major:"1", Minor:"34+", GitVersion:"v1.34.0-dev", GitCommit:"11c81b369b88958e5a37aae7f52e1d6dc421f8b0", GitTreeState:"clean", BuildDate:"2022-03-17T05:24:24+00:00", GoVersion:"go1.17.5", Compiler:"gc", Platform:"linux/amd64"}
```

Note that the version is `v1.34.0-dev` and not `v1.34.0`.
But still, I believe support for this case can be added separately.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
provider-aws and admission-aws components now support `--version` flag that prints the component version information and useful metadata.
```
