### PR TITLE
Add `QPS` and `Burst` to HealthCheckConfig

### DIFF
--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/version"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -42,7 +43,13 @@ var (
 	defaultSyncPeriod = time.Second * 30
 	// DefaultAddOptions are the default DefaultAddArgs for AddToManager.
 	DefaultAddOptions = healthcheck.DefaultAddArgs{
-		HealthCheckConfig: healthcheckconfig.HealthCheckConfig{SyncPeriod: metav1.Duration{Duration: defaultSyncPeriod}},
+		HealthCheckConfig: healthcheckconfig.HealthCheckConfig{
+			SyncPeriod: metav1.Duration{Duration: defaultSyncPeriod},
+			ShootRESTOptions: &healthcheckconfig.RESTOptions{
+				QPS:   pointer.Float32(100),
+				Burst: pointer.Int(130),
+			},
+		},
 	}
 )
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR adds QPS and Burst to the config passed to HealthCheck client.
The values used here are from https://github.com/gardener/gardener-extension-provider-aws/blob/003f0af55a373705075c2f361cbd5a74cceef397/example/00-componentconfig.yaml#L7-L8.
This is to prevent client-side throttling issues during health check execution. 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6045

**Special notes for your reviewer**:
/cc @oliver-goetz @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`QPS` and `Burst` are set in the HealthCheckConfig passed to the Controller.
```
