### PR TITLE
Enable the healthchecks for the csi-snapshot-validation Deployment

### DIFF
--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -80,12 +80,11 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 				HealthCheck:   general.NewSeedDeploymentHealthChecker(aws.CSISnapshotControllerName),
 				PreCheckFunc:  csiEnabledPreCheckFunc,
 			},
-			// TODO(acumino): Enable this health check in v1.36.
-			// {
-			// 	ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
-			// 	HealthCheck:   general.NewSeedDeploymentHealthChecker(aws.CSISnapshotValidation),
-			// 	PreCheckFunc:  csiEnabledPreCheckFunc,
-			// },
+			{
+				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
+				HealthCheck:   general.NewSeedDeploymentHealthChecker(aws.CSISnapshotValidation),
+				PreCheckFunc:  csiEnabledPreCheckFunc,
+			},
 			{
 				ConditionType: string(gardencorev1beta1.ShootSystemComponentsHealthy),
 				HealthCheck:   general.CheckManagedResource(genericcontrolplaneactuator.ControlPlaneShootChartResourceName),


### PR DESCRIPTION
Follow-up after https://github.com/gardener/gardener-extension-provider-aws/pull/507

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
