### PR TITLE
Update `aws-ebs-csi-driver` image registry

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -58,7 +58,7 @@ images:
 
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/aws-ebs-csi-driver
-  repository: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+  repository: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
   tag: "v1.5.3"
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind regression
/platform aws

**What this PR does / why we need it**:
With the old registry, the image cannot be pulled:

```
  Warning  Failed     13m (x2 over 14m)     kubelet            Failed to pull image "k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.5.3": rpc error: code = NotFound desc = failed to pull and unpack image "k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.5.3": failed to resolve reference "k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.5.3": k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.5.3: not found
```

**Special notes for your reviewer**:
Ref https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1213

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
