### PR TITLE
[GEP-20] Make MCM and CCM components HA

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.tsc }}
+      topologySpreadConstraints:
+{{ toYaml .Values.tsc | indent 6 }}
+{{- end }}
       priorityClassName: gardener-system-300
       serviceAccountName: machine-controller-manager
       terminationGracePeriodSeconds: 5

--- a/charts/internal/machine-controller-manager/seed/values.yaml
+++ b/charts/internal/machine-controller-manager/seed/values.yaml
@@ -4,6 +4,8 @@ images:
 
 replicas: 1
 
+tsc: {}
+
 podAnnotations: {}
 
 podLabels: {}

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.tsc }}
+      topologySpreadConstraints:
+{{ toYaml .Values.tsc | indent 6 }}
+{{- end }}
       automountServiceAccountToken: false
       priorityClassName: gardener-system-300
       containers:

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -4,6 +4,7 @@ kubernetesVersion: 1.7.5
 podNetwork: 192.168.0.0/16
 podAnnotations: {}
 podLabels: {}
+tsc: {}
 featureGates: {}
   # CustomResourceValidation: true
   # RotateKubeletServerCertificate: false


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area high-availability
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR makes the `machine-controller-manager` and `cloud-controller-manager` extension components highly available, based on the `failureToleranceType`.

**Which issue(s) this PR fixes**:
Fixes partially https://github.com/gardener/gardener/issues/6529

**Special notes for your reviewer**:
/invite @unmarshall @timuthy 

This PR needs to be merged only after https://github.com/gardener/gardener/pull/6646 is merged and released and vendored into this repo.
/hold

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Introduce [TSC](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) for `machine-controller-manager` and `cloud-controller-manager` extension components to make them highly available.
```
