### PR TITLE
Add CSI migration feature gates to the cluster-autoscaler

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -155,6 +155,38 @@ func (e *ensurer) EnsureKubeSchedulerDeployment(ctx context.Context, gctx gconte
 	return nil
 }
 
+// EnsureClusterAutoscalerDeployment ensures that the cluster-autoscaler deployment conforms to the provider requirements.
+func (e *ensurer) EnsureClusterAutoscalerDeployment(ctx context.Context, gctx gcontext.GardenContext, new, _ *appsv1.Deployment) error {
+	template := &new.Spec.Template
+	ps := &template.Spec
+
+	cluster, err := gctx.GetCluster(ctx)
+	if err != nil {
+		return err
+	}
+
+	// cluster-autoscaler supports the "--feature-gates" flag starting 1.20.
+	// Exit early and do not add the "--feature-gates" flag for K8s < 1.20 Shoots.
+	k8sLessThan120, err := versionutils.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.20")
+	if err != nil {
+		return err
+	}
+	if k8sLessThan120 {
+		return nil
+	}
+
+	// At this point K8s >= 1.20. As CSIMigrationKubernetesVersion is 1.18, we can assume that CSI is enabled and CSI migration is complete.
+	csiMigrationCompleteFeatureGate, err := computeCSIMigrationCompleteFeatureGate(cluster.Shoot.Spec.Kubernetes.Version)
+	if err != nil {
+		return err
+	}
+
+	if c := extensionswebhook.ContainerWithName(ps.Containers, "cluster-autoscaler"); c != nil {
+		ensureClusterAutoscalerCommandLineArgs(c, csiMigrationCompleteFeatureGate)
+	}
+	return nil
+}
+
 func ensureKubeAPIServerCommandLineArgs(c *corev1.Container, csiEnabled, csiMigrationComplete bool, csiMigrationCompleteFeatureGate string) {
 	if csiEnabled {
 		c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
@@ -220,6 +252,18 @@ func ensureKubeSchedulerCommandLineArgs(c *corev1.Container, csiEnabled, csiMigr
 			return
 		}
 	}
+}
+
+// ensureClusterAutoscalerCommandLineArgs ensures the cluster-autoscaler command line args.
+// cluster-autoscaler supports the "--feature-gates" flag starting 1.20. This func assumes that
+// the K8s version is >= 1.20 which means that CSI is enabled and CSI migration is complete.
+func ensureClusterAutoscalerCommandLineArgs(c *corev1.Container, csiMigrationCompleteFeatureGate string) {
+	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
+		"CSIMigration=true", ",")
+	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
+		"CSIMigrationAWS=true", ",")
+	c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
+		csiMigrationCompleteFeatureGate+"=true", ",")
 }
 
 func ensureKubeControllerManagerLabels(t *corev1.PodTemplateSpec, csiEnabled, csiMigrationComplete bool) {


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane auto-scaling
/kind bug
/platform aws

**What this PR does / why we need it**:
More details can be found on https://github.com/gardener/gardener/issues/5064

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5064

**Special notes for your reviewer**:
This PR depends on:
- [x] ✅  New cluster-autoscaler patch releases to be cut and adopted in gardener/gardener - ref https://github.com/gardener/gardener/pull/6163

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
This version of provider-aws requires Gardener v1.50.0.
```

```bugfix operator
provider-aws now mutates the `cluster-autoscaler` Deployment by implementing the `EnsureClusterAutoscalerDeployment` function. This is required in the context of https://github.com/kubernetes/autoscaler/issues/4517 - cluster-autoscaler supports `--feature-gates` flag and provider extensions have to mutate the cluster-autoscaler Deployment to add the CSI related feature gates to it.
```
