### PR TITLE
Enable custom aws route controller per default for kubernetes >= 1.22 unless explicitly disabled.

### DIFF
--- a/pkg/webhook/controlplane/add.go
+++ b/pkg/webhook/controlplane/add.go
@@ -40,8 +40,9 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Types: []extensionswebhook.Type{
 			{Obj: &appsv1.Deployment{}},
 			{Obj: &extensionsv1alpha1.OperatingSystemConfig{}},
+			{Obj: &extensionsv1alpha1.ControlPlane{}},
 		},
-		Mutator: genericmutator.NewMutator(NewEnsurer(logger), oscutils.NewUnitSerializer(),
-			kubelet.NewConfigCodec(fciCodec), fciCodec, logger),
+		Mutator: NewControlPlaneMutator(logger, genericmutator.NewMutator(NewEnsurer(logger),
+			oscutils.NewUnitSerializer(), kubelet.NewConfigCodec(fciCodec), fciCodec, logger)),
 	})
 }

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"regexp"
 
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/install"
+	awsv1alpha1 "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
 
 	"github.com/Masterminds/semver"
@@ -35,10 +37,29 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
+
+var (
+	// Scheme is a scheme with the types relevant for aws control plane configuration.
+	scheme *runtime.Scheme
+
+	decoder runtime.Decoder
+)
+
+func init() {
+	scheme = runtime.NewScheme()
+	utilruntime.Must(install.AddToScheme(scheme))
+
+	decoder = serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder()
+}
 
 // NewEnsurer creates a new controlplane ensurer.
 func NewEnsurer(logger logr.Logger) genericmutator.Ensurer {
@@ -603,4 +624,86 @@ func appendUniqueFile(files *[]extensionsv1alpha1.File, file extensionsv1alpha1.
 	}
 
 	*files = append(resFiles, file)
+}
+
+// NewControlPlaneMutator creates a new controlplane mutator.
+func NewControlPlaneMutator(logger logr.Logger, mutator extensionswebhook.Mutator) extensionswebhook.Mutator {
+	return &controlPlaneMutator{
+		logger:  logger.WithName("aws-controlplane-mutator"),
+		mutator: mutator,
+	}
+}
+
+type controlPlaneMutator struct {
+	client  client.Client
+	logger  logr.Logger
+	mutator extensionswebhook.Mutator
+}
+
+// InjectClient injects the given client into the mutator.
+func (c *controlPlaneMutator) InjectClient(client client.Client) error {
+	c.client = client
+	_, err := inject.ClientInto(client, c.mutator)
+	return err
+}
+
+// InjectFunc injects stuff into the mutator.
+func (c *controlPlaneMutator) InjectFunc(f inject.Func) error {
+	return f(c.mutator)
+}
+
+// Mutate validates and if needed mutates the given object.
+func (c *controlPlaneMutator) Mutate(ctx context.Context, new, old client.Object) error {
+	// If the object does have a deletion timestamp then we don't want to mutate anything.
+	if new.GetDeletionTimestamp() != nil {
+		return nil
+	}
+
+	switch x := new.(type) {
+	case *extensionsv1alpha1.ControlPlane:
+		// Only mutate inital control plane for now
+		if old != nil {
+			return nil
+		}
+
+		gctx := gcontext.NewGardenContext(c.client, new)
+		cluster, err := gctx.GetCluster(ctx)
+		if err != nil {
+			return err
+		}
+		// source/destination checks are only disabled for kubernetes >= 1.22
+		// see https://github.com/gardener/machine-controller-manager-provider-aws/issues/36 for details
+		greaterEqual122, err := versionutils.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", "1.22")
+		if err != nil {
+			return err
+		}
+		if greaterEqual122 {
+			switch x.Name {
+			case cluster.Shoot.Name:
+				if x.Spec.ProviderConfig != nil && x.Spec.ProviderConfig.Raw != nil {
+					config := &awsv1alpha1.ControlPlaneConfig{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: awsv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "ControlPlaneConfig",
+						},
+					}
+					if _, _, err := decoder.Decode(x.Spec.ProviderConfig.Raw, nil, config); err != nil {
+						return err
+					}
+					if config.CloudControllerManager == nil {
+						config.CloudControllerManager = &awsv1alpha1.CloudControllerManagerConfig{}
+					}
+					if config.CloudControllerManager.UseCustomRouteController == nil {
+						extensionswebhook.LogMutation(c.logger, x.Kind, x.Namespace, x.Name)
+						config.CloudControllerManager.UseCustomRouteController = pointer.Bool(true)
+						x.Spec.ProviderConfig = &runtime.RawExtension{
+							Object: config,
+						}
+					}
+				}
+			}
+		}
+		return nil
+	}
+	return c.mutator.Mutate(ctx, new, old)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Enable custom aws route controller per default for kubernetes >= 1.22 unless explicitly disabled.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
Requires https://github.com/gardener/gardener-extension-provider-aws/pull/591 as prerequisite.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Enable custom aws route controller per default for kubernetes >= 1.22 unless explicitly disabled.
```
