### PR TITLE
Update aws-ebs-csi-driver

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -64,7 +64,7 @@ images:
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/aws-ebs-csi-driver
   repository: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
-  tag: "v1.5.3"
+  tag: "v1.9.0"
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner


### PR DESCRIPTION
/area storage
/area quality
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR updates to the latest v1.9.0 of aws-ebs-csi-driver with the primary goal to adopt:
- the fix for https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1139
- https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1233 - in v1.8.0 the base image is switched to a minimal one
   ```
   public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver           v1.9.0                                                 5be74f0bad7e   5 days ago      87MB
   public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver           v1.5.3                                                 b6068b195506   3 months ago    295MB
   ```

   The image size of  public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver@v1.5.3 is 295MB while the image size of public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver@v1.9.0 is 87MB. This should also reduce the vulnerabilities count reported by image scans.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The following image is updated:
- k8s.gcr.io/provider-aws/aws-ebs-csi-driver: v1.5.3 -> v1.9.0
```
