### PR TITLE
Adding throughput field in worker config

### DIFF
--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -37,4 +37,5 @@ machineClasses:
       volumeSize: 50
       volumeType: gp2
     # iops: 100
+    # throughput: 125 #(only for gp3)
     # snapshotID: snap-12345

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -283,9 +283,11 @@ apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
 kind: WorkerConfig
 volume:
   iops: 10000
+  throughput: 200 
 dataVolumes:
 - name: kubelet-dir
   iops: 12345
+  throughput: 150
   snapshotID: snap-1234
 iamInstanceProfile: # (specify either ARN or name)
   name: my-profile
@@ -301,6 +303,8 @@ The `.volume.iops` is the number of I/O operations per second (IOPS) that the vo
 For `io1` and `gp3` volume type, this represents the number of IOPS that are provisioned for the volume.
 For `gp2` volume type, this represents the baseline performance of the volume and the rate at which the volume accumulates I/O credits for bursting. For more information about General Purpose SSD baseline performance, I/O credits, IOPS range and bursting, see Amazon EBS Volume Types (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html) in the Amazon Elastic Compute Cloud User Guide.\
 Constraint: IOPS should be a positive value. Validation of IOPS (i.e. whether it is allowed and is in the specified range for a particular volume type) is done on aws side.
+
+The `volume.throughput` is the throughput that the volume supports, in `MiB/s`. As of `16th Aug 2022`, this parameter is valid only for `gp3` volume types and will return an error from the provider side if specified for other volume types. Its current range of throughput is from `125MiB/s` to `1000 MiB/s`. To know more about throughput and its range, see the official AWS documentation [here](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html).
 
 The `.dataVolumes` can optionally contain configurations for the data volumes stated in the `Shoot` specification in the `.spec.provider.workers[].dataVolumes` list.
 The `.name` must match to the name of the data volume in the shoot.

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1255,6 +1255,19 @@ gp2 volumes.</p>
 it is not used in requests to create gp2, st1, sc1, or standard volumes.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>throughput</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>The throughput that the volume supports, in MiB/s.</p>
+<p>This parameter is valid only for gp3 volumes.</p>
+<p>Valid Range: The range as of 16th Aug 2022 is from 125 MiB/s to 1000 MiB/s. For more info refer (<a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html">http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html</a>)</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="aws.provider.extensions.gardener.cloud/v1alpha1.VolumeType">VolumeType

--- a/pkg/apis/aws/types_worker.go
+++ b/pkg/apis/aws/types_worker.go
@@ -53,6 +53,13 @@ type Volume struct {
 	// Condition: This parameter is required for requests to create io1 volumes;
 	// Do not specify it in requests to create gp2, st1, sc1, or standard volumes.
 	IOPS *int64
+
+	// The throughput that the volume supports, in MiB/s.
+	//
+	// This parameter is valid only for gp3 volumes.
+	//
+	// Valid Range: The range as of 16th Aug 2022 is from 125 MiB/s to 1000 MiB/s. For more info refer (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+	Throughput *int64
 }
 
 // DataVolume contains configuration for data volumes attached to VMs.

--- a/pkg/apis/aws/v1alpha1/types_worker.go
+++ b/pkg/apis/aws/v1alpha1/types_worker.go
@@ -59,6 +59,13 @@ type Volume struct {
 	// it is not used in requests to create gp2, st1, sc1, or standard volumes.
 	// +optional
 	IOPS *int64 `json:"iops,omitempty"`
+
+	// The throughput that the volume supports, in MiB/s.
+	//
+	// This parameter is valid only for gp3 volumes.
+	//
+	// Valid Range: The range as of 16th Aug 2022 is from 125 MiB/s to 1000 MiB/s. For more info refer (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+	Throughput *int64 `json:"throughput,omitempty"`
 }
 
 // DataVolume contains configuration for data volumes attached to VMs.
@@ -120,4 +127,6 @@ const (
 	VolumeTypeIO1 VolumeType = "io1"
 	// VolumeTypeGP2 is a constant for the gp2 volume type.
 	VolumeTypeGP2 VolumeType = "gp2"
+	// VolumeTypeGP3 is a constant for the gp3 volume type.
+	VolumeTypeGP3 VolumeType = "gp3"
 )

--- a/pkg/apis/aws/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.conversion.go
@@ -820,6 +820,7 @@ func Convert_aws_VPCStatus_To_v1alpha1_VPCStatus(in *aws.VPCStatus, out *VPCStat
 
 func autoConvert_v1alpha1_Volume_To_aws_Volume(in *Volume, out *aws.Volume, s conversion.Scope) error {
 	out.IOPS = (*int64)(unsafe.Pointer(in.IOPS))
+	out.Throughput = (*int64)(unsafe.Pointer(in.Throughput))
 	return nil
 }
 
@@ -830,6 +831,7 @@ func Convert_v1alpha1_Volume_To_aws_Volume(in *Volume, out *aws.Volume, s conver
 
 func autoConvert_aws_Volume_To_v1alpha1_Volume(in *aws.Volume, out *Volume, s conversion.Scope) error {
 	out.IOPS = (*int64)(unsafe.Pointer(in.IOPS))
+	out.Throughput = (*int64)(unsafe.Pointer(in.Throughput))
 	return nil
 }
 

--- a/pkg/apis/aws/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.deepcopy.go
@@ -558,6 +558,11 @@ func (in *Volume) DeepCopyInto(out *Volume) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.Throughput != nil {
+		in, out := &in.Throughput, &out.Throughput
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/aws/validation/worker.go
+++ b/pkg/apis/aws/validation/worker.go
@@ -114,5 +114,9 @@ func validateVolumeConfig(volume *apisaws.Volume, volumeType string, fldPath *fi
 	} else if volumeType == string(apisaws.VolumeTypeIO1) {
 		allErrs = append(allErrs, field.Required(iopsPath, fmt.Sprintf("iops must be provided when using %s volumes", apisaws.VolumeTypeIO1)))
 	}
+	if volume != nil && volume.Throughput != nil && *volume.Throughput <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("throughput"), *volume.Throughput, "throughput must be a positive value"))
+	}
+
 	return allErrs
 }

