### PR TITLE
Allowing IOPS for all volume types, removing IOPS range validation

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -298,14 +298,13 @@ nodeTemplate: # (to be specified only if the node capacity would be different fr
 ```
 
 The `.volume.iops` is the number of I/O operations per second (IOPS) that the volume supports.
-For `io1` volume type, this represents the number of IOPS that are provisioned for the volume.
-For `gp2` volume type, this represents the baseline performance of the volume and the rate at which the volume accumulates I/O credits for bursting. For more information about General Purpose SSD baseline performance, I/O credits, and bursting, see Amazon EBS Volume Types (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html) in the Amazon Elastic Compute Cloud User Guide.\
-Constraint: Range is 100-20000 IOPS for `io1` volumes and 100-10000 IOPS for `gp2` volumes.
+For `io1` and `gp3` volume type, this represents the number of IOPS that are provisioned for the volume.
+For `gp2` volume type, this represents the baseline performance of the volume and the rate at which the volume accumulates I/O credits for bursting. For more information about General Purpose SSD baseline performance, I/O credits, IOPS range and bursting, see Amazon EBS Volume Types (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html) in the Amazon Elastic Compute Cloud User Guide.\
+Constraint: IOPS should be a positive value. Validation of IOPS (i.e. whether it is allowed and is in the specified range for a particular volume type) is done on aws side.
 
 The `.dataVolumes` can optionally contain configurations for the data volumes stated in the `Shoot` specification in the `.spec.provider.workers[].dataVolumes` list.
 The `.name` must match to the name of the data volume in the shoot.
-Apart from the `.iops` (which, again, is only valid for `io1` or `gp2` volumes), it is also possible to provide a snapshot ID.
-It allows to [restore the data volume from an existing snapshot](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-restoring-volume.html).
+It is also possible to provide a snapshot ID. It allows to [restore the data volume from an existing snapshot](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-restoring-volume.html).
 
 The `iamInstanceProfile` section allows to specify the IAM instance profile name xor ARN that should be used for this worker pool.
 If not specified, a dedicated IAM instance profile created by the infrastructure controller is used (see above).
@@ -349,7 +348,7 @@ spec:
       volume:
         size: 50Gi
         type: gp2
-    # The following provider config is only valid if the volume type is `io1`.
+    # The following provider config is valid if the volume type is `io1`.
     # providerConfig:
     #   apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
     #   kind: WorkerConfig

--- a/pkg/apis/aws/types_worker.go
+++ b/pkg/apis/aws/types_worker.go
@@ -40,18 +40,18 @@ type WorkerConfig struct {
 // Volume contains configuration for the root disks attached to VMs.
 type Volume struct {
 	// IOPS is the number of I/O operations per second (IOPS) that the volume supports.
-	// For io1 volume type, this represents the number of IOPS that are provisioned for the
+	// For io1 and gp3 volume type, this represents the number of IOPS that are provisioned for the
 	// volume. For gp2 volume type, this represents the baseline performance of the volume and
 	// the rate at which the volume accumulates I/O credits for bursting. For more
 	// information about General Purpose SSD baseline performance, I/O credits,
 	// and bursting, see Amazon EBS Volume Types (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
 	// in the Amazon Elastic Compute Cloud User Guide.
 	//
-	// Constraint: Range is 100-20000 IOPS for io1 volumes and 100-10000 IOPS for
-	// gp2 volumes.
+	// Constraint: Constraint: IOPS should be a positive value.
+	// Validation of IOPS (i.e. whether it is allowed and is in the specified range for a particular volume type) is done on aws side.
 	//
 	// Condition: This parameter is required for requests to create io1 volumes;
-	// it is not used in requests to create gp2, st1, sc1, or standard volumes.
+	// Do not specify it in requests to create gp2, st1, sc1, or standard volumes.
 	IOPS *int64
 }
 
@@ -106,4 +106,6 @@ const (
 	VolumeTypeIO1 VolumeType = "io1"
 	// VolumeTypeGP2 is a constant for the gp2 volume type.
 	VolumeTypeGP2 VolumeType = "gp2"
+	// VolumeTypeGP3 is a constant for the gp3 volume type.
+	VolumeTypeGP3 VolumeType = "gp3"
 )

--- a/pkg/apis/aws/types_worker.go
+++ b/pkg/apis/aws/types_worker.go
@@ -47,7 +47,7 @@ type Volume struct {
 	// and bursting, see Amazon EBS Volume Types (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
 	// in the Amazon Elastic Compute Cloud User Guide.
 	//
-	// Constraint: Constraint: IOPS should be a positive value.
+	// Constraint: IOPS should be a positive value.
 	// Validation of IOPS (i.e. whether it is allowed and is in the specified range for a particular volume type) is done on aws side.
 	//
 	// Condition: This parameter is required for requests to create io1 volumes;

--- a/pkg/apis/aws/validation/worker.go
+++ b/pkg/apis/aws/validation/worker.go
@@ -106,27 +106,15 @@ func validateResourceQuantityValue(key corev1.ResourceName, value resource.Quant
 
 func validateVolumeConfig(volume *apisaws.Volume, volumeType string, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
+	iopsPath := fldPath.Child("iops")
 
 	if volumeType == string(apisaws.VolumeTypeIO1) && (volume == nil || volume.IOPS == nil) {
-		allErrs = append(allErrs, field.Required(fldPath.Child("iops"), fmt.Sprintf("iops must be provided when using %s volumes", apisaws.VolumeTypeIO1)))
+		allErrs = append(allErrs, field.Required(iopsPath, fmt.Sprintf("iops must be provided when using %s volumes", apisaws.VolumeTypeIO1)))
+		return allErrs
 	}
 
-	if volume != nil && volume.IOPS != nil {
-		iopsPath := fldPath.Child("iops")
-
-		switch volumeType {
-		case string(apisaws.VolumeTypeGP2):
-			if *volume.IOPS < 100 || *volume.IOPS > 10000 {
-				allErrs = append(allErrs, field.Forbidden(iopsPath, fmt.Sprintf("range is 100-10000 iops for %s volumes", apisaws.VolumeTypeGP2)))
-			}
-		case string(apisaws.VolumeTypeIO1):
-			if *volume.IOPS < 100 || *volume.IOPS > 20000 {
-				allErrs = append(allErrs, field.Forbidden(iopsPath, fmt.Sprintf("range is 100-20000 iops for %s volumes", apisaws.VolumeTypeIO1)))
-			}
-		default:
-			allErrs = append(allErrs, field.Forbidden(iopsPath, fmt.Sprintf("setting iops is only allowed if volume type is %q or %q", apisaws.VolumeTypeGP2, apisaws.VolumeTypeIO1)))
-		}
+	if volume != nil && volume.IOPS != nil && *volume.IOPS < 0 {
+		allErrs = append(allErrs, field.Forbidden(iopsPath, "iops must be a non negative value"))
 	}
-
 	return allErrs
 }

--- a/pkg/apis/aws/validation/worker.go
+++ b/pkg/apis/aws/validation/worker.go
@@ -107,14 +107,12 @@ func validateResourceQuantityValue(key corev1.ResourceName, value resource.Quant
 func validateVolumeConfig(volume *apisaws.Volume, volumeType string, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	iopsPath := fldPath.Child("iops")
-
-	if volumeType == string(apisaws.VolumeTypeIO1) && (volume == nil || volume.IOPS == nil) {
+	if volume != nil && volume.IOPS != nil {
+		if *volume.IOPS <= 0 {
+			allErrs = append(allErrs, field.Forbidden(iopsPath, "iops must be a positive value"))
+		}
+	} else if volumeType == string(apisaws.VolumeTypeIO1) {
 		allErrs = append(allErrs, field.Required(iopsPath, fmt.Sprintf("iops must be provided when using %s volumes", apisaws.VolumeTypeIO1)))
-		return allErrs
-	}
-
-	if volume != nil && volume.IOPS != nil && *volume.IOPS < 0 {
-		allErrs = append(allErrs, field.Forbidden(iopsPath, "iops must be a non negative value"))
 	}
 	return allErrs
 }

--- a/pkg/apis/aws/validation/worker_test.go
+++ b/pkg/apis/aws/validation/worker_test.go
@@ -36,14 +36,16 @@ var _ = Describe("ValidateWorkerConfig", func() {
 			io1type       = string(apisaws.VolumeTypeIO1)
 			io1iops int64 = 200
 			gp2type       = string(apisaws.VolumeTypeGP2)
-			gp2iops int64 = 400
-			footype       = "foo"
+			gp3type       = string(apisaws.VolumeTypeGP3)
+			gp3iops int64 = 4000
 
 			rootVolumeIO1 = &core.Volume{Type: &io1type}
 			rootVolumeGP2 = &core.Volume{Type: &gp2type}
+			rootVolumeGP3 = &core.Volume{Type: &gp3type}
 
 			dataVolume1Name = "foo"
 			dataVolume2Name = "bar"
+			dataVolume3Name = "baz"
 			dataVolumes     []core.DataVolume
 			nodeTemplate    *extensionsv1alpha1.NodeTemplate
 
@@ -63,6 +65,10 @@ var _ = Describe("ValidateWorkerConfig", func() {
 				{
 					Name: dataVolume2Name,
 					Type: &gp2type,
+				},
+				{
+					Name: dataVolume3Name,
+					Type: &gp3type,
 				},
 			}
 
@@ -131,11 +137,18 @@ var _ = Describe("ValidateWorkerConfig", func() {
 		})
 
 		It("should return no errors for a valid gp2 configuration", func() {
-			worker.Volume.IOPS = &gp2iops
-			Expect(ValidateWorkerConfig(worker, &core.Volume{Type: &gp2type}, dataVolumes, fldPath)).To(BeEmpty())
+			worker.Volume.IOPS = nil
+			Expect(ValidateWorkerConfig(worker, rootVolumeGP2, dataVolumes, fldPath)).To(BeEmpty())
 		})
 
-		It("should enforce that IOPS are provided for io1 volumes", func() {
+		It("should return no errors for a valid gp3 configuration", func() {
+			worker.Volume.IOPS = nil
+			Expect(ValidateWorkerConfig(worker, rootVolumeGP3, dataVolumes, fldPath)).To(BeEmpty())
+			worker.Volume.IOPS = &gp3iops
+			Expect(ValidateWorkerConfig(worker, rootVolumeGP3, dataVolumes, fldPath)).To(BeEmpty())
+		})
+
+		It("should enforce that IOPS is provided for io1 volumes", func() {
 			worker.Volume.IOPS = nil
 			worker.DataVolumes[0].IOPS = nil
 
@@ -153,34 +166,10 @@ var _ = Describe("ValidateWorkerConfig", func() {
 			))
 		})
 
-		It("should enforce that the IOPS for gp2 volumes is within the allowed range", func() {
-			var tooLarge int64 = 123123123
-			worker.Volume.IOPS = &tooLarge
-			worker.DataVolumes = append(worker.DataVolumes, apisaws.DataVolume{
-				Name: dataVolume2Name,
-				Volume: apisaws.Volume{
-					IOPS: &tooLarge,
-				},
-			})
-
-			errorList := ValidateWorkerConfig(worker, rootVolumeGP2, dataVolumes, fldPath)
-
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("config.volume.iops"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("config.dataVolumes[1].iops"),
-				})),
-			))
-		})
-
-		It("should enforce that the IOPS for io1 volumes is within the allowed range", func() {
-			var tooLarge int64 = 123123123
-			worker.Volume.IOPS = &tooLarge
-			worker.DataVolumes[0].IOPS = &tooLarge
+		It("should enforce that the IOPS is non negative", func() {
+			var negative int64 = -100
+			worker.Volume.IOPS = &negative
+			worker.DataVolumes[0].IOPS = &negative
 
 			errorList := ValidateWorkerConfig(worker, rootVolumeIO1, dataVolumes, fldPath)
 
@@ -192,32 +181,6 @@ var _ = Describe("ValidateWorkerConfig", func() {
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeForbidden),
 					"Field": Equal("config.dataVolumes[0].iops"),
-				})),
-			))
-		})
-
-		It("should return an error if IOPS is set for a non-supported volume type", func() {
-			dataVolumes = append(dataVolumes, core.DataVolume{
-				Name: "broken",
-				Type: &footype,
-			})
-			worker.DataVolumes = append(worker.DataVolumes, apisaws.DataVolume{
-				Name: "broken",
-				Volume: apisaws.Volume{
-					IOPS: &io1iops,
-				},
-			})
-
-			errorList := ValidateWorkerConfig(worker, &core.Volume{Type: &footype}, dataVolumes, fldPath)
-
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("config.volume.iops"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("config.dataVolumes[2].iops"),
 				})),
 			))
 		})

--- a/pkg/apis/aws/validation/worker_test.go
+++ b/pkg/apis/aws/validation/worker_test.go
@@ -36,6 +36,7 @@ var _ = Describe("ValidateWorkerConfig", func() {
 			io1type       = string(apisaws.VolumeTypeIO1)
 			io1iops int64 = 200
 			gp2type       = string(apisaws.VolumeTypeGP2)
+			gp2iops int64 = 400
 			gp3type       = string(apisaws.VolumeTypeGP3)
 			gp3iops int64 = 4000
 
@@ -139,6 +140,8 @@ var _ = Describe("ValidateWorkerConfig", func() {
 		It("should return no errors for a valid gp2 configuration", func() {
 			worker.Volume.IOPS = nil
 			Expect(ValidateWorkerConfig(worker, rootVolumeGP2, dataVolumes, fldPath)).To(BeEmpty())
+			worker.Volume.IOPS = &gp2iops // this will later fail on aws side because currently iops cannot be set for gp2.
+			Expect(ValidateWorkerConfig(worker, rootVolumeGP2, dataVolumes, fldPath)).To(BeEmpty())
 		})
 
 		It("should return no errors for a valid gp3 configuration", func() {
@@ -166,7 +169,7 @@ var _ = Describe("ValidateWorkerConfig", func() {
 			))
 		})
 
-		It("should enforce that the IOPS is non negative", func() {
+		It("should enforce that the IOPS is positive", func() {
 			var negative int64 = -100
 			worker.Volume.IOPS = &negative
 			worker.DataVolumes[0].IOPS = &negative
@@ -184,7 +187,6 @@ var _ = Describe("ValidateWorkerConfig", func() {
 				})),
 			))
 		})
-
 		It("should prevent duplicate entries for data volumes in workerconfig", func() {
 			worker.DataVolumes = append(worker.DataVolumes, apisaws.DataVolume{Name: dataVolume1Name})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind bug
/platform aws

**What this PR does / why we need it**:
This PR allows setting IOPS for any volume type and moves the validation to the AWS side. 
**Which issue(s) this PR fixes**:
Fixes #488 

**Special notes for your reviewer**:
This PR will allow setting IOPS for any valid volume type. The validation of the volume type against the cloud profile is not done here, so I have removed the default case and the test case where it checks setting IOPS for an invalid volume type. Testing on the dev landscape is also done. 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Users can now set IOPS for a GP3 volume type. Validation of IOPS (i.e. whether it is allowed and is in the specified range for a volume type) is done on the AWS side, so feedback will arrive once the volume is created. 
```
