### PR TITLE
[release-v1.34] Fix ControlPlane exposure reconciliation

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -225,7 +225,7 @@ func getExposureSecretConfigsFuncs(useTokenRequestor bool) secrets.Interface {
 
 func exposureShootAccessSecretsFunc(namespace string) []*gutil.ShootAccessSecret {
 	return []*gutil.ShootAccessSecret{
-		gutil.NewShootAccessSecret(aws.LBReadvertiserDeploymentName, ""),
+		gutil.NewShootAccessSecret(aws.LBReadvertiserDeploymentName, namespace),
 	}
 }
 


### PR DESCRIPTION
/area quality
/kind bug
/platform aws

@Diaphteiros reported that ControlPlane exposure fails to be created/deleted with error:
```yaml
  lastError:
    description: 'Error deleting controlplane: could not delete control plane exposure
      shoot access secret ''shoot-access-aws-lb-readvertiser'' for controlplane ''shoot--foo--aws/aws-exposure'':
      an empty namespace may not be set when a resource name is provided'
    lastUpdateTime: "2022-04-13T11:08:25Z"
```

We then found out that this issue is fixed in the master branch with a change in https://github.com/gardener/gardener-extension-provider-aws/pull/528.

I am opening this backport/cherry-pick to prevent others hitting this issue.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue preventing ControlPlane exposure to be successfully reconciled is now fixed.
```
