### PR TITLE
Add label to nodes indicating whether node local dns is enabled or not.

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/csimigration"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	genericworkeractuator "github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"
+	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -188,6 +189,7 @@ func (w *workerDelegate) generateMachineConfig() error {
 				deploymentName          = fmt.Sprintf("%s-%s-z%d", w.worker.Namespace, pool.Name, zoneIndex+1)
 				className               = fmt.Sprintf("%s-%s", deploymentName, workerPoolHash)
 				awsCSIDriverTopologyKey = "topology.ebs.csi.aws.com/zone"
+				nodeLocalDNSLabel       = w.cluster.Shoot.Annotations[gardencorev1beta1constants.AnnotationNodeLocalDNS]
 			)
 
 			machineDeployments = append(machineDeployments, worker.MachineDeployment{
@@ -204,7 +206,7 @@ func (w *workerDelegate) generateMachineConfig() error {
 					}
 					// TODO: remove the csi topology label when AWS CSI driver stops using the aws csi topology key - https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/899
 					// add aws csi driver topology label if its not specified
-					return utils.MergeStringMaps(pool.Labels, map[string]string{awsCSIDriverTopologyKey: zone})
+					return utils.MergeStringMaps(pool.Labels, map[string]string{awsCSIDriverTopologyKey: zone, "networking.gardener.cloud/node-local-dns-enabled": nodeLocalDNSLabel})
 				}(),
 				Annotations:          pool.Annotations,
 				Taints:               pool.Taints,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Add label to nodes indicating whether node local dns is enabled or not.

The label will later be used by a node selector to let node local dns components run until
the corresponding nodes are rolled.
The constant values will be changed to proper constants when the new gardener release is
revendored.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Nodes get a label indicating whether node-local-dns is enabled or not.
```
