### PR TITLE
Update golang for builder image and linter to 1.19 

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,6 @@
 run:
   concurrency: 4
   deadline: 10m
-  # some of the linters don't work correctly with 1.18, ref https://github.com/golangci/golangci-lint/issues/2649
-  # we are not using generics, so let's pin this to 1.17 until 1.18 is fully supported
-  go: "1.17"
 
 linters:
   disable:

--- a/.test-defs/bastion-test.yaml
+++ b/.test-defs/bastion-test.yaml
@@ -16,4 +16,4 @@ spec:
     --secret-access-key=$SECRET_ACCESS_KEY
     --region=$REGION
 
-  image: golang:1.17.5
+  image: golang:1.19.2

--- a/.test-defs/dnsrecord-test.yaml
+++ b/.test-defs/dnsrecord-test.yaml
@@ -15,4 +15,4 @@ spec:
     --access-key-id=$DNS_ACCESS_KEY_ID
     --secret-access-key=$DNS_SECRET_ACCESS_KEY
 
-  image: golang:1.17.5
+  image: golang:1.19.2

--- a/.test-defs/infrastructure-test.yaml
+++ b/.test-defs/infrastructure-test.yaml
@@ -16,4 +16,4 @@ spec:
     --secret-access-key=$SECRET_ACCESS_KEY
     --region=$REGION
 
-  image: golang:1.17.5
+  image: golang:1.19.2

--- a/.test-defs/provider-aws.yaml
+++ b/.test-defs/provider-aws.yaml
@@ -18,4 +18,4 @@ spec:
     --network-worker-cidr=$NETWORK_WORKER_CIDR
     --zone=$ZONE
 
-  image: golang:1.17.5
+  image: golang:1.19.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.19.1 AS builder
+FROM golang:1.19.2 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-aws
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.18.3 AS builder
+FROM golang:1.19.1 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-aws
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ SECRET_ACCESS_KEY_FILE := .kube-secrets/aws/secret_access_key.secret
 #########################################
 
 TOOLS_DIR := hack/tools
+# temporarily until Gardener version has been revendored >= v1.54
+GOLANGCI_LINT_VERSION := v1.49.0
 include vendor/github.com/gardener/gardener/hack/tools.mk
 
 #########################################

--- a/pkg/controller/infrastructure/configvalidator.go
+++ b/pkg/controller/infrastructure/configvalidator.go
@@ -18,17 +18,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
-	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
-	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/gardener/gardener/extensions/pkg/controller/common"
 	"github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
+	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
 )
 
 // configValidator implements ConfigValidator for aws infrastructure resources.
@@ -130,8 +130,8 @@ func (c *configValidator) validateVPC(ctx context.Context, awsClient awsclient.I
 
 // validateEIP validates if the given elastic IP exists and can be associated by the Shoot's NAT gateway
 // An EIP can be associated with the Shoot when
-//  - it is not associated yet (new)
-//  - it is already associated to any Gardener-created NAT Gateway of the Shoot cluster (identified by tag `kubernetes.io/cluster/<shoot-name>`)
+//   - it is not associated yet (new)
+//   - it is already associated to any Gardener-created NAT Gateway of the Shoot cluster (identified by tag `kubernetes.io/cluster/<shoot-name>`)
 func (c *configValidator) validateEIPS(ctx context.Context, awsClient awsclient.Interface, shootNamespace string, elasticIPAllocationIDs []string, elasticIPAllocationIDToZone map[string]string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- update golang for builder image: `1.18.3` -> `1.19.2`
- update golangci_lint:  `1.45.2` -> `1.49` to prepare switching to golang 1.19 for verify step


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update golang for builder image: `1.18.3` -> `1.19.2`
```