--- a/pkg/apis/aws/zz_generated.deepcopy.go
+++ b/pkg/apis/aws/zz_generated.deepcopy.go
@@ -558,6 +558,11 @@ func (in *Volume) DeepCopyInto(out *Volume) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.Throughput != nil {
+		in, out := &in.Throughput, &out.Throughput
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -251,8 +251,13 @@ func (w *workerDelegate) computeBlockDevices(pool extensionsv1alpha1.WorkerPool,
 	if err != nil {
 		return nil, fmt.Errorf("error when computing EBS for root disk: %w", err)
 	}
-	if workerConfig.Volume != nil && workerConfig.Volume.IOPS != nil {
-		rootDisk["iops"] = *workerConfig.Volume.IOPS
+	if workerConfig.Volume != nil {
+		if workerConfig.Volume.IOPS != nil {
+			rootDisk["iops"] = *workerConfig.Volume.IOPS
+		}
+		if workerConfig.Volume.Throughput != nil {
+			rootDisk["throughput"] = *workerConfig.Volume.Throughput
+		}
 	}
 	blockDevices = append(blockDevices, map[string]interface{}{"ebs": rootDisk})
 
@@ -276,6 +281,9 @@ func (w *workerDelegate) computeBlockDevices(pool extensionsv1alpha1.WorkerPool,
 				}
 				if dvConfig.SnapshotID != nil {
 					dataDisk["snapshotID"] = *dvConfig.SnapshotID
+				}
+				if dvConfig.Throughput != nil {
+					dataDisk["throughput"] = *dvConfig.Throughput
 				}
 			}
 			deviceName, err := computeEBSDeviceNameForIndex(i)

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -109,16 +109,18 @@ var _ = Describe("Machines", func() {
 				archAMD string
 				archARM string
 
-				volumeType      string
-				volumeSize      int
-				volumeEncrypted bool
-				volumeIOPS      int64
+				volumeType       string
+				volumeSize       int
+				volumeEncrypted  bool
+				volumeIOPS       int64
+				volumeThroughput int64
 
-				dataVolume1Name      string
-				dataVolume1Type      string
-				dataVolume1Size      int
-				dataVolume1IOPS      int64
-				dataVolume1Encrypted bool
+				dataVolume1Name       string
+				dataVolume1Type       string
+				dataVolume1Size       int
+				dataVolume1IOPS       int64
+				dataVolume1Throughput int64
+				dataVolume1Encrypted  bool
 
 				dataVolume2Name       string
 				dataVolume2Type       string
@@ -190,11 +192,13 @@ var _ = Describe("Machines", func() {
 				volumeSize = 20
 				volumeEncrypted = true
 				volumeIOPS = 400
+				volumeThroughput = 200
 
 				dataVolume1Name = "vol-1"
 				dataVolume1Type = "foo"
 				dataVolume1Size = 42
 				dataVolume1IOPS = 567
+				dataVolume1Throughput = 300
 				dataVolume1Encrypted = true
 
 				dataVolume2Name = "vol-2"
@@ -379,13 +383,15 @@ var _ = Describe("Machines", func() {
 								ProviderConfig: &runtime.RawExtension{
 									Raw: encode(&api.WorkerConfig{
 										Volume: &api.Volume{
-											IOPS: &volumeIOPS,
+											IOPS:       &volumeIOPS,
+											Throughput: &volumeThroughput,
 										},
 										DataVolumes: []api.DataVolume{
 											{
 												Name: dataVolume1Name,
 												Volume: api.Volume{
-													IOPS: &dataVolume1IOPS,
+													IOPS:       &dataVolume1IOPS,
+													Throughput: &dataVolume1Throughput,
 												},
 											},
 											{
@@ -536,6 +542,7 @@ var _ = Describe("Machines", func() {
 									"volumeSize":          volumeSize,
 									"volumeType":          volumeType,
 									"iops":                volumeIOPS,
+									"throughput":          volumeThroughput,
 									"deleteOnTermination": true,
 									"encrypted":           volumeEncrypted,
 								},
@@ -548,6 +555,7 @@ var _ = Describe("Machines", func() {
 									"deleteOnTermination": true,
 									"encrypted":           dataVolume1Encrypted,
 									"iops":                dataVolume1IOPS,
+									"throughput":          dataVolume1Throughput,
 								},
 							},
 							{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR allows configuring `throughput` for `gp3` volume types in the shoot yaml. The validation of throughput against different volume types is done on the provider side, so the error will be returned after the machine creation step.

**Which issue(s) this PR fixes**:
Fixes #584 

**Special notes for your reviewer**:
The following tests were performed on a local gardener setup (Current range of throughput is `125MiB/s - 1000MiB/s`)
(The throughput field is configured in the shoot yaml as part of the `providerConfig`) 
(mcm was run locally for these tests along with the necessary changes done on mcm-provider-aws as per [this](https://github.com/gardener/machine-controller-manager-provider-aws/pull/95) PR) :-

1. Throughput=`-100`, Volume Type =  `{gp3, io1, gp2}` —> Error Message from `gardener-extension-aws` :- `Invalid value: -100: throughput must be a positive value`. 
2. Throughput=`300`, IOPS=`3500`, Volume Type = `gp3` —> machine with throughput=`300`, IOPS=`3500` gets created
3. Throughput=`10000`, IOPS=`3500`, Volume Type =  `gp3` —> Error message in machine status :- `InvalidParameterValue: Volume throughput of 10000 is too high; maximum is 1000.`
4. Throughput=`999`, IOPS=`3500`, Volume Type = `gp3` —>  Error message in machine status:- `InvalidParameterValue: Throughput (MiBps) to iops ratio of 0.285429 is too high; maximum is 0.25MiBps per IOPS. 
5. Throughput=`199`, IOPS=`3500`, Volume Type = `gp3` —> machine gets created with the throughput=`199` and IOPS=`3500`.
6. Throughput=`0`, IOPS=`3500`, Volume Type = `gp3` —> Error Message from `gardener-extension-aws` :- `Invalid value: 0: throughput must be a positive value.`
7. Throughput=`10`, IOPS=`3500`, Volume Type = `gp3` —> machine with throughput=`125` and IOPS=`3500` gets created
8. Throughput=`200`, Volume Type = `{gp2, io1}` —> Error message in machine status :- `InvalidBlockDeviceMapping: throughput cannot be specified with the volumeType of device '/dev/xvda'.`
9. Throughput=`200`, no IOPS, Volume Type = `gp3` —> Machine with IOPS=`3000` and throughput=`200` gets created.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```user feature
Throughput is now configurable for gp3 volume types. This is not enabled on the UI and needs to be done in the shoot yaml. Throughput validation i.e. whether it is allowed or not and is within the range, is done on the provider(AWS) side. If the throughput specified is positive and below the minimum value in the range, then it will be defaulted to the minimum value in the range
```
