### PR TITLE
Flow-based infrastructure reconciliation without Terraformer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.26.2
 	k8s.io/apimachinery v0.26.2
 	k8s.io/autoscaler/vertical-pod-autoscaler v0.13.0
+	go.uber.org/atomic v1.9.0
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/code-generator v0.26.2
 	k8s.io/component-base v0.26.2
@@ -110,7 +111,6 @@ require (
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/onsi/gomega v1.27.1
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
+	go.uber.org/atomic v1.9.0
 	golang.org/x/exp v0.0.0-20230307190834-24139beb5833
 	golang.org/x/time v0.3.0
 	golang.org/x/tools v0.6.0
@@ -26,7 +27,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.26.2
 	k8s.io/apimachinery v0.26.2
 	k8s.io/autoscaler/vertical-pod-autoscaler v0.13.0
-	go.uber.org/atomic v1.9.0
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/code-generator v0.26.2
 	k8s.io/component-base v0.26.2

--- a/pkg/apis/aws/const.go
+++ b/pkg/apis/aws/const.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+const (
+	// AnnotationKeyUseFlow is the annotation key used to enable reconciliation with flow instead of terraformer.
+	AnnotationKeyUseFlow = "aws.provider.extensions.gardener.cloud/use-flow"
+	// SeedLabelKeyUseFlow is the label for seeds to enable flow reconciliation for all of its shoots if value is `true`
+	// or for new shoots only with value `new`
+	SeedLabelKeyUseFlow = AnnotationKeyUseFlow
+	// SeedLabelUseFlowValueNew is the value to restrict flow reconciliation to new shoot clusters
+	SeedLabelUseFlowValueNew = "new"
+)

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -16,7 +16,11 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/url"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +44,8 @@ import (
 	"github.com/go-logr/logr"
 	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -62,7 +68,10 @@ type Client struct {
 	Route53RateLimiter            *rate.Limiter
 	Route53RateLimiterWaitTimeout time.Duration
 	Logger                        logr.Logger
+	PollInterval                  time.Duration
 }
+
+var _ Interface = &Client{}
 
 // NewInterface creates a new instance of Interface for the given AWS credentials and region.
 func NewInterface(accessKeyID, secretAccessKey, region string) (Interface, error) {
@@ -96,6 +105,7 @@ func NewClient(accessKeyID, secretAccessKey, region string) (*Client, error) {
 		Route53RateLimiter:            rate.NewLimiter(rate.Inf, 0),
 		Route53RateLimiterWaitTimeout: 1 * time.Second,
 		Logger:                        log.Log.WithName("aws-client"),
+		PollInterval:                  5 * time.Second,
 	}, nil
 }
 
@@ -123,7 +133,7 @@ func (c *Client) GetVPCInternetGateway(ctx context.Context, vpcID string) (strin
 	}
 	describeInternetGatewaysOutput, err := c.EC2.DescribeInternetGatewaysWithContext(ctx, describeInternetGatewaysInput)
 	if err != nil {
-		return "", err
+		return "", ignoreNotFound(err)
 	}
 
 	if len(describeInternetGatewaysOutput.InternetGateways) > 0 {
@@ -147,7 +157,7 @@ func (c *Client) GetElasticIPsAssociationIDForAllocationIDs(ctx context.Context,
 
 	describeAddressesOutput, err := c.EC2.DescribeAddressesWithContext(ctx, describeAddressesInput)
 	if err != nil {
-		return nil, err
+		return nil, ignoreNotFound(err)
 	}
 
 	if len(describeAddressesOutput.Addresses) == 0 {
@@ -179,7 +189,7 @@ func (c *Client) GetNATGatewayAddressAllocations(ctx context.Context, shootNames
 
 	describeNatGatewaysOutput, err := c.EC2.DescribeNatGatewaysWithContext(ctx, describeAddressesInput)
 	if err != nil {
-		return nil, err
+		return nil, ignoreNotFound(err)
 	}
 
 	result := sets.New[string]()
@@ -209,7 +219,7 @@ func (c *Client) GetNATGatewayAddressAllocations(ctx context.Context, shootNames
 func (c *Client) GetVPCAttribute(ctx context.Context, vpcID string, attribute string) (bool, error) {
 	vpcAttribute, err := c.EC2.DescribeVpcAttributeWithContext(ctx, &ec2.DescribeVpcAttributeInput{VpcId: &vpcID, Attribute: aws.String(attribute)})
 	if err != nil {
-		return false, err
+		return false, ignoreNotFound(err)
 	}
 
 	switch attribute {
@@ -524,20 +534,20 @@ func (c *Client) ListKubernetesSecurityGroups(ctx context.Context, vpcID, cluste
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("vpc-id"),
-				Values: []*string{aws.String(vpcID)},
+				Values: aws.StringSlice([]string{vpcID}),
 			},
 			{
 				Name:   aws.String("tag-key"),
-				Values: []*string{aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", clusterName))},
+				Values: aws.StringSlice([]string{fmt.Sprintf("kubernetes.io/cluster/%s", clusterName)}),
 			},
 			{
 				Name:   aws.String("tag-value"),
-				Values: []*string{aws.String("owned")},
+				Values: aws.StringSlice([]string{"owned"}),
 			},
 		},
 	})
 	if err != nil {
-		return nil, err
+		return nil, ignoreNotFound(err)
 	}
 
 	var results []string
@@ -548,15 +558,1254 @@ func (c *Client) ListKubernetesSecurityGroups(ctx context.Context, vpcID, cluste
 	return results, nil
 }
 
-// DeleteSecurityGroup deletes the security group with the specific <id>. If it does not exist, no error is returned.
+// CreateVpcDhcpOptions creates a DHCP option resource.
+func (c *Client) CreateVpcDhcpOptions(ctx context.Context, options *DhcpOptions) (*DhcpOptions, error) {
+	var newConfigs []*ec2.NewDhcpConfiguration
+
+	for key, values := range options.DhcpConfigurations {
+		newConfigs = append(newConfigs, &ec2.NewDhcpConfiguration{
+			Key:    aws.String(key),
+			Values: aws.StringSlice(values),
+		})
+	}
+	input := &ec2.CreateDhcpOptionsInput{
+		DhcpConfigurations: newConfigs,
+		TagSpecifications:  options.ToTagSpecifications(ec2.ResourceTypeDhcpOptions),
+	}
+	output, err := c.EC2.CreateDhcpOptionsWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return fromDhcpOptions(output.DhcpOptions), nil
+}
+
+// GetVpcDhcpOptions gets a DHCP option resource by identifier.
+func (c *Client) GetVpcDhcpOptions(ctx context.Context, id string) (*DhcpOptions, error) {
+	input := &ec2.DescribeDhcpOptionsInput{DhcpOptionsIds: aws.StringSlice([]string{id})}
+	output, err := c.describeVpcDhcpOptions(ctx, input)
+	return single(output, err)
+}
+
+// FindVpcDhcpOptionsByTags finds DHCP option resources matching the given tag map.
+func (c *Client) FindVpcDhcpOptionsByTags(ctx context.Context, tags Tags) ([]*DhcpOptions, error) {
+	input := &ec2.DescribeDhcpOptionsInput{Filters: tags.ToFilters()}
+	return c.describeVpcDhcpOptions(ctx, input)
+}
+
+func (c *Client) describeVpcDhcpOptions(ctx context.Context, input *ec2.DescribeDhcpOptionsInput) ([]*DhcpOptions, error) {
+	output, err := c.EC2.DescribeDhcpOptionsWithContext(ctx, input)
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	var options []*DhcpOptions
+	for _, item := range output.DhcpOptions {
+		options = append(options, fromDhcpOptions(item))
+	}
+	return options, nil
+}
+
+// DeleteVpcDhcpOptions deletes a DHCP option resource by identifier.
+// Returns nil, if the resource is not found.
+func (c *Client) DeleteVpcDhcpOptions(ctx context.Context, id string) error {
+	_, err := c.EC2.DeleteDhcpOptionsWithContext(ctx, &ec2.DeleteDhcpOptionsInput{DhcpOptionsId: aws.String(id)})
+	return ignoreNotFound(err)
+}
+
+// CreateVpc creates a VPC resource.
+func (c *Client) CreateVpc(ctx context.Context, desired *VPC) (*VPC, error) {
+	input := &ec2.CreateVpcInput{
+		CidrBlock: aws.String(desired.CidrBlock),
+
+		TagSpecifications: desired.ToTagSpecifications(ec2.ResourceTypeVpc),
+	}
+	output, err := c.EC2.CreateVpc(input)
+	if err != nil {
+		return nil, err
+	}
+	vpcID := *output.Vpc.VpcId
+	return c.GetVpc(ctx, vpcID)
+}
+
+// UpdateVpcAttribute sets/updates a VPC attribute if needed.
+// Supported attribute names are
+// `enableDnsSupport` (const ec2.VpcAttributeNameEnableDnsSupport) and
+// `enableDnsHostnames` (const ec2.VpcAttributeNameEnableDnsHostnames) and
+func (c *Client) UpdateVpcAttribute(ctx context.Context, vpcId, attributeName string, value bool) error {
+	switch attributeName {
+	case ec2.VpcAttributeNameEnableDnsSupport:
+		input := &ec2.ModifyVpcAttributeInput{
+			EnableDnsSupport: &ec2.AttributeBooleanValue{
+				Value: aws.Bool(value),
+			},
+			VpcId: aws.String(vpcId),
+		}
+		if _, err := c.EC2.ModifyVpcAttribute(input); err != nil {
+			return err
+		}
+		if err := c.PollImmediateUntil(ctx, func(ctx context.Context) (bool, error) {
+			b, err := c.describeVpcAttributeWithContext(ctx, aws.String(vpcId), ec2.VpcAttributeNameEnableDnsSupport)
+			return b == value, err
+		}); err != nil {
+			return err
+		}
+		return nil
+	case ec2.VpcAttributeNameEnableDnsHostnames:
+		input := &ec2.ModifyVpcAttributeInput{
+			EnableDnsHostnames: &ec2.AttributeBooleanValue{
+				Value: aws.Bool(value),
+			},
+			VpcId: aws.String(vpcId),
+		}
+		if _, err := c.EC2.ModifyVpcAttribute(input); err != nil {
+			return err
+		}
+		if err := c.PollImmediateUntil(ctx, func(ctx context.Context) (bool, error) {
+			b, err := c.describeVpcAttributeWithContext(ctx, aws.String(vpcId), ec2.VpcAttributeNameEnableDnsHostnames)
+			return b == value, err
+		}); err != nil {
+			return err
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown attribute name: %s", attributeName)
+	}
+}
+
+// AddVpcDhcpOptionAssociation associates existing DHCP options resource to VPC resource, both identified by id.
+func (c *Client) AddVpcDhcpOptionAssociation(vpcId string, dhcpOptionsId *string) error {
+	if dhcpOptionsId == nil {
+		// AWS does not provide an API to disassociate a DHCP Options set from a VPC.
+		// So, we do this by setting the VPC to the default DHCP Options Set.
+		dhcpOptionsId = aws.String("default")
+	}
+	_, err := c.EC2.AssociateDhcpOptions(&ec2.AssociateDhcpOptionsInput{
+		DhcpOptionsId: dhcpOptionsId,
+		VpcId:         aws.String(vpcId),
+	})
+	return err
+}
+
+// DeleteVpc deletes a VPC resource by identifier.
+// Returns nil, if the resource is not found.
+func (c *Client) DeleteVpc(ctx context.Context, id string) error {
+	_, err := c.EC2.DeleteVpcWithContext(ctx, &ec2.DeleteVpcInput{VpcId: aws.String(id)})
+	return ignoreNotFound(err)
+}
+
+// GetVpc gets a VPC resource by identifier.
+// Returns nil, if the resource is not found.
+func (c *Client) GetVpc(ctx context.Context, id string) (*VPC, error) {
+	input := &ec2.DescribeVpcsInput{VpcIds: aws.StringSlice([]string{id})}
+	output, err := c.describeVpcs(ctx, input)
+	return single(output, err)
+}
+
+// FindVpcsByTags finds VPC resources matching the given tag map.
+func (c *Client) FindVpcsByTags(ctx context.Context, tags Tags) ([]*VPC, error) {
+	input := &ec2.DescribeVpcsInput{Filters: tags.ToFilters()}
+	return c.describeVpcs(ctx, input)
+}
+
+func (c *Client) describeVpcs(ctx context.Context, input *ec2.DescribeVpcsInput) ([]*VPC, error) {
+	output, err := c.EC2.DescribeVpcs(input)
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	var vpcList []*VPC
+	for _, item := range output.Vpcs {
+		vpc, err := c.fromVpc(ctx, item, true)
+		if err != nil {
+			return nil, err
+		}
+		vpcList = append(vpcList, vpc)
+	}
+	return vpcList, nil
+}
+
+func (c *Client) fromVpc(ctx context.Context, item *ec2.Vpc, withAttributes bool) (*VPC, error) {
+	vpc := &VPC{
+		VpcId:           aws.StringValue(item.VpcId),
+		Tags:            FromTags(item.Tags),
+		CidrBlock:       aws.StringValue(item.CidrBlock),
+		DhcpOptionsId:   item.DhcpOptionsId,
+		InstanceTenancy: item.InstanceTenancy,
+		State:           item.State,
+	}
+	var err error
+	if withAttributes {
+		if vpc.EnableDnsHostnames, err = c.describeVpcAttributeWithContext(ctx, item.VpcId, ec2.VpcAttributeNameEnableDnsHostnames); err != nil {
+			return nil, err
+		}
+		if vpc.EnableDnsSupport, err = c.describeVpcAttributeWithContext(ctx, item.VpcId, ec2.VpcAttributeNameEnableDnsSupport); err != nil {
+			return nil, err
+		}
+	}
+	return vpc, nil
+}
+
+func (c *Client) describeVpcAttributeWithContext(ctx context.Context, vpcId *string, attributeName string) (bool, error) {
+	output, err := c.EC2.DescribeVpcAttributeWithContext(ctx, &ec2.DescribeVpcAttributeInput{
+		Attribute: aws.String(attributeName),
+		VpcId:     vpcId,
+	})
+	if err != nil {
+		return false, ignoreNotFound(err)
+	}
+	switch attributeName {
+	case ec2.VpcAttributeNameEnableDnsHostnames:
+		return *output.EnableDnsHostnames.Value, nil
+	case ec2.VpcAttributeNameEnableDnsSupport:
+		return *output.EnableDnsSupport.Value, nil
+	default:
+		return false, fmt.Errorf("unknown attribute: %s", attributeName)
+	}
+}
+
+// CreateSecurityGroup creates a security group. Note that the rules of the input object are ignored.
+// Use the AuthorizeSecurityGroupRules method to add rules.
+func (c *Client) CreateSecurityGroup(ctx context.Context, sg *SecurityGroup) (*SecurityGroup, error) {
+	input := &ec2.CreateSecurityGroupInput{
+		GroupName:         aws.String(sg.GroupName),
+		TagSpecifications: sg.ToTagSpecifications(ec2.ResourceTypeSecurityGroup),
+		VpcId:             sg.VpcId,
+		Description:       sg.Description,
+	}
+	output, err := c.EC2.CreateSecurityGroupWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	created := *sg
+	created.Rules = nil
+	created.GroupId = *output.GroupId
+	return &created, nil
+}
+
+// AuthorizeSecurityGroupRules adds security group rules for the security group identified by the groupId.
+func (c *Client) AuthorizeSecurityGroupRules(ctx context.Context, groupId string, rules []*SecurityGroupRule) error {
+	ingressPermissions, egressPermissions, err := c.prepareRules(groupId, rules)
+	if err != nil {
+		return err
+	}
+	if len(ingressPermissions) > 0 {
+		input := &ec2.AuthorizeSecurityGroupIngressInput{
+			GroupId:       aws.String(groupId),
+			IpPermissions: ingressPermissions,
+		}
+		if _, err := c.EC2.AuthorizeSecurityGroupIngressWithContext(ctx, input); err != nil {
+			return err
+		}
+	}
+	if len(egressPermissions) > 0 {
+		input := &ec2.AuthorizeSecurityGroupEgressInput{
+			GroupId:       aws.String(groupId),
+			IpPermissions: egressPermissions,
+		}
+		if _, err := c.EC2.AuthorizeSecurityGroupEgressWithContext(ctx, input); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RevokeSecurityGroupRules removes security group rules for the security group identified by the groupId.
+func (c *Client) RevokeSecurityGroupRules(ctx context.Context, groupId string, rules []*SecurityGroupRule) error {
+	ingressPermissions, egressPermissions, err := c.prepareRules(groupId, rules)
+	if err != nil {
+		return err
+	}
+	if len(ingressPermissions) > 0 {
+		input := &ec2.RevokeSecurityGroupIngressInput{
+			GroupId:       aws.String(groupId),
+			IpPermissions: ingressPermissions,
+		}
+		if _, err := c.EC2.RevokeSecurityGroupIngressWithContext(ctx, input); err != nil {
+			return err
+		}
+	}
+	if len(egressPermissions) > 0 {
+		input := &ec2.RevokeSecurityGroupEgressInput{
+			GroupId:       aws.String(groupId),
+			IpPermissions: egressPermissions,
+		}
+		if _, err := c.EC2.RevokeSecurityGroupEgressWithContext(ctx, input); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Client) prepareRules(groupId string, rules []*SecurityGroupRule) (ingressPermissions, egressPermissions []*ec2.IpPermission, err error) {
+	for _, rule := range rules {
+		var ipPerm *ec2.IpPermission
+		if rule.Foreign != nil {
+			if err = json.Unmarshal([]byte(*rule.Foreign), ipPerm); err != nil {
+				return
+			}
+		} else {
+			ipPerm = &ec2.IpPermission{
+				IpProtocol:       aws.String(rule.Protocol),
+				IpRanges:         nil,
+				PrefixListIds:    nil,
+				UserIdGroupPairs: nil,
+			}
+			if rule.FromPort != 0 {
+				ipPerm.FromPort = aws.Int64(int64(rule.FromPort))
+			}
+			if rule.ToPort != 0 {
+				ipPerm.ToPort = aws.Int64(int64(rule.ToPort))
+			}
+			for _, block := range rule.CidrBlocks {
+				ipPerm.IpRanges = append(ipPerm.IpRanges, &ec2.IpRange{CidrIp: aws.String(block)})
+			}
+			if rule.Self {
+				ipPerm.UserIdGroupPairs = []*ec2.UserIdGroupPair{
+					{GroupId: aws.String(groupId)},
+				}
+			}
+		}
+		switch rule.Type {
+		case SecurityGroupRuleTypeIngress:
+			ingressPermissions = append(ingressPermissions, ipPerm)
+		case SecurityGroupRuleTypeEgress:
+			egressPermissions = append(egressPermissions, ipPerm)
+		default:
+			err = fmt.Errorf("unknown security group rule type: %s", rule.Type)
+			return
+		}
+	}
+	return
+}
+
+// GetSecurityGroup gets a security group by identifier. Ingress and egress rules are fetched, too.
+func (c *Client) GetSecurityGroup(ctx context.Context, id string) (*SecurityGroup, error) {
+	input := &ec2.DescribeSecurityGroupsInput{GroupIds: aws.StringSlice([]string{id})}
+	output, err := c.describeSecurityGroups(ctx, input)
+	return single(output, err)
+}
+
+// FindSecurityGroupsByTags finds security group matching the given tag map.
+// Ingress and egress rules are fetched, too.
+func (c *Client) FindSecurityGroupsByTags(ctx context.Context, tags Tags) ([]*SecurityGroup, error) {
+	input := &ec2.DescribeSecurityGroupsInput{Filters: tags.ToFilters()}
+	return c.describeSecurityGroups(ctx, input)
+}
+
+func (c *Client) describeSecurityGroups(ctx context.Context, input *ec2.DescribeSecurityGroupsInput) ([]*SecurityGroup, error) {
+	output, err := c.EC2.DescribeSecurityGroupsWithContext(ctx, input)
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	var sgList []*SecurityGroup
+	for _, item := range output.SecurityGroups {
+		sg := &SecurityGroup{
+			Tags:        FromTags(item.Tags),
+			GroupId:     aws.StringValue(item.GroupId),
+			GroupName:   aws.StringValue(item.GroupName),
+			VpcId:       item.VpcId,
+			Description: item.Description,
+		}
+		for _, ipPerm := range item.IpPermissions {
+			rule, err := fromIpPermission(aws.StringValue(item.GroupId), ipPerm, SecurityGroupRuleTypeIngress)
+			if err != nil {
+				return nil, err
+			}
+			sg.Rules = append(sg.Rules, rule)
+		}
+		for _, ipPerm := range item.IpPermissionsEgress {
+			rule, err := fromIpPermission(aws.StringValue(item.GroupId), ipPerm, SecurityGroupRuleTypeEgress)
+			if err != nil {
+				return nil, err
+			}
+			sg.Rules = append(sg.Rules, rule)
+		}
+		sgList = append(sgList, sg)
+	}
+	return sgList, nil
+}
+
+// FindDefaultSecurityGroupByVpcId finds the default security group for the given VPC identifier.
+func (c *Client) FindDefaultSecurityGroupByVpcId(ctx context.Context, vpcId string) (*SecurityGroup, error) {
+	input := &ec2.DescribeSecurityGroupsInput{
+		Filters: []*ec2.Filter{
+			{Name: aws.String("vpc-id"), Values: aws.StringSlice([]string{vpcId})},
+		},
+	}
+	groups, err := c.describeSecurityGroups(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	for _, group := range groups {
+		if group.GroupName == "default" {
+			return group, nil
+		}
+	}
+	return nil, nil
+}
+
+// DeleteSecurityGroup deletes a security group resource by identifier.
+// Returns nil, if the resource is not found.
 func (c *Client) DeleteSecurityGroup(ctx context.Context, id string) error {
 	_, err := c.EC2.DeleteSecurityGroupWithContext(ctx, &ec2.DeleteSecurityGroupInput{GroupId: aws.String(id)})
 	return ignoreNotFound(err)
 }
 
-// IsNotFoundError returns true if the given error is a awserr.Error indicating that a AWS resource was not found.
+// CreateInternetGateway creates an internet gateway.
+func (c *Client) CreateInternetGateway(ctx context.Context, gateway *InternetGateway) (*InternetGateway, error) {
+	input := &ec2.CreateInternetGatewayInput{
+		TagSpecifications: gateway.ToTagSpecifications(ec2.ResourceTypeInternetGateway),
+	}
+	output, err := c.EC2.CreateInternetGatewayWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return &InternetGateway{
+		Tags:              FromTags(output.InternetGateway.Tags),
+		InternetGatewayId: aws.StringValue(output.InternetGateway.InternetGatewayId),
+	}, nil
+}
+
+// AttachInternetGateway attaches an internet gateway to a VPC.
+// Returns no error, if the internet gateway is already attached to the VPC.
+func (c *Client) AttachInternetGateway(ctx context.Context, vpcId, internetGatewayId string) error {
+	input := &ec2.AttachInternetGatewayInput{
+		InternetGatewayId: aws.String(internetGatewayId),
+		VpcId:             aws.String(vpcId),
+	}
+	_, err := c.EC2.AttachInternetGatewayWithContext(ctx, input)
+	return ignoreAlreadyAssociated(err)
+}
+
+// DetachInternetGateway detaches an internet gateway to a VPC.
+// Returns no error, if the internet gateway is already detached.
+func (c *Client) DetachInternetGateway(ctx context.Context, vpcId, internetGatewayId string) error {
+	input := &ec2.DetachInternetGatewayInput{
+		InternetGatewayId: aws.String(internetGatewayId),
+		VpcId:             aws.String(vpcId),
+	}
+	_, err := c.EC2.DetachInternetGatewayWithContext(ctx, input)
+	return err
+}
+
+// GetInternetGateway gets an internet gateway resource by identifier.
+func (c *Client) GetInternetGateway(ctx context.Context, id string) (*InternetGateway, error) {
+	input := &ec2.DescribeInternetGatewaysInput{InternetGatewayIds: aws.StringSlice([]string{id})}
+	output, err := c.describeInternetGateways(ctx, input)
+	return single(output, err)
+}
+
+// FindInternetGatewaysByTags finds internet gateway resources matching the given tag map.
+func (c *Client) FindInternetGatewaysByTags(ctx context.Context, tags Tags) ([]*InternetGateway, error) {
+	input := &ec2.DescribeInternetGatewaysInput{Filters: tags.ToFilters()}
+	return c.describeInternetGateways(ctx, input)
+}
+
+// FindInternetGatewayByVPC finds an internet gateway resource attached to the given VPC.
+func (c *Client) FindInternetGatewayByVPC(ctx context.Context, vpcId string) (*InternetGateway, error) {
+	input := &ec2.DescribeInternetGatewaysInput{Filters: []*ec2.Filter{{
+		Name:   aws.String("attachment.vpc-id"),
+		Values: aws.StringSlice([]string{vpcId}),
+	}}}
+	output, err := c.describeInternetGateways(ctx, input)
+	return single(output, err)
+}
+
+func (c *Client) describeInternetGateways(ctx context.Context, input *ec2.DescribeInternetGatewaysInput) ([]*InternetGateway, error) {
+	output, err := c.EC2.DescribeInternetGatewaysWithContext(ctx, input)
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	var gateways []*InternetGateway
+	for _, item := range output.InternetGateways {
+		gw := &InternetGateway{
+			Tags:              FromTags(item.Tags),
+			InternetGatewayId: aws.StringValue(item.InternetGatewayId),
+		}
+		for _, attachment := range item.Attachments {
+			gw.VpcId = attachment.VpcId
+			break
+		}
+		gateways = append(gateways, gw)
+	}
+	return gateways, nil
+}
+
+// DeleteInternetGateway deletes an internet gateway resource.
+// Returns nil, if the resource is not found.
+func (c *Client) DeleteInternetGateway(ctx context.Context, id string) error {
+	input := &ec2.DeleteInternetGatewayInput{
+		InternetGatewayId: aws.String(id),
+	}
+	_, err := c.EC2.DeleteInternetGatewayWithContext(ctx, input)
+	return ignoreNotFound(err)
+}
+
+// CreateVpcEndpoint creates an EC2 VPC endpoint resource.
+func (c *Client) CreateVpcEndpoint(ctx context.Context, endpoint *VpcEndpoint) (*VpcEndpoint, error) {
+	input := &ec2.CreateVpcEndpointInput{
+		ServiceName: aws.String(endpoint.ServiceName),
+		//TagSpecifications: endpoint.ToTagSpecifications(ec2.ResourceTypeClientVpnEndpoint),
+		VpcId: endpoint.VpcId,
+	}
+	output, err := c.EC2.CreateVpcEndpointWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return &VpcEndpoint{
+		//Tags:          FromTags(output.VpcEndpoint.Tags),
+		VpcEndpointId: aws.StringValue(output.VpcEndpoint.VpcEndpointId),
+		VpcId:         output.VpcEndpoint.VpcId,
+		ServiceName:   aws.StringValue(output.VpcEndpoint.ServiceName),
+	}, nil
+}
+
+// GetVpcEndpoints gets VPC endpoint resources by identifiers.
+// Non-existing identifiers are silently ignored.
+func (c *Client) GetVpcEndpoints(ctx context.Context, ids []string) ([]*VpcEndpoint, error) {
+	input := &ec2.DescribeVpcEndpointsInput{VpcEndpointIds: aws.StringSlice(ids)}
+	return c.describeVpcEndpoints(ctx, input)
+}
+
+// FindVpcEndpointsByTags finds VPC endpoint resources matching the given tag map.
+func (c *Client) FindVpcEndpointsByTags(ctx context.Context, tags Tags) ([]*VpcEndpoint, error) {
+	input := &ec2.DescribeVpcEndpointsInput{Filters: tags.ToFilters()}
+	return c.describeVpcEndpoints(ctx, input)
+}
+
+func (c *Client) describeVpcEndpoints(ctx context.Context, input *ec2.DescribeVpcEndpointsInput) ([]*VpcEndpoint, error) {
+	output, err := c.EC2.DescribeVpcEndpointsWithContext(ctx, input)
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	var endpoints []*VpcEndpoint
+	for _, item := range output.VpcEndpoints {
+		endpoint := &VpcEndpoint{
+			Tags:          FromTags(item.Tags),
+			VpcEndpointId: aws.StringValue(item.VpcEndpointId),
+			VpcId:         item.VpcId,
+			ServiceName:   aws.StringValue(item.ServiceName),
+		}
+		endpoints = append(endpoints, endpoint)
+	}
+	return endpoints, nil
+}
+
+// DeleteVpcEndpoint deletes a VPC endpoint by id.
+// Returns nil if resource is not found.
+func (c *Client) DeleteVpcEndpoint(ctx context.Context, id string) error {
+	input := &ec2.DeleteVpcEndpointsInput{
+		VpcEndpointIds: []*string{&id},
+	}
+	_, err := c.EC2.DeleteVpcEndpointsWithContext(ctx, input)
+	return ignoreNotFound(err)
+}
+
+// CreateVpcEndpointRouteTableAssociation creates a route for a VPC endpoint.
+// Itempotent, i.e. does nothing if the route is already existing.
+func (c *Client) CreateVpcEndpointRouteTableAssociation(ctx context.Context, routeTableId, vpcEndpointId string) error {
+	routeTable, err := c.GetRouteTable(ctx, routeTableId)
+	if err != nil {
+		return err
+	}
+	for _, route := range routeTable.Routes {
+		if route.GatewayId != nil && *route.GatewayId == vpcEndpointId {
+			return nil // already existing
+		}
+	}
+
+	input := &ec2.ModifyVpcEndpointInput{
+		VpcEndpointId:    aws.String(vpcEndpointId),
+		AddRouteTableIds: aws.StringSlice([]string{routeTableId}),
+	}
+	_, err = c.EC2.ModifyVpcEndpointWithContext(ctx, input)
+	return err
+}
+
+// DeleteVpcEndpointRouteTableAssociation deletes the route to a VPC endpoint
+// Returns nil not found
+func (c *Client) DeleteVpcEndpointRouteTableAssociation(ctx context.Context, routeTableId, vpcEndpointId string) error {
+	routeTable, err := c.GetRouteTable(ctx, routeTableId)
+	if err != nil {
+		return err
+	}
+	for _, route := range routeTable.Routes {
+		if route.GatewayId != nil && *route.GatewayId == vpcEndpointId {
+			input := &ec2.ModifyVpcEndpointInput{
+				VpcEndpointId:       aws.String(vpcEndpointId),
+				RemoveRouteTableIds: aws.StringSlice([]string{routeTableId}),
+			}
+			_, err = c.EC2.ModifyVpcEndpointWithContext(ctx, input)
+			return err
+		}
+	}
+	return nil
+}
+
+// CreateRouteTable creates an EC2 route table resource.
+// Routes specified in the input object are ignored.
+func (c *Client) CreateRouteTable(ctx context.Context, routeTable *RouteTable) (*RouteTable, error) {
+	input := &ec2.CreateRouteTableInput{
+		TagSpecifications: routeTable.ToTagSpecifications(ec2.ResourceTypeRouteTable),
+		VpcId:             routeTable.VpcId,
+	}
+	output, err := c.EC2.CreateRouteTableWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	created := &RouteTable{
+		Tags:         FromTags(output.RouteTable.Tags),
+		RouteTableId: aws.StringValue(output.RouteTable.RouteTableId),
+		VpcId:        output.RouteTable.VpcId,
+	}
+
+	return created, nil
+}
+
+// CreateRoute creates a route for the given route table.
+func (c *Client) CreateRoute(ctx context.Context, routeTableId string, route *Route) error {
+	input := &ec2.CreateRouteInput{
+		DestinationCidrBlock:    route.DestinationCidrBlock,
+		DestinationPrefixListId: route.DestinationPrefixListId,
+		GatewayId:               route.GatewayId,
+		NatGatewayId:            route.NatGatewayId,
+		RouteTableId:            aws.String(routeTableId),
+	}
+	_, err := c.EC2.CreateRouteWithContext(ctx, input)
+	return err
+}
+
+// DeleteRoute deletes a route from the given route table.
+func (c *Client) DeleteRoute(ctx context.Context, routeTableId string, route *Route) error {
+	input := &ec2.DeleteRouteInput{
+		DestinationCidrBlock:    route.DestinationCidrBlock,
+		DestinationPrefixListId: route.DestinationPrefixListId,
+		RouteTableId:            aws.String(routeTableId),
+	}
+	_, err := c.EC2.DeleteRouteWithContext(ctx, input)
+	return err
+}
+
+// GetRouteTable gets a route table by the identifier.
+func (c *Client) GetRouteTable(ctx context.Context, id string) (*RouteTable, error) {
+	input := &ec2.DescribeRouteTablesInput{RouteTableIds: aws.StringSlice([]string{id})}
+	output, err := c.describeRouteTables(ctx, input)
+	return single(output, err)
+}
+
+// FindRouteTablesByTags finds routing table resources matching the given tag map.
+func (c *Client) FindRouteTablesByTags(ctx context.Context, tags Tags) ([]*RouteTable, error) {
+	input := &ec2.DescribeRouteTablesInput{Filters: tags.ToFilters()}
+	return c.describeRouteTables(ctx, input)
+}
+
+func (c *Client) describeRouteTables(ctx context.Context, input *ec2.DescribeRouteTablesInput) ([]*RouteTable, error) {
+	output, err := c.EC2.DescribeRouteTablesWithContext(ctx, input)
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	var tables []*RouteTable
+	for _, item := range output.RouteTables {
+		table := &RouteTable{
+			Tags:         FromTags(item.Tags),
+			RouteTableId: aws.StringValue(item.RouteTableId),
+			VpcId:        item.VpcId,
+		}
+		for _, route := range item.Routes {
+			table.Routes = append(table.Routes, &Route{
+				DestinationCidrBlock:    route.DestinationCidrBlock,
+				GatewayId:               route.GatewayId,
+				NatGatewayId:            route.NatGatewayId,
+				DestinationPrefixListId: route.DestinationPrefixListId,
+			})
+		}
+		for _, assoc := range item.Associations {
+			table.Associations = append(table.Associations, &RouteTableAssociation{
+				RouteTableAssociationId: aws.StringValue(assoc.RouteTableAssociationId),
+				Main:                    aws.BoolValue(assoc.Main),
+				GatewayId:               assoc.GatewayId,
+				SubnetId:                assoc.SubnetId,
+			})
+		}
+		tables = append(tables, table)
+	}
+	return tables, nil
+}
+
+// DeleteRouteTable delete a route table by identifier.
+// Returns nil if the resource is not found.
+func (c *Client) DeleteRouteTable(ctx context.Context, id string) error {
+	input := &ec2.DeleteRouteTableInput{
+		RouteTableId: aws.String(id),
+	}
+	_, err := c.EC2.DeleteRouteTableWithContext(ctx, input)
+	return ignoreNotFound(err)
+}
+
+// CreateSubnet creates an EC2 subnet resource.
+func (c *Client) CreateSubnet(ctx context.Context, subnet *Subnet) (*Subnet, error) {
+	input := &ec2.CreateSubnetInput{
+		AvailabilityZone:  aws.String(subnet.AvailabilityZone),
+		CidrBlock:         aws.String(subnet.CidrBlock),
+		TagSpecifications: subnet.ToTagSpecifications(ec2.ResourceTypeSubnet),
+		VpcId:             subnet.VpcId,
+	}
+	output, err := c.EC2.CreateSubnetWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return fromSubnet(output.Subnet), nil
+}
+
+// GetSubnets gets subnets for the given identifiers.
+// Non-existing identifiers are ignored silently.
+func (c *Client) GetSubnets(ctx context.Context, ids []string) ([]*Subnet, error) {
+	input := &ec2.DescribeSubnetsInput{SubnetIds: aws.StringSlice(ids)}
+	return c.describeSubnets(ctx, input)
+}
+
+// FindSubnetsByTags finds subnet resources matching the given tag map.
+func (c *Client) FindSubnetsByTags(ctx context.Context, tags Tags) ([]*Subnet, error) {
+	input := &ec2.DescribeSubnetsInput{Filters: tags.ToFilters()}
+	return c.describeSubnets(ctx, input)
+}
+
+func (c *Client) describeSubnets(ctx context.Context, input *ec2.DescribeSubnetsInput) ([]*Subnet, error) {
+	output, err := c.EC2.DescribeSubnetsWithContext(ctx, input)
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	var subnets []*Subnet
+	for _, item := range output.Subnets {
+		subnets = append(subnets, fromSubnet(item))
+	}
+	return subnets, nil
+}
+
+// UpdateSubnetAttributes updates attributes of the given subnet
+func (c *Client) UpdateSubnetAttributes(ctx context.Context, desired, current *Subnet) (bool, error) {
+	modified := false
+	if trueOrFalse(current.AssignIpv6AddressOnCreation) != trueOrFalse(desired.AssignIpv6AddressOnCreation) {
+		input := &ec2.ModifySubnetAttributeInput{
+			AssignIpv6AddressOnCreation: toAttributeBooleanValue(desired.AssignIpv6AddressOnCreation),
+			SubnetId:                    aws.String(current.SubnetId),
+		}
+		if _, err := c.EC2.ModifySubnetAttributeWithContext(ctx, input); err != nil {
+			return false, fmt.Errorf("updating AssignIpv6AddressOnCreation failed: %w", err)
+		}
+		modified = true
+	}
+	if trueOrFalse(current.EnableDns64) != trueOrFalse(desired.EnableDns64) {
+		input := &ec2.ModifySubnetAttributeInput{
+			EnableDns64: toAttributeBooleanValue(desired.EnableDns64),
+			SubnetId:    aws.String(current.SubnetId),
+		}
+		if _, err := c.EC2.ModifySubnetAttributeWithContext(ctx, input); err != nil {
+			return false, fmt.Errorf("updating EnableDns64 failed: %w", err)
+		}
+		modified = true
+	}
+	if trueOrFalse(current.EnableResourceNameDnsAAAARecordOnLaunch) != trueOrFalse(desired.EnableResourceNameDnsAAAARecordOnLaunch) {
+		input := &ec2.ModifySubnetAttributeInput{
+			EnableResourceNameDnsAAAARecordOnLaunch: toAttributeBooleanValue(desired.EnableResourceNameDnsAAAARecordOnLaunch),
+			SubnetId:                                aws.String(current.SubnetId),
+		}
+		if _, err := c.EC2.ModifySubnetAttributeWithContext(ctx, input); err != nil {
+			return false, fmt.Errorf("updating EnableResourceNameDnsAAAARecordOnLaunch failed: %w", err)
+		}
+		modified = true
+	}
+	if trueOrFalse(current.EnableResourceNameDnsARecordOnLaunch) != trueOrFalse(desired.EnableResourceNameDnsARecordOnLaunch) {
+		input := &ec2.ModifySubnetAttributeInput{
+			EnableResourceNameDnsARecordOnLaunch: toAttributeBooleanValue(desired.EnableResourceNameDnsARecordOnLaunch),
+			SubnetId:                             aws.String(current.SubnetId),
+		}
+		if _, err := c.EC2.ModifySubnetAttributeWithContext(ctx, input); err != nil {
+			return false, fmt.Errorf("updating EnableResourceNameDnsARecordOnLaunch failed: %w", err)
+		}
+		modified = true
+	}
+	if trueOrFalse(current.MapCustomerOwnedIpOnLaunch) != trueOrFalse(desired.MapCustomerOwnedIpOnLaunch) {
+		input := &ec2.ModifySubnetAttributeInput{
+			MapCustomerOwnedIpOnLaunch: toAttributeBooleanValue(desired.MapCustomerOwnedIpOnLaunch),
+			SubnetId:                   aws.String(current.SubnetId),
+		}
+		if _, err := c.EC2.ModifySubnetAttributeWithContext(ctx, input); err != nil {
+			return false, fmt.Errorf("updating MapCustomerOwnedIpOnLaunch failed: %w", err)
+		}
+		modified = true
+	}
+	if trueOrFalse(current.MapPublicIpOnLaunch) != trueOrFalse(desired.MapPublicIpOnLaunch) {
+		input := &ec2.ModifySubnetAttributeInput{
+			MapPublicIpOnLaunch: toAttributeBooleanValue(desired.MapPublicIpOnLaunch),
+			SubnetId:            aws.String(current.SubnetId),
+		}
+		if _, err := c.EC2.ModifySubnetAttributeWithContext(ctx, input); err != nil {
+			return false, fmt.Errorf("updating MapPublicIpOnLaunch failed: %w", err)
+		}
+		modified = true
+	}
+	if !reflect.DeepEqual(current.CustomerOwnedIpv4Pool, desired.CustomerOwnedIpv4Pool) {
+		input := &ec2.ModifySubnetAttributeInput{
+			CustomerOwnedIpv4Pool: desired.CustomerOwnedIpv4Pool,
+			SubnetId:              aws.String(current.SubnetId),
+		}
+		if _, err := c.EC2.ModifySubnetAttributeWithContext(ctx, input); err != nil {
+			return false, fmt.Errorf("updating CustomerOwnedIpv4Pool failed: %w", err)
+		}
+		modified = true
+	}
+	privateDnsHostnameTypeOnLaunch := desired.PrivateDnsHostnameTypeOnLaunch
+	if privateDnsHostnameTypeOnLaunch == nil {
+		privateDnsHostnameTypeOnLaunch = aws.String(ec2.HostnameTypeIpName)
+	}
+	if !reflect.DeepEqual(current.PrivateDnsHostnameTypeOnLaunch, privateDnsHostnameTypeOnLaunch) {
+		input := &ec2.ModifySubnetAttributeInput{
+			PrivateDnsHostnameTypeOnLaunch: privateDnsHostnameTypeOnLaunch,
+			SubnetId:                       aws.String(current.SubnetId),
+		}
+		if _, err := c.EC2.ModifySubnetAttributeWithContext(ctx, input); err != nil {
+			return false, fmt.Errorf("updating PrivateDnsHostnameTypeOnLaunch failed: %w", err)
+		}
+		modified = true
+	}
+	return modified, nil
+}
+
+// DeleteSubnet delete a subnet by identifier.
+// Returns nil if the resource is not found.
+func (c *Client) DeleteSubnet(ctx context.Context, id string) error {
+	input := &ec2.DeleteSubnetInput{
+		SubnetId: aws.String(id),
+	}
+	var realErr error
+	err := c.PollImmediateUntil(ctx, func(ctx context.Context) (done bool, err error) {
+		_, realErr = c.EC2.DeleteSubnetWithContext(ctx, input)
+		return ignoreNotFound(realErr) == nil, nil
+	})
+	if err != nil {
+		if realErr != nil {
+			return realErr
+		}
+	}
+	return err
+}
+
+// CreateElasticIP creates an EC2 elastip IP resource.
+func (c *Client) CreateElasticIP(ctx context.Context, eip *ElasticIP) (*ElasticIP, error) {
+	domainOpt := ""
+	if eip.Vpc {
+		domainOpt = ec2.DomainTypeVpc
+	}
+	input := &ec2.AllocateAddressInput{
+		Domain:            aws.String(domainOpt),
+		TagSpecifications: eip.ToTagSpecifications(ec2.ResourceTypeElasticIp),
+	}
+	output, err := c.EC2.AllocateAddressWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return &ElasticIP{
+		Tags:         eip.Tags.Clone(),
+		Vpc:          eip.Vpc,
+		AllocationId: aws.StringValue(output.AllocationId),
+		PublicIp:     aws.StringValue(output.PublicIp),
+	}, nil
+}
+
+// GetElasticIP gets an elastic IP resource by identifier.
+func (c *Client) GetElasticIP(ctx context.Context, id string) (*ElasticIP, error) {
+	input := &ec2.DescribeAddressesInput{AllocationIds: aws.StringSlice([]string{id})}
+	output, err := c.describeElasticIPs(ctx, input)
+	return single(output, err)
+}
+
+// FindElasticIPsByTags finds elastic IP resources matching the given tag map.
+func (c *Client) FindElasticIPsByTags(ctx context.Context, tags Tags) ([]*ElasticIP, error) {
+	input := &ec2.DescribeAddressesInput{Filters: tags.ToFilters()}
+	return c.describeElasticIPs(ctx, input)
+}
+
+func (c *Client) describeElasticIPs(ctx context.Context, input *ec2.DescribeAddressesInput) ([]*ElasticIP, error) {
+	output, err := c.EC2.DescribeAddressesWithContext(ctx, input)
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	var eips []*ElasticIP
+	for _, item := range output.Addresses {
+		eips = append(eips, fromAddress(item))
+	}
+	return eips, nil
+}
+
+// DeleteElasticIP deletes an elastic IP resource by identifier.
+// Returns nil if the resource is not found.
+func (c *Client) DeleteElasticIP(ctx context.Context, id string) error {
+	input := &ec2.ReleaseAddressInput{
+		AllocationId: aws.String(id),
+	}
+	var realErr error
+	err := c.PollImmediateUntil(ctx, func(ctx context.Context) (done bool, err error) {
+		_, realErr = c.EC2.ReleaseAddressWithContext(ctx, input)
+		return ignoreNotFound(realErr) == nil, nil
+	})
+	if err != nil {
+		if realErr != nil {
+			return realErr
+		}
+	}
+	return err
+}
+
+// CreateNATGateway creates an EC2 NAT gateway resource.
+// The method does NOT wait until the NAT gateway is available.
+func (c *Client) CreateNATGateway(ctx context.Context, gateway *NATGateway) (*NATGateway, error) {
+	input := &ec2.CreateNatGatewayInput{
+		AllocationId:      aws.String(gateway.EIPAllocationId),
+		SubnetId:          aws.String(gateway.SubnetId),
+		TagSpecifications: gateway.ToTagSpecifications(ec2.ResourceTypeNatgateway),
+	}
+	output, err := c.EC2.CreateNatGatewayWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return fromNatGateway(output.NatGateway), nil
+}
+
+// WaitForNATGatewayAvailable waits until the NAT gateway has state "available" or the context is cancelled.
+func (c *Client) WaitForNATGatewayAvailable(ctx context.Context, id string) error {
+	return c.PollImmediateUntil(ctx, func(ctx context.Context) (done bool, err error) {
+		if item, err := c.GetNATGateway(ctx, id); err != nil {
+			return false, err
+		} else {
+			return strings.EqualFold(item.State, ec2.StateAvailable), nil
+		}
+	})
+}
+
+// GetNATGateway gets an NAT gateway by identifier.
+// If the resource is not found or in state "deleted", nil is returned
+func (c *Client) GetNATGateway(ctx context.Context, id string) (*NATGateway, error) {
+	input := &ec2.DescribeNatGatewaysInput{NatGatewayIds: aws.StringSlice([]string{id})}
+	output, err := c.describeNATGateways(ctx, input)
+	gw, err := single(output, err)
+	if gw != nil && strings.EqualFold(gw.State, ec2.StateDeleted) {
+		return nil, nil
+	}
+	return gw, err
+}
+
+// FindNATGatewaysByTags finds NAT gateway resources matching the given tag map.
+func (c *Client) FindNATGatewaysByTags(ctx context.Context, tags Tags) ([]*NATGateway, error) {
+	input := &ec2.DescribeNatGatewaysInput{Filter: tags.ToFilters()}
+	return c.describeNATGateways(ctx, input)
+}
+
+func (c *Client) describeNATGateways(ctx context.Context, input *ec2.DescribeNatGatewaysInput) ([]*NATGateway, error) {
+	output, err := c.EC2.DescribeNatGatewaysWithContext(ctx, input)
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	var gateways []*NATGateway
+	for _, item := range output.NatGateways {
+		gw := fromNatGateway(item)
+		if gw != nil {
+			gateways = append(gateways, gw)
+		}
+	}
+	return gateways, nil
+}
+
+// DeleteNATGateway deletes a NAT gateway by identifier.
+// Returns nil if the resource is not found.
+func (c *Client) DeleteNATGateway(ctx context.Context, id string) error {
+	input := &ec2.DeleteNatGatewayInput{
+		NatGatewayId: aws.String(id),
+	}
+	_, err := c.EC2.DeleteNatGatewayWithContext(ctx, input)
+	if err != nil {
+		return ignoreNotFound(err)
+	}
+	err = c.PollUntil(ctx, func(ctx context.Context) (done bool, err error) {
+		if item, err := c.GetNATGateway(ctx, id); err != nil {
+			return false, err
+		} else {
+			return item == nil, nil
+		}
+	})
+	return ignoreNotFound(err)
+}
+
+// ImportKeyPair creates a EC2 key pair.
+func (c *Client) ImportKeyPair(ctx context.Context, keyName string, publicKey []byte, tags Tags) (*KeyPairInfo, error) {
+	input := &ec2.ImportKeyPairInput{
+		KeyName:           aws.String(keyName),
+		PublicKeyMaterial: publicKey,
+		TagSpecifications: tags.ToTagSpecifications(ec2.ResourceTypeKeyPair),
+	}
+	output, err := c.EC2.ImportKeyPairWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return &KeyPairInfo{
+		Tags:           FromTags(output.Tags),
+		KeyName:        aws.StringValue(output.KeyName),
+		KeyFingerprint: aws.StringValue(output.KeyFingerprint),
+	}, nil
+}
+
+// GetKeyPair gets a EC2 key pair by its key name.
+func (c *Client) GetKeyPair(ctx context.Context, keyName string) (*KeyPairInfo, error) {
+	input := &ec2.DescribeKeyPairsInput{KeyNames: aws.StringSlice([]string{keyName})}
+	output, err := c.describeKeyPairs(ctx, input)
+	return single(output, err)
+}
+
+// FindKeyPairsByTags finds EC key pair resources matching the given tag map.
+func (c *Client) FindKeyPairsByTags(ctx context.Context, tags Tags) ([]*KeyPairInfo, error) {
+	input := &ec2.DescribeKeyPairsInput{Filters: tags.ToFilters()}
+	return c.describeKeyPairs(ctx, input)
+}
+
+func (c *Client) describeKeyPairs(ctx context.Context, input *ec2.DescribeKeyPairsInput) ([]*KeyPairInfo, error) {
+	output, err := c.EC2.DescribeKeyPairsWithContext(ctx, input)
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	var pairs []*KeyPairInfo
+	for _, item := range output.KeyPairs {
+		pairs = append(pairs, fromKeyPairInfo(item))
+	}
+	return pairs, nil
+}
+
+// DeleteKeyPair deletes an EC2 key pair given by the key name.
+// Returns nil if resource is not found.
+func (c *Client) DeleteKeyPair(ctx context.Context, keyName string) error {
+	input := &ec2.DeleteKeyPairInput{
+		KeyName: aws.String(keyName),
+	}
+	_, err := c.EC2.DeleteKeyPairWithContext(ctx, input)
+	return ignoreNotFound(err)
+}
+
+// CreateRouteTableAssociation associates a route table with a subnet.
+// Returns association id and error.
+func (c *Client) CreateRouteTableAssociation(ctx context.Context, routeTableId, subnetId string) (*string, error) {
+	input := &ec2.AssociateRouteTableInput{
+		RouteTableId: aws.String(routeTableId),
+		SubnetId:     aws.String(subnetId),
+	}
+	output, err := c.EC2.AssociateRouteTableWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return output.AssociationId, nil
+}
+
+// DeleteRouteTableAssociation deletes the route table association by the assocation identifier.
+// Returns nil if the resource is not found.
+func (c *Client) DeleteRouteTableAssociation(ctx context.Context, associationId string) error {
+	input := &ec2.DisassociateRouteTableInput{
+		AssociationId: aws.String(associationId),
+	}
+	_, err := c.EC2.DisassociateRouteTableWithContext(ctx, input)
+	return ignoreNotFound(err)
+}
+
+// CreateIAMRole creates an IAM role resource.
+func (c *Client) CreateIAMRole(ctx context.Context, role *IAMRole) (*IAMRole, error) {
+	input := &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: aws.String(role.AssumeRolePolicyDocument),
+		Path:                     aws.String(role.Path),
+		RoleName:                 aws.String(role.RoleName),
+	}
+	output, err := c.IAM.CreateRoleWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return fromIAMRole(output.Role), nil
+}
+
+// GetIAMRole gets an IAM role by role name.
+func (c *Client) GetIAMRole(ctx context.Context, roleName string) (*IAMRole, error) {
+	input := &iam.GetRoleInput{
+		RoleName: aws.String(roleName),
+	}
+	output, err := c.IAM.GetRoleWithContext(ctx, input)
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	return fromIAMRole(output.Role), nil
+}
+
+// DeleteIAMRole deletes an IAM role by role name.
+// Returns nil if the resource is not found.
+func (c *Client) DeleteIAMRole(ctx context.Context, roleName string) error {
+	input := &iam.DeleteRoleInput{
+		RoleName: aws.String(roleName),
+	}
+	_, err := c.IAM.DeleteRoleWithContext(ctx, input)
+	return ignoreNotFound(err)
+}
+
+// UpdateAssumeRolePolicy updates the assumeRolePolicy of an IAM role.
+func (c *Client) UpdateAssumeRolePolicy(ctx context.Context, roleName, assumeRolePolicy string) error {
+	input := &iam.UpdateAssumeRolePolicyInput{
+		RoleName:       aws.String(roleName),
+		PolicyDocument: aws.String(assumeRolePolicy),
+	}
+	_, err := c.IAM.UpdateAssumeRolePolicyWithContext(ctx, input)
+	return err
+}
+
+// CreateIAMInstanceProfile creates an IAM instance profile.
+func (c *Client) CreateIAMInstanceProfile(ctx context.Context, profile *IAMInstanceProfile) (*IAMInstanceProfile, error) {
+	input := &iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String(profile.InstanceProfileName),
+		Path:                aws.String(profile.Path),
+	}
+	output, err := c.IAM.CreateInstanceProfileWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	profileName := aws.StringValue(output.InstanceProfile.InstanceProfileName)
+	if err = c.PollImmediateUntil(ctx, func(ctx context.Context) (done bool, err error) {
+		if item, err := c.GetIAMInstanceProfile(ctx, profileName); err != nil {
+			return false, err
+		} else {
+			return item != nil, nil
+		}
+	}); err != nil {
+		return nil, err
+	}
+	return c.GetIAMInstanceProfile(ctx, profileName)
+}
+
+// GetIAMInstanceProfile gets an IAM instance profile by profile name.
+func (c *Client) GetIAMInstanceProfile(ctx context.Context, profileName string) (*IAMInstanceProfile, error) {
+	input := &iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+	}
+	output, err := c.IAM.GetInstanceProfileWithContext(ctx, input)
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	return fromIAMInstanceProfile(output.InstanceProfile), nil
+}
+
+// AddRoleToIAMInstanceProfile adds a role to an instance profile.
+func (c *Client) AddRoleToIAMInstanceProfile(ctx context.Context, profileName, roleName string) error {
+	input := &iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+		RoleName:            aws.String(roleName),
+	}
+	_, err := c.IAM.AddRoleToInstanceProfileWithContext(ctx, input)
+	return err
+}
+
+// RemoveRoleFromIAMInstanceProfile removes a role from an instance profile.
+func (c *Client) RemoveRoleFromIAMInstanceProfile(ctx context.Context, profileName, roleName string) error {
+	input := &iam.RemoveRoleFromInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+		RoleName:            aws.String(roleName),
+	}
+	_, err := c.IAM.RemoveRoleFromInstanceProfileWithContext(ctx, input)
+	return ignoreNotFound(err)
+}
+
+// DeleteIAMInstanceProfile deletes an IAM instance profile by profile name.
+// Returns nil if the resource is not found.
+func (c *Client) DeleteIAMInstanceProfile(ctx context.Context, profileName string) error {
+	input := &iam.DeleteInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+	}
+	_, err := c.IAM.DeleteInstanceProfileWithContext(ctx, input)
+	return ignoreNotFound(err)
+}
+
+// PutIAMRolePolicy creates or updates an IAM role policy.
+func (c *Client) PutIAMRolePolicy(ctx context.Context, policy *IAMRolePolicy) error {
+	input := &iam.PutRolePolicyInput{
+		PolicyDocument: aws.String(policy.PolicyDocument),
+		PolicyName:     aws.String(policy.PolicyName),
+		RoleName:       aws.String(policy.RoleName),
+	}
+	_, err := c.IAM.PutRolePolicyWithContext(ctx, input)
+	return err
+}
+
+// GetIAMRolePolicy gets an IAM role policy by policy name and role name.
+func (c *Client) GetIAMRolePolicy(ctx context.Context, policyName, roleName string) (*IAMRolePolicy, error) {
+	input := &iam.GetRolePolicyInput{
+		PolicyName: aws.String(policyName),
+		RoleName:   aws.String(roleName),
+	}
+	output, err := c.IAM.GetRolePolicyWithContext(ctx, input)
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	return &IAMRolePolicy{
+		PolicyName:     aws.StringValue(output.PolicyName),
+		RoleName:       aws.StringValue(output.RoleName),
+		PolicyDocument: aws.StringValue(output.PolicyDocument),
+	}, nil
+}
+
+// DeleteIAMRolePolicy deletes an IAM role policy by policy name and role name.
+// Returns nil if the resource is not found.
+func (c *Client) DeleteIAMRolePolicy(ctx context.Context, policyName, roleName string) error {
+	input := &iam.DeleteRolePolicyInput{
+		PolicyName: aws.String(policyName),
+		RoleName:   aws.String(roleName),
+	}
+	_, err := c.IAM.DeleteRolePolicyWithContext(ctx, input)
+	return ignoreNotFound(err)
+}
+
+// CreateEC2Tags creates the tags for the given EC2 resource identifiers
+func (c *Client) CreateEC2Tags(ctx context.Context, resources []string, tags Tags) error {
+	input := &ec2.CreateTagsInput{
+		Resources: aws.StringSlice(resources),
+		Tags:      tags.ToEC2Tags(),
+	}
+	_, err := c.EC2.CreateTagsWithContext(ctx, input)
+	return err
+}
+
+// DeleteEC2Tags deletes the tags for the given EC2 resource identifiers
+func (c *Client) DeleteEC2Tags(ctx context.Context, resources []string, tags Tags) error {
+	input := &ec2.DeleteTagsInput{
+		Resources: aws.StringSlice(resources),
+		Tags:      tags.ToEC2Tags(),
+	}
+	_, err := c.EC2.DeleteTagsWithContext(ctx, input)
+	return err
+}
+
+// PollImmediateUntil runs the 'condition' before waiting for the interval.
+// 'condition' will always be invoked at least once.
+func (c *Client) PollImmediateUntil(ctx context.Context, condition wait.ConditionWithContextFunc) error {
+	return wait.PollImmediateUntilWithContext(ctx, c.PollInterval, condition)
+}
+
+// PollUntil tries a condition func until it returns true,
+// an error or the specified context is cancelled or expired.
+func (c *Client) PollUntil(ctx context.Context, condition wait.ConditionWithContextFunc) error {
+	return wait.PollUntilWithContext(ctx, c.PollInterval, condition)
+}
+
+// IsNotFoundError returns true if the given error is a awserr.Error indicating that an AWS resource was not found.
 func IsNotFoundError(err error) bool {
-	if aerr, ok := err.(awserr.Error); ok && (aerr.Code() == elb.ErrCodeAccessPointNotFoundException || aerr.Code() == "InvalidGroup.NotFound" || aerr.Code() == "InvalidVpcID.NotFound") {
+	if aerr, ok := err.(awserr.Error); ok && (aerr.Code() == elb.ErrCodeAccessPointNotFoundException ||
+		aerr.Code() == iam.ErrCodeNoSuchEntityException || aerr.Code() == "NatGatewayNotFound" ||
+		strings.HasSuffix(aerr.Code(), ".NotFound")) {
+		return true
+	}
+	return false
+}
+
+// IsAlreadyAssociatedError returns true if the given error is a awserr.Error indicating that an AWS resource was already associated.
+func IsAlreadyAssociatedError(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "Resource.AlreadyAssociated" {
 		return true
 	}
 	return false
@@ -564,6 +1813,13 @@ func IsNotFoundError(err error) bool {
 
 func ignoreNotFound(err error) error {
 	if err == nil || IsNotFoundError(err) {
+		return nil
+	}
+	return err
+}
+
+func ignoreAlreadyAssociated(err error) error {
+	if err == nil || IsAlreadyAssociatedError(err) {
 		return nil
 	}
 	return err
@@ -582,4 +1838,181 @@ func chunkSlice(slice []*string, chunkSize int) [][]*string {
 	}
 
 	return chunks
+}
+
+func fromDhcpOptions(item *ec2.DhcpOptions) *DhcpOptions {
+	config := map[string][]string{}
+	for _, cfg := range item.DhcpConfigurations {
+		var values []string
+		for _, av := range cfg.Values {
+			values = append(values, *av.Value)
+		}
+		config[*cfg.Key] = values
+	}
+	return &DhcpOptions{
+		Tags:               FromTags(item.Tags),
+		DhcpOptionsId:      aws.StringValue(item.DhcpOptionsId),
+		DhcpConfigurations: config,
+	}
+}
+
+func fromIpPermission(groupId string, ipPerm *ec2.IpPermission, ruleType SecurityGroupRuleType) (*SecurityGroupRule, error) {
+	var foreign bool
+	var blocks []string
+	for _, block := range ipPerm.IpRanges {
+		blocks = append(blocks, *block.CidrIp)
+	}
+	rule := &SecurityGroupRule{
+		Type:       ruleType,
+		Protocol:   aws.StringValue(ipPerm.IpProtocol),
+		CidrBlocks: blocks,
+	}
+	if ipPerm.FromPort != nil {
+		rule.FromPort = int(*ipPerm.FromPort)
+	}
+	if ipPerm.ToPort != nil {
+		rule.ToPort = int(*ipPerm.ToPort)
+	}
+	if len(ipPerm.UserIdGroupPairs) == 1 && ipPerm.UserIdGroupPairs[0].GroupId != nil && *ipPerm.UserIdGroupPairs[0].GroupId == groupId {
+		rule.Self = true
+	} else if len(ipPerm.UserIdGroupPairs) != 0 {
+		foreign = true
+	}
+	if len(ipPerm.Ipv6Ranges) > 0 || len(ipPerm.PrefixListIds) > 0 {
+		foreign = true
+	}
+	if foreign {
+		data, err := json.Marshal(ipPerm)
+		if err != nil {
+			return nil, err
+		}
+		rule.Foreign = pointer.String(string(data))
+	}
+	return rule, nil
+}
+
+func fromSubnet(item *ec2.Subnet) *Subnet {
+	s := &Subnet{
+		Tags:                        FromTags(item.Tags),
+		SubnetId:                    aws.StringValue(item.SubnetId),
+		VpcId:                       item.VpcId,
+		CidrBlock:                   aws.StringValue(item.CidrBlock),
+		AvailabilityZone:            aws.StringValue(item.AvailabilityZone),
+		AssignIpv6AddressOnCreation: trueOrNil(item.AssignIpv6AddressOnCreation),
+		CustomerOwnedIpv4Pool:       item.CustomerOwnedIpv4Pool,
+		EnableDns64:                 trueOrNil(item.EnableDns64),
+		Ipv6Native:                  trueOrNil(item.Ipv6Native),
+		MapCustomerOwnedIpOnLaunch:  trueOrNil(item.MapCustomerOwnedIpOnLaunch),
+		MapPublicIpOnLaunch:         trueOrNil(item.MapPublicIpOnLaunch),
+		OutpostArn:                  item.OutpostArn,
+	}
+	if item.PrivateDnsNameOptionsOnLaunch != nil {
+		s.EnableResourceNameDnsAAAARecordOnLaunch = trueOrNil(item.PrivateDnsNameOptionsOnLaunch.EnableResourceNameDnsAAAARecord)
+		s.EnableResourceNameDnsARecordOnLaunch = trueOrNil(item.PrivateDnsNameOptionsOnLaunch.EnableResourceNameDnsARecord)
+		s.PrivateDnsHostnameTypeOnLaunch = item.PrivateDnsNameOptionsOnLaunch.HostnameType
+	}
+	for _, block := range item.Ipv6CidrBlockAssociationSet {
+		s.Ipv6CidrBlocks = append(s.Ipv6CidrBlocks, aws.StringValue(block.Ipv6CidrBlock))
+	}
+	return s
+}
+
+func fromAddress(item *ec2.Address) *ElasticIP {
+	return &ElasticIP{
+		Tags:         FromTags(item.Tags),
+		Vpc:          aws.StringValue(item.Domain) == ec2.DomainTypeVpc,
+		AllocationId: aws.StringValue(item.AllocationId),
+		PublicIp:     aws.StringValue(item.PublicIp),
+	}
+}
+
+func fromNatGateway(item *ec2.NatGateway) *NATGateway {
+	if strings.EqualFold(aws.StringValue(item.State), ec2.StateDeleted) {
+		return nil
+	}
+	var allocationId, publicIP string
+	for _, address := range item.NatGatewayAddresses {
+		allocationId = aws.StringValue(address.AllocationId)
+		publicIP = aws.StringValue(address.PublicIp)
+		break
+	}
+	return &NATGateway{
+		Tags:            FromTags(item.Tags),
+		NATGatewayId:    aws.StringValue(item.NatGatewayId),
+		EIPAllocationId: allocationId,
+		PublicIP:        publicIP,
+		SubnetId:        aws.StringValue(item.SubnetId),
+		State:           aws.StringValue(item.State),
+	}
+}
+
+func fromKeyPairInfo(item *ec2.KeyPairInfo) *KeyPairInfo {
+	return &KeyPairInfo{
+		Tags:           FromTags(item.Tags),
+		KeyName:        aws.StringValue(item.KeyName),
+		KeyFingerprint: aws.StringValue(item.KeyFingerprint),
+	}
+}
+
+func fromIAMRole(item *iam.Role) *IAMRole {
+	role := &IAMRole{
+		RoleId:                   aws.StringValue(item.RoleId),
+		RoleName:                 aws.StringValue(item.RoleName),
+		Path:                     aws.StringValue(item.Path),
+		AssumeRolePolicyDocument: aws.StringValue(item.AssumeRolePolicyDocument),
+		ARN:                      aws.StringValue(item.Arn),
+	}
+	if strings.Contains(role.AssumeRolePolicyDocument, "%7B") {
+		// URL decode needed, very strange API !?
+		decoded, err := url.QueryUnescape(role.AssumeRolePolicyDocument)
+		if err == nil {
+			role.AssumeRolePolicyDocument = decoded
+		}
+	}
+	return role
+}
+
+func fromIAMInstanceProfile(item *iam.InstanceProfile) *IAMInstanceProfile {
+	var roleName string
+	for _, role := range item.Roles {
+		roleName = aws.StringValue(role.RoleName)
+		break
+	}
+	return &IAMInstanceProfile{
+		InstanceProfileId:   aws.StringValue(item.InstanceProfileId),
+		InstanceProfileName: aws.StringValue(item.InstanceProfileName),
+		Path:                aws.StringValue(item.Path),
+		RoleName:            roleName,
+	}
+}
+
+func single[T any](list []*T, err error) (*T, error) {
+	if err != nil {
+		return nil, ignoreNotFound(err)
+	}
+	if len(list) == 0 {
+		return nil, nil
+	}
+	return list[0], nil
+}
+
+func toAttributeBooleanValue(value *bool) *ec2.AttributeBooleanValue {
+	if value == nil {
+		value = aws.Bool(false)
+	}
+	return &ec2.AttributeBooleanValue{Value: value}
+}
+
+func trueOrNil(value *bool) *bool {
+	if value == nil || !*value {
+		return nil
+	}
+	return value
+}
+
+func trueOrFalse(value *bool) bool {
+	if value == nil || !*value {
+		return false
+	}
+	return *value
 }

--- a/pkg/aws/client/client_suite_test.go
+++ b/pkg/aws/client/client_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAws(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AWS Client Suite")
+}

--- a/pkg/aws/client/mock/mocks.go
+++ b/pkg/aws/client/mock/mocks.go
@@ -36,6 +36,62 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
 }
 
+// AddRoleToIAMInstanceProfile mocks base method.
+func (m *MockInterface) AddRoleToIAMInstanceProfile(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddRoleToIAMInstanceProfile", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddRoleToIAMInstanceProfile indicates an expected call of AddRoleToIAMInstanceProfile.
+func (mr *MockInterfaceMockRecorder) AddRoleToIAMInstanceProfile(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRoleToIAMInstanceProfile", reflect.TypeOf((*MockInterface)(nil).AddRoleToIAMInstanceProfile), arg0, arg1, arg2)
+}
+
+// AddVpcDhcpOptionAssociation mocks base method.
+func (m *MockInterface) AddVpcDhcpOptionAssociation(arg0 string, arg1 *string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddVpcDhcpOptionAssociation", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddVpcDhcpOptionAssociation indicates an expected call of AddVpcDhcpOptionAssociation.
+func (mr *MockInterfaceMockRecorder) AddVpcDhcpOptionAssociation(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddVpcDhcpOptionAssociation", reflect.TypeOf((*MockInterface)(nil).AddVpcDhcpOptionAssociation), arg0, arg1)
+}
+
+// AttachInternetGateway mocks base method.
+func (m *MockInterface) AttachInternetGateway(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AttachInternetGateway", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AttachInternetGateway indicates an expected call of AttachInternetGateway.
+func (mr *MockInterfaceMockRecorder) AttachInternetGateway(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachInternetGateway", reflect.TypeOf((*MockInterface)(nil).AttachInternetGateway), arg0, arg1, arg2)
+}
+
+// AuthorizeSecurityGroupRules mocks base method.
+func (m *MockInterface) AuthorizeSecurityGroupRules(arg0 context.Context, arg1 string, arg2 []*client.SecurityGroupRule) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthorizeSecurityGroupRules", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AuthorizeSecurityGroupRules indicates an expected call of AuthorizeSecurityGroupRules.
+func (mr *MockInterfaceMockRecorder) AuthorizeSecurityGroupRules(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeSecurityGroupRules", reflect.TypeOf((*MockInterface)(nil).AuthorizeSecurityGroupRules), arg0, arg1, arg2)
+}
+
 // CreateBucketIfNotExists mocks base method.
 func (m *MockInterface) CreateBucketIfNotExists(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
@@ -50,6 +106,95 @@ func (mr *MockInterfaceMockRecorder) CreateBucketIfNotExists(arg0, arg1, arg2 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBucketIfNotExists", reflect.TypeOf((*MockInterface)(nil).CreateBucketIfNotExists), arg0, arg1, arg2)
 }
 
+// CreateEC2Tags mocks base method.
+func (m *MockInterface) CreateEC2Tags(arg0 context.Context, arg1 []string, arg2 client.Tags) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateEC2Tags", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateEC2Tags indicates an expected call of CreateEC2Tags.
+func (mr *MockInterfaceMockRecorder) CreateEC2Tags(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEC2Tags", reflect.TypeOf((*MockInterface)(nil).CreateEC2Tags), arg0, arg1, arg2)
+}
+
+// CreateElasticIP mocks base method.
+func (m *MockInterface) CreateElasticIP(arg0 context.Context, arg1 *client.ElasticIP) (*client.ElasticIP, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateElasticIP", arg0, arg1)
+	ret0, _ := ret[0].(*client.ElasticIP)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateElasticIP indicates an expected call of CreateElasticIP.
+func (mr *MockInterfaceMockRecorder) CreateElasticIP(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateElasticIP", reflect.TypeOf((*MockInterface)(nil).CreateElasticIP), arg0, arg1)
+}
+
+// CreateIAMInstanceProfile mocks base method.
+func (m *MockInterface) CreateIAMInstanceProfile(arg0 context.Context, arg1 *client.IAMInstanceProfile) (*client.IAMInstanceProfile, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateIAMInstanceProfile", arg0, arg1)
+	ret0, _ := ret[0].(*client.IAMInstanceProfile)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateIAMInstanceProfile indicates an expected call of CreateIAMInstanceProfile.
+func (mr *MockInterfaceMockRecorder) CreateIAMInstanceProfile(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIAMInstanceProfile", reflect.TypeOf((*MockInterface)(nil).CreateIAMInstanceProfile), arg0, arg1)
+}
+
+// CreateIAMRole mocks base method.
+func (m *MockInterface) CreateIAMRole(arg0 context.Context, arg1 *client.IAMRole) (*client.IAMRole, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateIAMRole", arg0, arg1)
+	ret0, _ := ret[0].(*client.IAMRole)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateIAMRole indicates an expected call of CreateIAMRole.
+func (mr *MockInterfaceMockRecorder) CreateIAMRole(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIAMRole", reflect.TypeOf((*MockInterface)(nil).CreateIAMRole), arg0, arg1)
+}
+
+// CreateInternetGateway mocks base method.
+func (m *MockInterface) CreateInternetGateway(arg0 context.Context, arg1 *client.InternetGateway) (*client.InternetGateway, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateInternetGateway", arg0, arg1)
+	ret0, _ := ret[0].(*client.InternetGateway)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateInternetGateway indicates an expected call of CreateInternetGateway.
+func (mr *MockInterfaceMockRecorder) CreateInternetGateway(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInternetGateway", reflect.TypeOf((*MockInterface)(nil).CreateInternetGateway), arg0, arg1)
+}
+
+// CreateNATGateway mocks base method.
+func (m *MockInterface) CreateNATGateway(arg0 context.Context, arg1 *client.NATGateway) (*client.NATGateway, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNATGateway", arg0, arg1)
+	ret0, _ := ret[0].(*client.NATGateway)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateNATGateway indicates an expected call of CreateNATGateway.
+func (mr *MockInterfaceMockRecorder) CreateNATGateway(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNATGateway", reflect.TypeOf((*MockInterface)(nil).CreateNATGateway), arg0, arg1)
+}
+
 // CreateOrUpdateDNSRecordSet mocks base method.
 func (m *MockInterface) CreateOrUpdateDNSRecordSet(arg0 context.Context, arg1, arg2, arg3 string, arg4 []string, arg5 int64) error {
 	m.ctrl.T.Helper()
@@ -62,6 +207,139 @@ func (m *MockInterface) CreateOrUpdateDNSRecordSet(arg0 context.Context, arg1, a
 func (mr *MockInterfaceMockRecorder) CreateOrUpdateDNSRecordSet(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateDNSRecordSet", reflect.TypeOf((*MockInterface)(nil).CreateOrUpdateDNSRecordSet), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+// CreateRoute mocks base method.
+func (m *MockInterface) CreateRoute(arg0 context.Context, arg1 string, arg2 *client.Route) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRoute", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateRoute indicates an expected call of CreateRoute.
+func (mr *MockInterfaceMockRecorder) CreateRoute(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoute", reflect.TypeOf((*MockInterface)(nil).CreateRoute), arg0, arg1, arg2)
+}
+
+// CreateRouteTable mocks base method.
+func (m *MockInterface) CreateRouteTable(arg0 context.Context, arg1 *client.RouteTable) (*client.RouteTable, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRouteTable", arg0, arg1)
+	ret0, _ := ret[0].(*client.RouteTable)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateRouteTable indicates an expected call of CreateRouteTable.
+func (mr *MockInterfaceMockRecorder) CreateRouteTable(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRouteTable", reflect.TypeOf((*MockInterface)(nil).CreateRouteTable), arg0, arg1)
+}
+
+// CreateRouteTableAssociation mocks base method.
+func (m *MockInterface) CreateRouteTableAssociation(arg0 context.Context, arg1, arg2 string) (*string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRouteTableAssociation", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateRouteTableAssociation indicates an expected call of CreateRouteTableAssociation.
+func (mr *MockInterfaceMockRecorder) CreateRouteTableAssociation(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRouteTableAssociation", reflect.TypeOf((*MockInterface)(nil).CreateRouteTableAssociation), arg0, arg1, arg2)
+}
+
+// CreateSecurityGroup mocks base method.
+func (m *MockInterface) CreateSecurityGroup(arg0 context.Context, arg1 *client.SecurityGroup) (*client.SecurityGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSecurityGroup", arg0, arg1)
+	ret0, _ := ret[0].(*client.SecurityGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateSecurityGroup indicates an expected call of CreateSecurityGroup.
+func (mr *MockInterfaceMockRecorder) CreateSecurityGroup(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroup", reflect.TypeOf((*MockInterface)(nil).CreateSecurityGroup), arg0, arg1)
+}
+
+// CreateSubnet mocks base method.
+func (m *MockInterface) CreateSubnet(arg0 context.Context, arg1 *client.Subnet) (*client.Subnet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSubnet", arg0, arg1)
+	ret0, _ := ret[0].(*client.Subnet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateSubnet indicates an expected call of CreateSubnet.
+func (mr *MockInterfaceMockRecorder) CreateSubnet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSubnet", reflect.TypeOf((*MockInterface)(nil).CreateSubnet), arg0, arg1)
+}
+
+// CreateVpc mocks base method.
+func (m *MockInterface) CreateVpc(arg0 context.Context, arg1 *client.VPC) (*client.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVpc", arg0, arg1)
+	ret0, _ := ret[0].(*client.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateVpc indicates an expected call of CreateVpc.
+func (mr *MockInterfaceMockRecorder) CreateVpc(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpc", reflect.TypeOf((*MockInterface)(nil).CreateVpc), arg0, arg1)
+}
+
+// CreateVpcDhcpOptions mocks base method.
+func (m *MockInterface) CreateVpcDhcpOptions(arg0 context.Context, arg1 *client.DhcpOptions) (*client.DhcpOptions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVpcDhcpOptions", arg0, arg1)
+	ret0, _ := ret[0].(*client.DhcpOptions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateVpcDhcpOptions indicates an expected call of CreateVpcDhcpOptions.
+func (mr *MockInterfaceMockRecorder) CreateVpcDhcpOptions(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcDhcpOptions", reflect.TypeOf((*MockInterface)(nil).CreateVpcDhcpOptions), arg0, arg1)
+}
+
+// CreateVpcEndpoint mocks base method.
+func (m *MockInterface) CreateVpcEndpoint(arg0 context.Context, arg1 *client.VpcEndpoint) (*client.VpcEndpoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVpcEndpoint", arg0, arg1)
+	ret0, _ := ret[0].(*client.VpcEndpoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateVpcEndpoint indicates an expected call of CreateVpcEndpoint.
+func (mr *MockInterfaceMockRecorder) CreateVpcEndpoint(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcEndpoint", reflect.TypeOf((*MockInterface)(nil).CreateVpcEndpoint), arg0, arg1)
+}
+
+// CreateVpcEndpointRouteTableAssociation mocks base method.
+func (m *MockInterface) CreateVpcEndpointRouteTableAssociation(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVpcEndpointRouteTableAssociation", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateVpcEndpointRouteTableAssociation indicates an expected call of CreateVpcEndpointRouteTableAssociation.
+func (mr *MockInterfaceMockRecorder) CreateVpcEndpointRouteTableAssociation(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcEndpointRouteTableAssociation", reflect.TypeOf((*MockInterface)(nil).CreateVpcEndpointRouteTableAssociation), arg0, arg1, arg2)
 }
 
 // DeleteBucketIfExists mocks base method.
@@ -92,6 +370,20 @@ func (mr *MockInterfaceMockRecorder) DeleteDNSRecordSet(arg0, arg1, arg2, arg3, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDNSRecordSet", reflect.TypeOf((*MockInterface)(nil).DeleteDNSRecordSet), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
+// DeleteEC2Tags mocks base method.
+func (m *MockInterface) DeleteEC2Tags(arg0 context.Context, arg1 []string, arg2 client.Tags) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteEC2Tags", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteEC2Tags indicates an expected call of DeleteEC2Tags.
+func (mr *MockInterfaceMockRecorder) DeleteEC2Tags(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEC2Tags", reflect.TypeOf((*MockInterface)(nil).DeleteEC2Tags), arg0, arg1, arg2)
+}
+
 // DeleteELB mocks base method.
 func (m *MockInterface) DeleteELB(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -120,6 +412,104 @@ func (mr *MockInterfaceMockRecorder) DeleteELBV2(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteELBV2", reflect.TypeOf((*MockInterface)(nil).DeleteELBV2), arg0, arg1)
 }
 
+// DeleteElasticIP mocks base method.
+func (m *MockInterface) DeleteElasticIP(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteElasticIP", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteElasticIP indicates an expected call of DeleteElasticIP.
+func (mr *MockInterfaceMockRecorder) DeleteElasticIP(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteElasticIP", reflect.TypeOf((*MockInterface)(nil).DeleteElasticIP), arg0, arg1)
+}
+
+// DeleteIAMInstanceProfile mocks base method.
+func (m *MockInterface) DeleteIAMInstanceProfile(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteIAMInstanceProfile", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteIAMInstanceProfile indicates an expected call of DeleteIAMInstanceProfile.
+func (mr *MockInterfaceMockRecorder) DeleteIAMInstanceProfile(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteIAMInstanceProfile", reflect.TypeOf((*MockInterface)(nil).DeleteIAMInstanceProfile), arg0, arg1)
+}
+
+// DeleteIAMRole mocks base method.
+func (m *MockInterface) DeleteIAMRole(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteIAMRole", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteIAMRole indicates an expected call of DeleteIAMRole.
+func (mr *MockInterfaceMockRecorder) DeleteIAMRole(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteIAMRole", reflect.TypeOf((*MockInterface)(nil).DeleteIAMRole), arg0, arg1)
+}
+
+// DeleteIAMRolePolicy mocks base method.
+func (m *MockInterface) DeleteIAMRolePolicy(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteIAMRolePolicy", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteIAMRolePolicy indicates an expected call of DeleteIAMRolePolicy.
+func (mr *MockInterfaceMockRecorder) DeleteIAMRolePolicy(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteIAMRolePolicy", reflect.TypeOf((*MockInterface)(nil).DeleteIAMRolePolicy), arg0, arg1, arg2)
+}
+
+// DeleteInternetGateway mocks base method.
+func (m *MockInterface) DeleteInternetGateway(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteInternetGateway", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteInternetGateway indicates an expected call of DeleteInternetGateway.
+func (mr *MockInterfaceMockRecorder) DeleteInternetGateway(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInternetGateway", reflect.TypeOf((*MockInterface)(nil).DeleteInternetGateway), arg0, arg1)
+}
+
+// DeleteKeyPair mocks base method.
+func (m *MockInterface) DeleteKeyPair(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteKeyPair", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteKeyPair indicates an expected call of DeleteKeyPair.
+func (mr *MockInterfaceMockRecorder) DeleteKeyPair(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKeyPair", reflect.TypeOf((*MockInterface)(nil).DeleteKeyPair), arg0, arg1)
+}
+
+// DeleteNATGateway mocks base method.
+func (m *MockInterface) DeleteNATGateway(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNATGateway", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteNATGateway indicates an expected call of DeleteNATGateway.
+func (mr *MockInterfaceMockRecorder) DeleteNATGateway(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNATGateway", reflect.TypeOf((*MockInterface)(nil).DeleteNATGateway), arg0, arg1)
+}
+
 // DeleteObjectsWithPrefix mocks base method.
 func (m *MockInterface) DeleteObjectsWithPrefix(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
@@ -134,6 +524,48 @@ func (mr *MockInterfaceMockRecorder) DeleteObjectsWithPrefix(arg0, arg1, arg2 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObjectsWithPrefix", reflect.TypeOf((*MockInterface)(nil).DeleteObjectsWithPrefix), arg0, arg1, arg2)
 }
 
+// DeleteRoute mocks base method.
+func (m *MockInterface) DeleteRoute(arg0 context.Context, arg1 string, arg2 *client.Route) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRoute", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRoute indicates an expected call of DeleteRoute.
+func (mr *MockInterfaceMockRecorder) DeleteRoute(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoute", reflect.TypeOf((*MockInterface)(nil).DeleteRoute), arg0, arg1, arg2)
+}
+
+// DeleteRouteTable mocks base method.
+func (m *MockInterface) DeleteRouteTable(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRouteTable", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRouteTable indicates an expected call of DeleteRouteTable.
+func (mr *MockInterfaceMockRecorder) DeleteRouteTable(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRouteTable", reflect.TypeOf((*MockInterface)(nil).DeleteRouteTable), arg0, arg1)
+}
+
+// DeleteRouteTableAssociation mocks base method.
+func (m *MockInterface) DeleteRouteTableAssociation(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRouteTableAssociation", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRouteTableAssociation indicates an expected call of DeleteRouteTableAssociation.
+func (mr *MockInterfaceMockRecorder) DeleteRouteTableAssociation(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRouteTableAssociation", reflect.TypeOf((*MockInterface)(nil).DeleteRouteTableAssociation), arg0, arg1)
+}
+
 // DeleteSecurityGroup mocks base method.
 func (m *MockInterface) DeleteSecurityGroup(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -146,6 +578,270 @@ func (m *MockInterface) DeleteSecurityGroup(arg0 context.Context, arg1 string) e
 func (mr *MockInterfaceMockRecorder) DeleteSecurityGroup(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroup", reflect.TypeOf((*MockInterface)(nil).DeleteSecurityGroup), arg0, arg1)
+}
+
+// DeleteSubnet mocks base method.
+func (m *MockInterface) DeleteSubnet(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteSubnet", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteSubnet indicates an expected call of DeleteSubnet.
+func (mr *MockInterfaceMockRecorder) DeleteSubnet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubnet", reflect.TypeOf((*MockInterface)(nil).DeleteSubnet), arg0, arg1)
+}
+
+// DeleteVpc mocks base method.
+func (m *MockInterface) DeleteVpc(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVpc", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteVpc indicates an expected call of DeleteVpc.
+func (mr *MockInterfaceMockRecorder) DeleteVpc(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpc", reflect.TypeOf((*MockInterface)(nil).DeleteVpc), arg0, arg1)
+}
+
+// DeleteVpcDhcpOptions mocks base method.
+func (m *MockInterface) DeleteVpcDhcpOptions(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVpcDhcpOptions", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteVpcDhcpOptions indicates an expected call of DeleteVpcDhcpOptions.
+func (mr *MockInterfaceMockRecorder) DeleteVpcDhcpOptions(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcDhcpOptions", reflect.TypeOf((*MockInterface)(nil).DeleteVpcDhcpOptions), arg0, arg1)
+}
+
+// DeleteVpcEndpoint mocks base method.
+func (m *MockInterface) DeleteVpcEndpoint(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVpcEndpoint", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteVpcEndpoint indicates an expected call of DeleteVpcEndpoint.
+func (mr *MockInterfaceMockRecorder) DeleteVpcEndpoint(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpoint", reflect.TypeOf((*MockInterface)(nil).DeleteVpcEndpoint), arg0, arg1)
+}
+
+// DeleteVpcEndpointRouteTableAssociation mocks base method.
+func (m *MockInterface) DeleteVpcEndpointRouteTableAssociation(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVpcEndpointRouteTableAssociation", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteVpcEndpointRouteTableAssociation indicates an expected call of DeleteVpcEndpointRouteTableAssociation.
+func (mr *MockInterfaceMockRecorder) DeleteVpcEndpointRouteTableAssociation(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpointRouteTableAssociation", reflect.TypeOf((*MockInterface)(nil).DeleteVpcEndpointRouteTableAssociation), arg0, arg1, arg2)
+}
+
+// DetachInternetGateway mocks base method.
+func (m *MockInterface) DetachInternetGateway(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachInternetGateway", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DetachInternetGateway indicates an expected call of DetachInternetGateway.
+func (mr *MockInterfaceMockRecorder) DetachInternetGateway(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachInternetGateway", reflect.TypeOf((*MockInterface)(nil).DetachInternetGateway), arg0, arg1, arg2)
+}
+
+// FindDefaultSecurityGroupByVpcId mocks base method.
+func (m *MockInterface) FindDefaultSecurityGroupByVpcId(arg0 context.Context, arg1 string) (*client.SecurityGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindDefaultSecurityGroupByVpcId", arg0, arg1)
+	ret0, _ := ret[0].(*client.SecurityGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindDefaultSecurityGroupByVpcId indicates an expected call of FindDefaultSecurityGroupByVpcId.
+func (mr *MockInterfaceMockRecorder) FindDefaultSecurityGroupByVpcId(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDefaultSecurityGroupByVpcId", reflect.TypeOf((*MockInterface)(nil).FindDefaultSecurityGroupByVpcId), arg0, arg1)
+}
+
+// FindElasticIPsByTags mocks base method.
+func (m *MockInterface) FindElasticIPsByTags(arg0 context.Context, arg1 client.Tags) ([]*client.ElasticIP, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindElasticIPsByTags", arg0, arg1)
+	ret0, _ := ret[0].([]*client.ElasticIP)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindElasticIPsByTags indicates an expected call of FindElasticIPsByTags.
+func (mr *MockInterfaceMockRecorder) FindElasticIPsByTags(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindElasticIPsByTags", reflect.TypeOf((*MockInterface)(nil).FindElasticIPsByTags), arg0, arg1)
+}
+
+// FindInternetGatewayByVPC mocks base method.
+func (m *MockInterface) FindInternetGatewayByVPC(arg0 context.Context, arg1 string) (*client.InternetGateway, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindInternetGatewayByVPC", arg0, arg1)
+	ret0, _ := ret[0].(*client.InternetGateway)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindInternetGatewayByVPC indicates an expected call of FindInternetGatewayByVPC.
+func (mr *MockInterfaceMockRecorder) FindInternetGatewayByVPC(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindInternetGatewayByVPC", reflect.TypeOf((*MockInterface)(nil).FindInternetGatewayByVPC), arg0, arg1)
+}
+
+// FindInternetGatewaysByTags mocks base method.
+func (m *MockInterface) FindInternetGatewaysByTags(arg0 context.Context, arg1 client.Tags) ([]*client.InternetGateway, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindInternetGatewaysByTags", arg0, arg1)
+	ret0, _ := ret[0].([]*client.InternetGateway)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindInternetGatewaysByTags indicates an expected call of FindInternetGatewaysByTags.
+func (mr *MockInterfaceMockRecorder) FindInternetGatewaysByTags(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindInternetGatewaysByTags", reflect.TypeOf((*MockInterface)(nil).FindInternetGatewaysByTags), arg0, arg1)
+}
+
+// FindKeyPairsByTags mocks base method.
+func (m *MockInterface) FindKeyPairsByTags(arg0 context.Context, arg1 client.Tags) ([]*client.KeyPairInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindKeyPairsByTags", arg0, arg1)
+	ret0, _ := ret[0].([]*client.KeyPairInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindKeyPairsByTags indicates an expected call of FindKeyPairsByTags.
+func (mr *MockInterfaceMockRecorder) FindKeyPairsByTags(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindKeyPairsByTags", reflect.TypeOf((*MockInterface)(nil).FindKeyPairsByTags), arg0, arg1)
+}
+
+// FindNATGatewaysByTags mocks base method.
+func (m *MockInterface) FindNATGatewaysByTags(arg0 context.Context, arg1 client.Tags) ([]*client.NATGateway, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindNATGatewaysByTags", arg0, arg1)
+	ret0, _ := ret[0].([]*client.NATGateway)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindNATGatewaysByTags indicates an expected call of FindNATGatewaysByTags.
+func (mr *MockInterfaceMockRecorder) FindNATGatewaysByTags(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindNATGatewaysByTags", reflect.TypeOf((*MockInterface)(nil).FindNATGatewaysByTags), arg0, arg1)
+}
+
+// FindRouteTablesByTags mocks base method.
+func (m *MockInterface) FindRouteTablesByTags(arg0 context.Context, arg1 client.Tags) ([]*client.RouteTable, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindRouteTablesByTags", arg0, arg1)
+	ret0, _ := ret[0].([]*client.RouteTable)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindRouteTablesByTags indicates an expected call of FindRouteTablesByTags.
+func (mr *MockInterfaceMockRecorder) FindRouteTablesByTags(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindRouteTablesByTags", reflect.TypeOf((*MockInterface)(nil).FindRouteTablesByTags), arg0, arg1)
+}
+
+// FindSecurityGroupsByTags mocks base method.
+func (m *MockInterface) FindSecurityGroupsByTags(arg0 context.Context, arg1 client.Tags) ([]*client.SecurityGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindSecurityGroupsByTags", arg0, arg1)
+	ret0, _ := ret[0].([]*client.SecurityGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindSecurityGroupsByTags indicates an expected call of FindSecurityGroupsByTags.
+func (mr *MockInterfaceMockRecorder) FindSecurityGroupsByTags(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindSecurityGroupsByTags", reflect.TypeOf((*MockInterface)(nil).FindSecurityGroupsByTags), arg0, arg1)
+}
+
+// FindSubnetsByTags mocks base method.
+func (m *MockInterface) FindSubnetsByTags(arg0 context.Context, arg1 client.Tags) ([]*client.Subnet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindSubnetsByTags", arg0, arg1)
+	ret0, _ := ret[0].([]*client.Subnet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindSubnetsByTags indicates an expected call of FindSubnetsByTags.
+func (mr *MockInterfaceMockRecorder) FindSubnetsByTags(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindSubnetsByTags", reflect.TypeOf((*MockInterface)(nil).FindSubnetsByTags), arg0, arg1)
+}
+
+// FindVpcDhcpOptionsByTags mocks base method.
+func (m *MockInterface) FindVpcDhcpOptionsByTags(arg0 context.Context, arg1 client.Tags) ([]*client.DhcpOptions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindVpcDhcpOptionsByTags", arg0, arg1)
+	ret0, _ := ret[0].([]*client.DhcpOptions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindVpcDhcpOptionsByTags indicates an expected call of FindVpcDhcpOptionsByTags.
+func (mr *MockInterfaceMockRecorder) FindVpcDhcpOptionsByTags(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindVpcDhcpOptionsByTags", reflect.TypeOf((*MockInterface)(nil).FindVpcDhcpOptionsByTags), arg0, arg1)
+}
+
+// FindVpcEndpointsByTags mocks base method.
+func (m *MockInterface) FindVpcEndpointsByTags(arg0 context.Context, arg1 client.Tags) ([]*client.VpcEndpoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindVpcEndpointsByTags", arg0, arg1)
+	ret0, _ := ret[0].([]*client.VpcEndpoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindVpcEndpointsByTags indicates an expected call of FindVpcEndpointsByTags.
+func (mr *MockInterfaceMockRecorder) FindVpcEndpointsByTags(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindVpcEndpointsByTags", reflect.TypeOf((*MockInterface)(nil).FindVpcEndpointsByTags), arg0, arg1)
+}
+
+// FindVpcsByTags mocks base method.
+func (m *MockInterface) FindVpcsByTags(arg0 context.Context, arg1 client.Tags) ([]*client.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindVpcsByTags", arg0, arg1)
+	ret0, _ := ret[0].([]*client.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindVpcsByTags indicates an expected call of FindVpcsByTags.
+func (mr *MockInterfaceMockRecorder) FindVpcsByTags(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindVpcsByTags", reflect.TypeOf((*MockInterface)(nil).FindVpcsByTags), arg0, arg1)
 }
 
 // GetAccountID mocks base method.
@@ -193,6 +889,21 @@ func (mr *MockInterfaceMockRecorder) GetDNSHostedZones(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDNSHostedZones", reflect.TypeOf((*MockInterface)(nil).GetDNSHostedZones), arg0)
 }
 
+// GetElasticIP mocks base method.
+func (m *MockInterface) GetElasticIP(arg0 context.Context, arg1 string) (*client.ElasticIP, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetElasticIP", arg0, arg1)
+	ret0, _ := ret[0].(*client.ElasticIP)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetElasticIP indicates an expected call of GetElasticIP.
+func (mr *MockInterfaceMockRecorder) GetElasticIP(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetElasticIP", reflect.TypeOf((*MockInterface)(nil).GetElasticIP), arg0, arg1)
+}
+
 // GetElasticIPsAssociationIDForAllocationIDs mocks base method.
 func (m *MockInterface) GetElasticIPsAssociationIDForAllocationIDs(arg0 context.Context, arg1 []string) (map[string]*string, error) {
 	m.ctrl.T.Helper()
@@ -208,6 +919,96 @@ func (mr *MockInterfaceMockRecorder) GetElasticIPsAssociationIDForAllocationIDs(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetElasticIPsAssociationIDForAllocationIDs", reflect.TypeOf((*MockInterface)(nil).GetElasticIPsAssociationIDForAllocationIDs), arg0, arg1)
 }
 
+// GetIAMInstanceProfile mocks base method.
+func (m *MockInterface) GetIAMInstanceProfile(arg0 context.Context, arg1 string) (*client.IAMInstanceProfile, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIAMInstanceProfile", arg0, arg1)
+	ret0, _ := ret[0].(*client.IAMInstanceProfile)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIAMInstanceProfile indicates an expected call of GetIAMInstanceProfile.
+func (mr *MockInterfaceMockRecorder) GetIAMInstanceProfile(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIAMInstanceProfile", reflect.TypeOf((*MockInterface)(nil).GetIAMInstanceProfile), arg0, arg1)
+}
+
+// GetIAMRole mocks base method.
+func (m *MockInterface) GetIAMRole(arg0 context.Context, arg1 string) (*client.IAMRole, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIAMRole", arg0, arg1)
+	ret0, _ := ret[0].(*client.IAMRole)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIAMRole indicates an expected call of GetIAMRole.
+func (mr *MockInterfaceMockRecorder) GetIAMRole(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIAMRole", reflect.TypeOf((*MockInterface)(nil).GetIAMRole), arg0, arg1)
+}
+
+// GetIAMRolePolicy mocks base method.
+func (m *MockInterface) GetIAMRolePolicy(arg0 context.Context, arg1, arg2 string) (*client.IAMRolePolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIAMRolePolicy", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*client.IAMRolePolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIAMRolePolicy indicates an expected call of GetIAMRolePolicy.
+func (mr *MockInterfaceMockRecorder) GetIAMRolePolicy(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIAMRolePolicy", reflect.TypeOf((*MockInterface)(nil).GetIAMRolePolicy), arg0, arg1, arg2)
+}
+
+// GetInternetGateway mocks base method.
+func (m *MockInterface) GetInternetGateway(arg0 context.Context, arg1 string) (*client.InternetGateway, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInternetGateway", arg0, arg1)
+	ret0, _ := ret[0].(*client.InternetGateway)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInternetGateway indicates an expected call of GetInternetGateway.
+func (mr *MockInterfaceMockRecorder) GetInternetGateway(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInternetGateway", reflect.TypeOf((*MockInterface)(nil).GetInternetGateway), arg0, arg1)
+}
+
+// GetKeyPair mocks base method.
+func (m *MockInterface) GetKeyPair(arg0 context.Context, arg1 string) (*client.KeyPairInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKeyPair", arg0, arg1)
+	ret0, _ := ret[0].(*client.KeyPairInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetKeyPair indicates an expected call of GetKeyPair.
+func (mr *MockInterfaceMockRecorder) GetKeyPair(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyPair", reflect.TypeOf((*MockInterface)(nil).GetKeyPair), arg0, arg1)
+}
+
+// GetNATGateway mocks base method.
+func (m *MockInterface) GetNATGateway(arg0 context.Context, arg1 string) (*client.NATGateway, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNATGateway", arg0, arg1)
+	ret0, _ := ret[0].(*client.NATGateway)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNATGateway indicates an expected call of GetNATGateway.
+func (mr *MockInterfaceMockRecorder) GetNATGateway(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNATGateway", reflect.TypeOf((*MockInterface)(nil).GetNATGateway), arg0, arg1)
+}
+
 // GetNATGatewayAddressAllocations mocks base method.
 func (m *MockInterface) GetNATGatewayAddressAllocations(arg0 context.Context, arg1 string) (sets.Set[string], error) {
 	m.ctrl.T.Helper()
@@ -221,6 +1022,51 @@ func (m *MockInterface) GetNATGatewayAddressAllocations(arg0 context.Context, ar
 func (mr *MockInterfaceMockRecorder) GetNATGatewayAddressAllocations(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNATGatewayAddressAllocations", reflect.TypeOf((*MockInterface)(nil).GetNATGatewayAddressAllocations), arg0, arg1)
+}
+
+// GetRouteTable mocks base method.
+func (m *MockInterface) GetRouteTable(arg0 context.Context, arg1 string) (*client.RouteTable, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRouteTable", arg0, arg1)
+	ret0, _ := ret[0].(*client.RouteTable)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRouteTable indicates an expected call of GetRouteTable.
+func (mr *MockInterfaceMockRecorder) GetRouteTable(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouteTable", reflect.TypeOf((*MockInterface)(nil).GetRouteTable), arg0, arg1)
+}
+
+// GetSecurityGroup mocks base method.
+func (m *MockInterface) GetSecurityGroup(arg0 context.Context, arg1 string) (*client.SecurityGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecurityGroup", arg0, arg1)
+	ret0, _ := ret[0].(*client.SecurityGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSecurityGroup indicates an expected call of GetSecurityGroup.
+func (mr *MockInterfaceMockRecorder) GetSecurityGroup(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecurityGroup", reflect.TypeOf((*MockInterface)(nil).GetSecurityGroup), arg0, arg1)
+}
+
+// GetSubnets mocks base method.
+func (m *MockInterface) GetSubnets(arg0 context.Context, arg1 []string) ([]*client.Subnet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSubnets", arg0, arg1)
+	ret0, _ := ret[0].([]*client.Subnet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSubnets indicates an expected call of GetSubnets.
+func (mr *MockInterfaceMockRecorder) GetSubnets(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnets", reflect.TypeOf((*MockInterface)(nil).GetSubnets), arg0, arg1)
 }
 
 // GetVPCAttribute mocks base method.
@@ -251,6 +1097,66 @@ func (m *MockInterface) GetVPCInternetGateway(arg0 context.Context, arg1 string)
 func (mr *MockInterfaceMockRecorder) GetVPCInternetGateway(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCInternetGateway", reflect.TypeOf((*MockInterface)(nil).GetVPCInternetGateway), arg0, arg1)
+}
+
+// GetVpc mocks base method.
+func (m *MockInterface) GetVpc(arg0 context.Context, arg1 string) (*client.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVpc", arg0, arg1)
+	ret0, _ := ret[0].(*client.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVpc indicates an expected call of GetVpc.
+func (mr *MockInterfaceMockRecorder) GetVpc(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVpc", reflect.TypeOf((*MockInterface)(nil).GetVpc), arg0, arg1)
+}
+
+// GetVpcDhcpOptions mocks base method.
+func (m *MockInterface) GetVpcDhcpOptions(arg0 context.Context, arg1 string) (*client.DhcpOptions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVpcDhcpOptions", arg0, arg1)
+	ret0, _ := ret[0].(*client.DhcpOptions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVpcDhcpOptions indicates an expected call of GetVpcDhcpOptions.
+func (mr *MockInterfaceMockRecorder) GetVpcDhcpOptions(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVpcDhcpOptions", reflect.TypeOf((*MockInterface)(nil).GetVpcDhcpOptions), arg0, arg1)
+}
+
+// GetVpcEndpoints mocks base method.
+func (m *MockInterface) GetVpcEndpoints(arg0 context.Context, arg1 []string) ([]*client.VpcEndpoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVpcEndpoints", arg0, arg1)
+	ret0, _ := ret[0].([]*client.VpcEndpoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVpcEndpoints indicates an expected call of GetVpcEndpoints.
+func (mr *MockInterfaceMockRecorder) GetVpcEndpoints(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVpcEndpoints", reflect.TypeOf((*MockInterface)(nil).GetVpcEndpoints), arg0, arg1)
+}
+
+// ImportKeyPair mocks base method.
+func (m *MockInterface) ImportKeyPair(arg0 context.Context, arg1 string, arg2 []byte, arg3 client.Tags) (*client.KeyPairInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImportKeyPair", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*client.KeyPairInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImportKeyPair indicates an expected call of ImportKeyPair.
+func (mr *MockInterfaceMockRecorder) ImportKeyPair(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportKeyPair", reflect.TypeOf((*MockInterface)(nil).ImportKeyPair), arg0, arg1, arg2, arg3)
 }
 
 // ListKubernetesELBs mocks base method.
@@ -296,6 +1202,105 @@ func (m *MockInterface) ListKubernetesSecurityGroups(arg0 context.Context, arg1,
 func (mr *MockInterfaceMockRecorder) ListKubernetesSecurityGroups(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKubernetesSecurityGroups", reflect.TypeOf((*MockInterface)(nil).ListKubernetesSecurityGroups), arg0, arg1, arg2)
+}
+
+// PutIAMRolePolicy mocks base method.
+func (m *MockInterface) PutIAMRolePolicy(arg0 context.Context, arg1 *client.IAMRolePolicy) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutIAMRolePolicy", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutIAMRolePolicy indicates an expected call of PutIAMRolePolicy.
+func (mr *MockInterfaceMockRecorder) PutIAMRolePolicy(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutIAMRolePolicy", reflect.TypeOf((*MockInterface)(nil).PutIAMRolePolicy), arg0, arg1)
+}
+
+// RemoveRoleFromIAMInstanceProfile mocks base method.
+func (m *MockInterface) RemoveRoleFromIAMInstanceProfile(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveRoleFromIAMInstanceProfile", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveRoleFromIAMInstanceProfile indicates an expected call of RemoveRoleFromIAMInstanceProfile.
+func (mr *MockInterfaceMockRecorder) RemoveRoleFromIAMInstanceProfile(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRoleFromIAMInstanceProfile", reflect.TypeOf((*MockInterface)(nil).RemoveRoleFromIAMInstanceProfile), arg0, arg1, arg2)
+}
+
+// RevokeSecurityGroupRules mocks base method.
+func (m *MockInterface) RevokeSecurityGroupRules(arg0 context.Context, arg1 string, arg2 []*client.SecurityGroupRule) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokeSecurityGroupRules", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RevokeSecurityGroupRules indicates an expected call of RevokeSecurityGroupRules.
+func (mr *MockInterfaceMockRecorder) RevokeSecurityGroupRules(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecurityGroupRules", reflect.TypeOf((*MockInterface)(nil).RevokeSecurityGroupRules), arg0, arg1, arg2)
+}
+
+// UpdateAssumeRolePolicy mocks base method.
+func (m *MockInterface) UpdateAssumeRolePolicy(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAssumeRolePolicy", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateAssumeRolePolicy indicates an expected call of UpdateAssumeRolePolicy.
+func (mr *MockInterfaceMockRecorder) UpdateAssumeRolePolicy(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssumeRolePolicy", reflect.TypeOf((*MockInterface)(nil).UpdateAssumeRolePolicy), arg0, arg1, arg2)
+}
+
+// UpdateSubnetAttributes mocks base method.
+func (m *MockInterface) UpdateSubnetAttributes(arg0 context.Context, arg1, arg2 *client.Subnet) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSubnetAttributes", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateSubnetAttributes indicates an expected call of UpdateSubnetAttributes.
+func (mr *MockInterfaceMockRecorder) UpdateSubnetAttributes(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubnetAttributes", reflect.TypeOf((*MockInterface)(nil).UpdateSubnetAttributes), arg0, arg1, arg2)
+}
+
+// UpdateVpcAttribute mocks base method.
+func (m *MockInterface) UpdateVpcAttribute(arg0 context.Context, arg1, arg2 string, arg3 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateVpcAttribute", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateVpcAttribute indicates an expected call of UpdateVpcAttribute.
+func (mr *MockInterfaceMockRecorder) UpdateVpcAttribute(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVpcAttribute", reflect.TypeOf((*MockInterface)(nil).UpdateVpcAttribute), arg0, arg1, arg2, arg3)
+}
+
+// WaitForNATGatewayAvailable mocks base method.
+func (m *MockInterface) WaitForNATGatewayAvailable(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForNATGatewayAvailable", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForNATGatewayAvailable indicates an expected call of WaitForNATGatewayAvailable.
+func (mr *MockInterfaceMockRecorder) WaitForNATGatewayAvailable(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForNATGatewayAvailable", reflect.TypeOf((*MockInterface)(nil).WaitForNATGatewayAvailable), arg0, arg1)
 }
 
 // MockFactory is a mock of Factory interface.

--- a/pkg/aws/client/tags.go
+++ b/pkg/aws/client/tags.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// Tags is map of string key to string values. Duplicate keys are not supported in AWS.
+type Tags map[string]string
+
+// FromTags creates a Tags map from the given EC2 tag array.
+func FromTags(ec2Tags []*ec2.Tag) Tags {
+	tags := Tags{}
+	for _, et := range ec2Tags {
+		tags[aws.StringValue(et.Key)] = aws.StringValue(et.Value)
+	}
+	return tags
+}
+
+// ToTagSpecification exports the tags map as a EC2 TagSpecification for the given resource type.
+func (tags Tags) ToTagSpecification(resourceType string) *ec2.TagSpecification {
+	tagspec := &ec2.TagSpecification{
+		ResourceType: aws.String(resourceType),
+	}
+	for k, v := range tags {
+		tagspec.Tags = append(tagspec.Tags, &ec2.Tag{Key: aws.String(k), Value: aws.String(v)})
+	}
+	return tagspec
+}
+
+// ToTagSpecifications exports the tags map as a EC2 TagSpecification array for the given resource type.
+func (tags Tags) ToTagSpecifications(resourceType string) []*ec2.TagSpecification {
+	if tags == nil {
+		return nil
+	}
+	return []*ec2.TagSpecification{tags.ToTagSpecification(resourceType)}
+}
+
+// ToEC2Tags exports the tags map as a EC2 Tag array.
+func (tags Tags) ToEC2Tags() []*ec2.Tag {
+	var copy []*ec2.Tag
+	for k, v := range tags {
+		copy = append(copy, &ec2.Tag{Key: aws.String(k), Value: aws.String(v)})
+	}
+	return copy
+}
+
+// ToFilters exports the tags map as a EC2 Filter array.
+func (tags Tags) ToFilters() []*ec2.Filter {
+	if tags == nil {
+		return nil
+	}
+	var filters []*ec2.Filter
+	for k, v := range tags {
+		filters = append(filters, &ec2.Filter{Name: aws.String(fmt.Sprintf("tag:%s", k)), Values: []*string{aws.String(v)}})
+	}
+	return filters
+}
+
+// Clone creates a copy of the tags aps
+func (tags Tags) Clone() Tags {
+	copy := Tags{}
+	for k, v := range tags {
+		copy[k] = v
+	}
+	return copy
+}

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -205,7 +205,7 @@ type SecurityGroup struct {
 // Clone creates a copy.
 func (sg *SecurityGroup) Clone() *SecurityGroup {
 	copy := *sg
-	copy.Rules = copyArray(sg.Rules)
+	copy.Rules = copySlice(sg.Rules)
 	copy.Tags = sg.Tags.Clone()
 	return &copy
 }
@@ -300,7 +300,7 @@ type SecurityGroupRule struct {
 // Clone creates a copy.
 func (sgr *SecurityGroupRule) Clone() *SecurityGroupRule {
 	copy := *sgr
-	copy.CidrBlocks = copyArray(sgr.CidrBlocks)
+	copy.CidrBlocks = copySlice(sgr.CidrBlocks)
 	return &copy
 }
 

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+	"sort"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -56,7 +57,106 @@ type Interface interface {
 	ListKubernetesSecurityGroups(ctx context.Context, vpcID, clusterName string) ([]string, error)
 	DeleteELB(ctx context.Context, name string) error
 	DeleteELBV2(ctx context.Context, arn string) error
+
+	// VPCs
+	CreateVpcDhcpOptions(ctx context.Context, options *DhcpOptions) (*DhcpOptions, error)
+	GetVpcDhcpOptions(ctx context.Context, id string) (*DhcpOptions, error)
+	FindVpcDhcpOptionsByTags(ctx context.Context, tags Tags) ([]*DhcpOptions, error)
+	DeleteVpcDhcpOptions(ctx context.Context, id string) error
+	CreateVpc(ctx context.Context, vpc *VPC) (*VPC, error)
+	AddVpcDhcpOptionAssociation(vpcId string, dhcpOptionsId *string) error
+	UpdateVpcAttribute(ctx context.Context, vpcId, attributeName string, value bool) error
+	DeleteVpc(ctx context.Context, id string) error
+	GetVpc(ctx context.Context, id string) (*VPC, error)
+	FindVpcsByTags(ctx context.Context, tags Tags) ([]*VPC, error)
+
+	// Security groups
+	CreateSecurityGroup(ctx context.Context, sg *SecurityGroup) (*SecurityGroup, error)
+	GetSecurityGroup(ctx context.Context, id string) (*SecurityGroup, error)
+	FindSecurityGroupsByTags(ctx context.Context, tags Tags) ([]*SecurityGroup, error)
+	FindDefaultSecurityGroupByVpcId(ctx context.Context, vpcId string) (*SecurityGroup, error)
+	AuthorizeSecurityGroupRules(ctx context.Context, id string, rules []*SecurityGroupRule) error
+	RevokeSecurityGroupRules(ctx context.Context, id string, rules []*SecurityGroupRule) error
 	DeleteSecurityGroup(ctx context.Context, id string) error
+
+	// Internet gateways
+	CreateInternetGateway(ctx context.Context, gateway *InternetGateway) (*InternetGateway, error)
+	GetInternetGateway(ctx context.Context, id string) (*InternetGateway, error)
+	FindInternetGatewaysByTags(ctx context.Context, tags Tags) ([]*InternetGateway, error)
+	FindInternetGatewayByVPC(ctx context.Context, vpcId string) (*InternetGateway, error)
+	DeleteInternetGateway(ctx context.Context, id string) error
+	AttachInternetGateway(ctx context.Context, vpcId, internetGatewayId string) error
+	DetachInternetGateway(ctx context.Context, vpcId, internetGatewayId string) error
+
+	// VPC Endpoints
+	CreateVpcEndpoint(ctx context.Context, endpoint *VpcEndpoint) (*VpcEndpoint, error)
+	GetVpcEndpoints(ctx context.Context, ids []string) ([]*VpcEndpoint, error)
+	FindVpcEndpointsByTags(ctx context.Context, tags Tags) ([]*VpcEndpoint, error)
+	DeleteVpcEndpoint(ctx context.Context, id string) error
+
+	// VPC Endpoints Route table associations
+	CreateVpcEndpointRouteTableAssociation(ctx context.Context, routeTableId, vpcEndpointId string) error
+	DeleteVpcEndpointRouteTableAssociation(ctx context.Context, routeTableId, vpcEndpointId string) error
+
+	// Route tables
+	CreateRouteTable(ctx context.Context, routeTable *RouteTable) (*RouteTable, error)
+	GetRouteTable(ctx context.Context, id string) (*RouteTable, error)
+	FindRouteTablesByTags(ctx context.Context, tags Tags) ([]*RouteTable, error)
+	DeleteRouteTable(ctx context.Context, id string) error
+	CreateRoute(ctx context.Context, routeTableId string, route *Route) error
+	DeleteRoute(ctx context.Context, routeTableId string, route *Route) error
+
+	// Subnets
+	CreateSubnet(ctx context.Context, subnet *Subnet) (*Subnet, error)
+	GetSubnets(ctx context.Context, ids []string) ([]*Subnet, error)
+	FindSubnetsByTags(ctx context.Context, tags Tags) ([]*Subnet, error)
+	UpdateSubnetAttributes(ctx context.Context, desired, current *Subnet) (modified bool, err error)
+	DeleteSubnet(ctx context.Context, id string) error
+
+	// Route table associations
+	CreateRouteTableAssociation(ctx context.Context, routeTableId, subnetId string) (associationId *string, err error)
+	DeleteRouteTableAssociation(ctx context.Context, associationId string) error
+
+	// Elastic IP
+	CreateElasticIP(ctx context.Context, eip *ElasticIP) (*ElasticIP, error)
+	GetElasticIP(ctx context.Context, id string) (*ElasticIP, error)
+	FindElasticIPsByTags(ctx context.Context, tags Tags) ([]*ElasticIP, error)
+	DeleteElasticIP(ctx context.Context, id string) error
+
+	// Internet gateways
+	CreateNATGateway(ctx context.Context, gateway *NATGateway) (*NATGateway, error)
+	WaitForNATGatewayAvailable(ctx context.Context, id string) error
+	GetNATGateway(ctx context.Context, id string) (*NATGateway, error)
+	FindNATGatewaysByTags(ctx context.Context, tags Tags) ([]*NATGateway, error)
+	DeleteNATGateway(ctx context.Context, id string) error
+
+	// Key pairs
+	ImportKeyPair(ctx context.Context, keyName string, publicKey []byte, tags Tags) (*KeyPairInfo, error)
+	GetKeyPair(ctx context.Context, keyName string) (*KeyPairInfo, error)
+	FindKeyPairsByTags(ctx context.Context, tags Tags) ([]*KeyPairInfo, error)
+	DeleteKeyPair(ctx context.Context, keyName string) error
+
+	// IAM Role
+	CreateIAMRole(ctx context.Context, role *IAMRole) (*IAMRole, error)
+	GetIAMRole(ctx context.Context, roleName string) (*IAMRole, error)
+	DeleteIAMRole(ctx context.Context, roleName string) error
+	UpdateAssumeRolePolicy(ctx context.Context, roleName, assumeRolePolicy string) error
+
+	// IAM Instance Profile
+	CreateIAMInstanceProfile(ctx context.Context, profile *IAMInstanceProfile) (*IAMInstanceProfile, error)
+	GetIAMInstanceProfile(ctx context.Context, profileName string) (*IAMInstanceProfile, error)
+	DeleteIAMInstanceProfile(ctx context.Context, profileName string) error
+	AddRoleToIAMInstanceProfile(ctx context.Context, profileName, roleName string) error
+	RemoveRoleFromIAMInstanceProfile(ctx context.Context, profileName, roleName string) error
+
+	// IAM Role Policy
+	PutIAMRolePolicy(ctx context.Context, policy *IAMRolePolicy) error
+	GetIAMRolePolicy(ctx context.Context, policyName, roleName string) (*IAMRolePolicy, error)
+	DeleteIAMRolePolicy(ctx context.Context, policyName, roleName string) error
+
+	// EC2 tags
+	CreateEC2Tags(ctx context.Context, resources []string, tags Tags) error
+	DeleteEC2Tags(ctx context.Context, resources []string, tags Tags) error
 }
 
 // Factory creates instances of Interface.
@@ -71,4 +171,320 @@ type FactoryFunc func(accessKeyID, secretAccessKey, region string) (Interface, e
 // NewClient creates a new instance of Interface for the given AWS credentials and region.
 func (f FactoryFunc) NewClient(accessKeyID, secretAccessKey, region string) (Interface, error) {
 	return f(accessKeyID, secretAccessKey, region)
+}
+
+// DhcpOptions contains the relevant fields of a EC2 DHCP options resource.
+type DhcpOptions struct {
+	Tags
+	DhcpOptionsId      string
+	DhcpConfigurations map[string][]string
+}
+
+// VPC contains the relevant fields of a EC2 VPC resource.
+type VPC struct {
+	Tags
+	VpcId              string
+	CidrBlock          string
+	EnableDnsSupport   bool
+	EnableDnsHostnames bool
+	DhcpOptionsId      *string
+	InstanceTenancy    *string
+	State              *string
+}
+
+// SecurityGroup contains the relevant fields of a EC2 security group resource.
+type SecurityGroup struct {
+	Tags
+	GroupId     string
+	GroupName   string
+	VpcId       *string
+	Description *string
+	Rules       []*SecurityGroupRule
+}
+
+// Clone creates a copy.
+func (sg *SecurityGroup) Clone() *SecurityGroup {
+	copy := *sg
+	copy.Rules = copyArray(sg.Rules)
+	copy.Tags = sg.Tags.Clone()
+	return &copy
+}
+
+// SortedClone creates a copy with sorted rules.
+func (sg *SecurityGroup) SortedClone() *SecurityGroup {
+	copy := sg.Clone()
+	sort.Slice(copy.Rules, func(i, j int) bool {
+		ri := copy.Rules[i].SortedClone()
+		rj := copy.Rules[j].SortedClone()
+		return ri.LessThan(rj)
+	})
+	return copy
+}
+
+// EquivalentRulesTo returns true if the security rules are equivalent to the rules of another security group.
+func (sg *SecurityGroup) EquivalentRulesTo(other *SecurityGroup) bool {
+	if len(sg.Rules) != len(other.Rules) {
+		return false
+	}
+	a := sg.SortedClone()
+	b := other.SortedClone()
+	for i := range a.Rules {
+		ra := a.Rules[i]
+		rb := b.Rules[i]
+		if ra.LessThan(rb) || rb.LessThan(ra) {
+			return false
+		}
+	}
+	return true
+}
+
+// DiffRules calculates the different rules to another security group.
+func (sg *SecurityGroup) DiffRules(other *SecurityGroup) (addedRules, removedRules []*SecurityGroupRule) {
+	a := sg.SortedClone()
+	b := other.SortedClone()
+	an := len(a.Rules)
+	bn := len(b.Rules)
+	ai := 0
+	bi := 0
+	for ai < an || bi < bn {
+		var ra, rb *SecurityGroupRule
+		if ai < an {
+			ra = a.Rules[ai]
+		}
+		if bi < bn {
+			rb = b.Rules[bi]
+		}
+		if ra != nil {
+			if rb == nil || ra.LessThan(rb) {
+				addedRules = append(addedRules, ra)
+				ai++
+				continue
+			}
+		}
+		if rb != nil {
+			if ra == nil || rb.LessThan(ra) {
+				removedRules = append(removedRules, rb)
+				bi++
+				continue
+			}
+		}
+		if ra != nil && rb != nil {
+			ai++
+			bi++
+		}
+	}
+	return
+}
+
+// SecurityGroupRuleType is type for security group rule types
+type SecurityGroupRuleType string
+
+const (
+	// SecurityGroupRuleTypeIngress is the type for ingress rules
+	SecurityGroupRuleTypeIngress SecurityGroupRuleType = "ingress"
+	// SecurityGroupRuleTypeEgress is the type for egress rules
+	SecurityGroupRuleTypeEgress SecurityGroupRuleType = "egress"
+)
+
+// SecurityGroupRule contains the relevant fields of a EC2 security group rule resource.
+type SecurityGroupRule struct {
+	Type       SecurityGroupRuleType
+	FromPort   int
+	ToPort     int
+	Protocol   string
+	CidrBlocks []string
+	Self       bool
+	Foreign    *string
+}
+
+// Clone creates a copy.
+func (sgr *SecurityGroupRule) Clone() *SecurityGroupRule {
+	copy := *sgr
+	copy.CidrBlocks = copyArray(sgr.CidrBlocks)
+	return &copy
+}
+
+// SortedClone creates a copy with sorted CidrBlocks array for comparing and sorting.
+func (sgr *SecurityGroupRule) SortedClone() *SecurityGroupRule {
+	copy := sgr.Clone()
+	sort.Strings(copy.CidrBlocks)
+	return copy
+}
+
+// LessThan compares to another securitry group role for ordering.
+func (sgr *SecurityGroupRule) LessThan(other *SecurityGroupRule) bool {
+	if sgr.Type < other.Type {
+		return true
+	}
+	if sgr.Type > other.Type {
+		return false
+	}
+	if sgr.Foreign != nil || other.Foreign != nil {
+		if sgr.Foreign == nil {
+			return true
+		}
+		if other.Foreign == nil {
+			return false
+		}
+		if *sgr.Foreign < *other.Foreign {
+			return true
+		}
+		if *sgr.Foreign > *other.Foreign {
+			return false
+		}
+	}
+	if sgr.Protocol < other.Protocol {
+		return true
+	}
+	if sgr.Protocol > other.Protocol {
+		return false
+	}
+	if sgr.FromPort < other.FromPort {
+		return true
+	}
+	if sgr.FromPort > other.FromPort {
+		return false
+	}
+	if sgr.ToPort < other.ToPort {
+		return true
+	}
+	if sgr.ToPort > other.ToPort {
+		return false
+	}
+	if sgr.Self != other.Self {
+		return other.Self
+	}
+	if len(sgr.CidrBlocks) < len(other.CidrBlocks) {
+		return true
+	}
+	if len(sgr.CidrBlocks) > len(other.CidrBlocks) {
+		return false
+	}
+	for i := range sgr.CidrBlocks {
+		if sgr.CidrBlocks[i] < other.CidrBlocks[i] {
+			return true
+		}
+		if sgr.CidrBlocks[i] > other.CidrBlocks[i] {
+			return false
+		}
+	}
+	return false
+}
+
+// InternetGateway contains the relevant fields for an EC2 internet gateway resource.
+type InternetGateway struct {
+	Tags
+	InternetGatewayId string
+	VpcId             *string
+}
+
+// VpcEndpoint contains the relevant fields for an EC2 VPC endpoint resource.
+type VpcEndpoint struct {
+	Tags
+	VpcEndpointId string
+	VpcId         *string
+	ServiceName   string
+}
+
+// RouteTable contains the relevant fields for an EC2 route table resource.
+// Routes and Associations are filled for returned values, but ignored on creation.
+type RouteTable struct {
+	Tags
+	RouteTableId string
+	VpcId        *string
+	Routes       []*Route
+	Associations []*RouteTableAssociation
+}
+
+// Route contains the relevant fields for a route of an EC2 route table resource.
+type Route struct {
+	DestinationCidrBlock    *string
+	GatewayId               *string
+	NatGatewayId            *string
+	DestinationPrefixListId *string
+}
+
+// RouteTableAssociation contains the relevant fields for a route association of an EC2 route table resource.
+type RouteTableAssociation struct {
+	RouteTableAssociationId string
+	Main                    bool
+	GatewayId               *string
+	SubnetId                *string
+}
+
+// Subnet contains the relevant fields for an EC2 subnet resource.
+type Subnet struct {
+	Tags
+	SubnetId         string
+	VpcId            *string
+	CidrBlock        string
+	AvailabilityZone string
+
+	AssignIpv6AddressOnCreation             *bool
+	CustomerOwnedIpv4Pool                   *string
+	EnableDns64                             *bool
+	EnableResourceNameDnsAAAARecordOnLaunch *bool
+	EnableResourceNameDnsARecordOnLaunch    *bool
+	Ipv6CidrBlocks                          []string
+	Ipv6Native                              *bool
+	MapPublicIpOnLaunch                     *bool
+	MapCustomerOwnedIpOnLaunch              *bool
+	OutpostArn                              *string
+	PrivateDnsHostnameTypeOnLaunch          *string
+}
+
+// Clone creates a copy.
+func (s *Subnet) Clone() *Subnet {
+	copy := *s
+	copy.Tags = s.Tags.Clone()
+	return &copy
+}
+
+// ElasticIP contains the relevant fields for an EC2 elastic IP resource.
+type ElasticIP struct {
+	Tags
+	AllocationId string
+	PublicIp     string
+	Vpc          bool
+}
+
+// NATGateway contains the relevant fields for an EC2 NAT gateway resource.
+type NATGateway struct {
+	Tags
+	NATGatewayId    string
+	EIPAllocationId string
+	PublicIP        string
+	SubnetId        string
+	State           string
+}
+
+// KeyPairInfo contains the relevant fields for an EC2 key pair.
+type KeyPairInfo struct {
+	Tags
+	KeyName        string
+	KeyFingerprint string
+}
+
+// IAMRole contains the relevant fields for an IAM role resource.
+type IAMRole struct {
+	RoleId                   string
+	RoleName                 string
+	Path                     string
+	AssumeRolePolicyDocument string
+	ARN                      string
+}
+
+// IAMInstanceProfile contains the relevant fields for an IAM instance profile resource.
+type IAMInstanceProfile struct {
+	InstanceProfileId   string
+	InstanceProfileName string
+	Path                string
+	RoleName            string
+}
+
+// IAMRolePolicy contains the relevant fields for an IAM role policy resource.
+type IAMRolePolicy struct {
+	PolicyName     string
+	RoleName       string
+	PolicyDocument string
 }

--- a/pkg/aws/client/types_test.go
+++ b/pkg/aws/client/types_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"fmt"
+	"reflect"
+
+	. "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
+	"k8s.io/utils/pointer"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SecurityGroup", func() {
+	var (
+		rules1 = []*SecurityGroupRule{
+			{
+				Type:     SecurityGroupRuleTypeIngress,
+				Protocol: "-1",
+				Self:     true,
+			},
+			{
+				Type:       SecurityGroupRuleTypeIngress,
+				FromPort:   30000,
+				ToPort:     32767,
+				Protocol:   "tcp",
+				CidrBlocks: []string{"0.0.0.0/0"},
+			},
+			{
+				Type:       SecurityGroupRuleTypeIngress,
+				FromPort:   30000,
+				ToPort:     32767,
+				Protocol:   "udp",
+				CidrBlocks: []string{"0.0.0.0/0"},
+			},
+			{
+				Type:       SecurityGroupRuleTypeEgress,
+				Protocol:   "-1",
+				CidrBlocks: []string{"0.0.0.0/0"},
+			},
+		}
+		rules2 = []*SecurityGroupRule{
+			{
+				Type:       SecurityGroupRuleTypeIngress,
+				FromPort:   30000,
+				ToPort:     32767,
+				Protocol:   "udp",
+				CidrBlocks: []string{"10.0.0.0/8"},
+			},
+			{
+				Type:     SecurityGroupRuleTypeIngress,
+				Protocol: "-1",
+				Self:     true,
+			},
+		}
+		sg1 = &SecurityGroup{
+			GroupId:   "sg-1",
+			GroupName: "sg1",
+			VpcId:     pointer.String("vpc-1"),
+			Rules:     rules1,
+		}
+		clone1  = sg1.SortedClone()
+		clone1b = sg1.Clone()
+		sg2     = &SecurityGroup{
+			GroupId:   "sg-2",
+			GroupName: "sg2",
+			VpcId:     pointer.String("vpc-1"),
+			Rules:     rules2,
+		}
+		sg3 = &SecurityGroup{
+			GroupId:   "sg-3",
+			GroupName: "sg3",
+			VpcId:     pointer.String("vpc-1"),
+		}
+	)
+
+	clone1b.Rules = clone1b.Rules[2:]
+
+	Describe("#SortedClone", func() {
+		It("should copy all rules", func() {
+			Expect(clone1.GroupId).To(Equal(sg1.GroupId))
+			Expect(clone1.GroupName).To(Equal(sg1.GroupName))
+			Expect(clone1.VpcId).To(Equal(sg1.VpcId))
+			Expect(len(clone1.Rules)).To(Equal(len(sg1.Rules)))
+		outer:
+			for i, r1 := range clone1.Rules {
+				for _, r2 := range sg1.Rules {
+					if reflect.DeepEqual(r1, r2) {
+						continue outer
+					}
+				}
+				Fail(fmt.Sprintf("rule not found: %d %v", i, *r1))
+			}
+		})
+	})
+
+	DescribeTable("#EquivalentRules",
+		func(a, b *SecurityGroup, expectedEqual bool) {
+			Expect(a.EquivalentRulesTo(b)).To(Equal(expectedEqual))
+		},
+
+		Entry("sg1-sg1", sg1, sg1, true),
+		Entry("sg1-clone1", sg1, clone1, true),
+		Entry("clone1-sg1", clone1, sg1, true),
+		Entry("sg1-sg2", sg1, sg2, false),
+	)
+
+	DescribeTable("#DiffRules",
+		func(a, b *SecurityGroup, expectedAddedCount, expectedRemovedCount int) {
+			added, removed := a.DiffRules(b)
+			Expect(len(added)).To(Equal(expectedAddedCount))
+			Expect(len(removed)).To(Equal(expectedRemovedCount))
+		},
+
+		Entry("sg1-sg1", sg1, sg1, 0, 0),
+		Entry("sg1-clone1", sg1, clone1, 0, 0),
+		Entry("clone1-sg1", clone1, sg1, 0, 0),
+		Entry("sg1-clone1b", sg1, clone1b, 2, 0),
+		Entry("clone1-clone1b", clone1, clone1b, 2, 0),
+		Entry("clone1b-sg1", clone1b, sg1, 0, 2),
+		Entry("clone1b-clone1", clone1b, clone1, 0, 2),
+		Entry("sg1-sg2", sg1, sg2, 3, 1),
+		Entry("sg2-sg1", sg2, sg1, 1, 3),
+		Entry("sg1-sg3", sg1, sg3, 4, 0),
+		Entry("sg3-sg1", sg3, sg1, 0, 4),
+	)
+})

--- a/pkg/aws/client/types_test.go
+++ b/pkg/aws/client/types_test.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"reflect"
 
-	. "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
-	"k8s.io/utils/pointer"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+
+	. "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
 )
 
 var _ = Describe("SecurityGroup", func() {

--- a/pkg/aws/client/updater.go
+++ b/pkg/aws/client/updater.go
@@ -22,9 +22,10 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
-	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/go-logr/logr"
 	"k8s.io/utils/pointer"
+
+	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 )
 
 // Updater provides methods to update selected AWS client objects.

--- a/pkg/aws/client/updater.go
+++ b/pkg/aws/client/updater.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
+	"github.com/go-logr/logr"
+	"k8s.io/utils/pointer"
+)
+
+// Updater provides methods to update selected AWS client objects.
+type Updater interface {
+	UpdateVpc(ctx context.Context, desired, current *VPC) (modified bool, err error)
+	UpdateSecurityGroup(ctx context.Context, desired, current *SecurityGroup) (modified bool, err error)
+	UpdateRouteTable(ctx context.Context, log logr.Logger, desired, current *RouteTable, controlledCidrBlocks ...string) (modified bool, err error)
+	UpdateSubnet(ctx context.Context, desired, current *Subnet) (modified bool, err error)
+	UpdateIAMInstanceProfile(ctx context.Context, desired, current *IAMInstanceProfile) (modified bool, err error)
+	UpdateIAMRole(ctx context.Context, desired, current *IAMRole) (modified bool, err error)
+	UpdateEC2Tags(ctx context.Context, id string, desired, current Tags) (modified bool, err error)
+}
+
+type updater struct {
+	client     Interface
+	ignoreTags *awsapi.IgnoreTags
+}
+
+// NewUpdater creates a new updater instance.
+func NewUpdater(client Interface, ignoreTags *awsapi.IgnoreTags) Updater {
+	return &updater{
+		client:     client,
+		ignoreTags: ignoreTags,
+	}
+}
+
+func (u *updater) UpdateVpc(ctx context.Context, desired, current *VPC) (modified bool, err error) {
+	if desired.CidrBlock != current.CidrBlock {
+		return false, fmt.Errorf("cannot change CIDR block")
+	}
+	modified, err = u.updateVpcAttributes(ctx, desired, current)
+	if err != nil {
+		return
+	}
+	if !reflect.DeepEqual(desired.DhcpOptionsId, current.DhcpOptionsId) {
+		if err = u.client.AddVpcDhcpOptionAssociation(current.VpcId, desired.DhcpOptionsId); err != nil {
+			return
+		}
+		modified = true
+	}
+
+	mod2, err := u.UpdateEC2Tags(ctx, current.VpcId, desired.Tags, current.Tags)
+	if err != nil {
+		return
+	}
+	return modified || mod2, nil
+}
+
+func (u *updater) updateVpcAttributes(ctx context.Context, desired, current *VPC) (modified bool, err error) {
+	if desired.EnableDnsSupport != current.EnableDnsSupport {
+		if err = u.client.UpdateVpcAttribute(ctx, current.VpcId, ec2.VpcAttributeNameEnableDnsSupport, desired.EnableDnsSupport); err != nil {
+			return
+		}
+		modified = true
+	}
+	if desired.EnableDnsHostnames != current.EnableDnsHostnames {
+		if err = u.client.UpdateVpcAttribute(ctx, current.VpcId, ec2.VpcAttributeNameEnableDnsHostnames, desired.EnableDnsHostnames); err != nil {
+			return
+		}
+		modified = true
+	}
+	return
+}
+
+func (u *updater) UpdateSecurityGroup(ctx context.Context, desired, current *SecurityGroup) (modified bool, err error) {
+	added, removed := desired.DiffRules(current)
+	if len(added) == 0 && len(removed) == 0 {
+		return
+	}
+	if err = u.client.RevokeSecurityGroupRules(ctx, current.GroupId, removed); err != nil {
+		return
+	}
+	if err = u.client.AuthorizeSecurityGroupRules(ctx, current.GroupId, added); err != nil {
+		return
+	}
+	if _, err = u.UpdateEC2Tags(ctx, current.GroupId, desired.Tags, current.Tags); err != nil {
+		return
+	}
+	return true, nil
+}
+
+func (u *updater) UpdateRouteTable(ctx context.Context, log logr.Logger, desired, current *RouteTable, controlledCidrBlocks ...string) (modified bool, err error) {
+outerDelete:
+	for _, cr := range current.Routes {
+		for _, dr := range desired.Routes {
+			if reflect.DeepEqual(cr, dr) {
+				continue outerDelete
+			}
+		}
+		if cr.GatewayId != nil && *cr.GatewayId == "local" {
+			// ignore local gateway route
+			continue outerDelete
+		}
+		if cr.DestinationPrefixListId != nil {
+			// ignore VPC endpoint route table associations
+			continue outerDelete
+		}
+		routeCidrBlock := pointer.StringDeref(cr.DestinationCidrBlock, "")
+		found := false
+		for _, cidr := range controlledCidrBlocks {
+			if routeCidrBlock == cidr {
+				found = true
+				break
+			}
+		}
+		if !found {
+			// ignore unknown routes
+			continue
+		}
+		if err = u.client.DeleteRoute(ctx, current.RouteTableId, cr); err != nil {
+			return
+		}
+		log.Info("Deleted route", "cidr", routeCidrBlock)
+		modified = true
+	}
+outerCreate:
+	for _, dr := range desired.Routes {
+		for _, cr := range current.Routes {
+			if reflect.DeepEqual(cr, dr) {
+				continue outerCreate
+			}
+		}
+		if err = u.client.CreateRoute(ctx, current.RouteTableId, dr); err != nil {
+			return
+		}
+		log.Info("Created route", "cidr", pointer.StringDeref(dr.DestinationCidrBlock, ""))
+		modified = true
+	}
+	return
+}
+
+func (u *updater) UpdateSubnet(ctx context.Context, desired, current *Subnet) (modified bool, err error) {
+	modified, err = u.client.UpdateSubnetAttributes(ctx, desired, current)
+	if err != nil {
+		return
+	}
+
+	mod2, err := u.UpdateEC2Tags(ctx, current.SubnetId, desired.Tags, current.Tags)
+	if err != nil {
+		return
+	}
+	return modified || mod2, nil
+}
+
+func (u *updater) UpdateIAMInstanceProfile(ctx context.Context, desired, current *IAMInstanceProfile) (modified bool, err error) {
+	if current.RoleName == desired.RoleName {
+		return
+	}
+	if desired.RoleName != "" {
+		if err = u.client.AddRoleToIAMInstanceProfile(ctx, current.InstanceProfileName, desired.RoleName); err != nil {
+			return
+		}
+		modified = true
+	}
+	if current.RoleName != "" {
+		if err = u.client.RemoveRoleFromIAMInstanceProfile(ctx, current.InstanceProfileName, current.RoleName); err != nil {
+			return
+		}
+		modified = true
+	}
+	return
+}
+
+func (u *updater) UpdateIAMRole(ctx context.Context, desired, current *IAMRole) (modified bool, err error) {
+	var equalDocument bool
+	equalDocument, err = u.equalJSON(current.AssumeRolePolicyDocument, desired.AssumeRolePolicyDocument)
+	if err != nil {
+		return
+	}
+	if equalDocument {
+		return
+	}
+
+	if err = u.client.UpdateAssumeRolePolicy(ctx, current.RoleName, desired.AssumeRolePolicyDocument); err != nil {
+		return
+	}
+	modified = true
+	return
+}
+
+func (u *updater) equalJSON(a, b string) (bool, error) {
+	ma := map[string]any{}
+	mb := map[string]any{}
+	if err := json.Unmarshal([]byte(a), &ma); err != nil {
+		return false, err
+	}
+	if err := json.Unmarshal([]byte(b), &mb); err != nil {
+		return false, err
+	}
+	return reflect.DeepEqual(ma, mb), nil
+}
+
+func (u *updater) UpdateEC2Tags(ctx context.Context, id string, desired, current Tags) (bool, error) {
+	modified := false
+	toBeDeleted := Tags{}
+	toBeCreated := Tags{}
+	toBeIgnored := Tags{}
+	for k, v := range current {
+		if dv, ok := desired[k]; ok {
+			if dv != v {
+				toBeDeleted[k] = v
+				toBeCreated[k] = dv
+			}
+		} else if u.ignoreTag(k) {
+			toBeIgnored[k] = v
+		} else {
+			toBeDeleted[k] = v
+		}
+	}
+	for k, v := range desired {
+		if _, ok := current[k]; !ok && !u.ignoreTag(k) {
+			toBeCreated[k] = v
+		}
+	}
+
+	if len(toBeDeleted) > 0 {
+		if err := u.client.DeleteEC2Tags(ctx, []string{id}, toBeDeleted); err != nil {
+			return false, err
+		}
+		modified = true
+	}
+	if len(toBeCreated) > 0 {
+		if err := u.client.CreateEC2Tags(ctx, []string{id}, toBeCreated); err != nil {
+			return false, err
+		}
+		modified = true
+	}
+
+	return modified, nil
+}
+
+func (u *updater) ignoreTag(key string) bool {
+	if u.ignoreTags == nil {
+		return false
+	}
+	for _, ignoreKey := range u.ignoreTags.Keys {
+		if ignoreKey == key {
+			return true
+		}
+	}
+	for _, ignoreKeyPrefix := range u.ignoreTags.KeyPrefixes {
+		if strings.HasPrefix(key, ignoreKeyPrefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/aws/client/utils.go
+++ b/pkg/aws/client/utils.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+func copyArray[T any](array []T) []T {
+	var copy []T
+	return append(copy, array...)
+}

--- a/pkg/aws/client/utils.go
+++ b/pkg/aws/client/utils.go
@@ -14,7 +14,7 @@
 
 package client
 
-func copyArray[T any](array []T) []T {
+func copySlice[T any](array []T) []T {
 	var copy []T
 	return append(copy, array...)
 }

--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -30,11 +30,6 @@ import (
 	"github.com/gardener/gardener-extension-provider-aws/pkg/imagevector"
 )
 
-const (
-	// AnnotationKeyUseFlow is the annotation key used to enable reconciliation with flow instead of terraformer.
-	AnnotationKeyUseFlow = "aws.provider.extensions.gardener.cloud/use-flow"
-)
-
 type actuator struct {
 	common.RESTConfigContext
 	disableProjectedTokenMount bool

--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -15,7 +15,6 @@
 package infrastructure
 
 import (
-	"strings"
 	"time"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/common"
@@ -94,15 +93,4 @@ func generateTerraformerEnvVars(secretRef corev1.SecretReference) []corev1.EnvVa
 			Key: aws.SecretAccessKey,
 		}},
 	}}
-}
-
-func (a *actuator) addErrorCodes(err error) error {
-	if err == nil {
-		return nil
-	}
-	if msg := err.Error(); strings.Contains(msg, "AuthFailure:") ||
-		strings.Contains(msg, "InvalidClientTokenId:") {
-		return helper.NewErrorWithCodes(err, gardencorev1beta1.ErrorInfraUnauthorized)
-	}
-	return err
 }

--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -28,8 +28,6 @@ import (
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/imagevector"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 )
 
 const (

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -33,7 +33,6 @@ import (
 	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
-	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow"
 )
 

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -33,8 +33,8 @@ import (
 	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
-	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow"
 	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow"
 )
 
 func (a *actuator) Delete(ctx context.Context, log logr.Logger, infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) error {
@@ -59,7 +59,7 @@ func (a *actuator) deleteWithFlow(ctx context.Context, log logr.Logger, infrastr
 	}
 	if err = flowContext.Delete(ctx); err != nil {
 		_ = flowContext.PersistState(ctx, true)
-		return a.addErrorCodes(err)
+		return util.DetermineError(err, helper.KnownCodes)
 	}
 	return flowContext.PersistState(ctx, true)
 }

--- a/pkg/controller/infrastructure/actuator_restore.go
+++ b/pkg/controller/infrastructure/actuator_restore.go
@@ -17,8 +17,10 @@ package infrastructure
 import (
 	"context"
 
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
+	"github.com/gardener/gardener/extensions/pkg/util"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
 )
@@ -35,7 +37,7 @@ func (a *actuator) Restore(ctx context.Context, log logr.Logger, infrastructure 
 	if a.shouldUseFlow(infrastructure, cluster) {
 		flowState, err = a.migrateFromTerraformerState(ctx, log, infrastructure)
 		if err != nil {
-			return a.addErrorCodes(err)
+			return util.DetermineError(err, helper.KnownCodes)
 		}
 		return a.reconcileWithFlow(ctx, log, infrastructure, flowState)
 	}

--- a/pkg/controller/infrastructure/actuator_restore.go
+++ b/pkg/controller/infrastructure/actuator_restore.go
@@ -24,13 +24,31 @@ import (
 )
 
 // Restore takes the infrastructure state and deploys it as terraform state ConfigMap before calling the terraformer
-func (a *actuator) Restore(ctx context.Context, log logr.Logger, infrastructure *extensionsv1alpha1.Infrastructure, _ *extensionscontroller.Cluster) error {
+func (a *actuator) Restore(ctx context.Context, log logr.Logger, infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) error {
+	flowState, err := a.getStateFromInfraStatus(ctx, infrastructure)
+	if err != nil {
+		return err
+	}
+	if flowState != nil {
+		return a.reconcileWithFlow(ctx, log, infrastructure, flowState)
+	}
+	if a.shouldUseFlow(infrastructure, cluster) {
+		flowState, err = a.migrateFromTerraformerState(ctx, log, infrastructure)
+		if err != nil {
+			return a.addErrorCodes(err)
+		}
+		return a.reconcileWithFlow(ctx, log, infrastructure, flowState)
+	}
+	return a.restoreWithTerraformer(ctx, log, infrastructure)
+}
+
+func (a *actuator) restoreWithTerraformer(ctx context.Context, log logr.Logger, infrastructure *extensionsv1alpha1.Infrastructure) error {
 	terraformState, err := terraformer.UnmarshalRawState(infrastructure.Status.State)
 	if err != nil {
 		return err
 	}
 
-	infrastructureStatus, state, err := Reconcile(
+	infrastructureStatus, state, err := ReconcileWithTerraformer(
 		ctx,
 		log,
 		a.RESTConfig(),
@@ -44,5 +62,5 @@ func (a *actuator) Restore(ctx context.Context, log logr.Logger, infrastructure 
 		return err
 	}
 
-	return updateProviderStatus(ctx, a.Client(), infrastructure, infrastructureStatus, state)
+	return updateProviderStatusTf(ctx, a.Client(), infrastructure, infrastructureStatus, state)
 }

--- a/pkg/controller/infrastructure/actuator_restore.go
+++ b/pkg/controller/infrastructure/actuator_restore.go
@@ -17,12 +17,13 @@ package infrastructure
 import (
 	"context"
 
-	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	"github.com/gardener/gardener/extensions/pkg/util"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 )
 
 // Restore takes the infrastructure state and deploys it as terraform state ConfigMap before calling the terraformer

--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -187,7 +187,7 @@ func (c *FlowContext) zoneSuffixHelpers(zoneName string) *ZoneSuffixHelper {
 		return &ZoneSuffixHelper{suffix: *suffix}
 	}
 	zones := c.state.GetChild(ChildIdZones)
-	existing := sets.String{}
+	existing := sets.New[string]()
 	for _, key := range zones.GetChildrenKeys() {
 		otherChild := zones.GetChild(key)
 		if suffix := otherChild.Get(IdentifierZoneSuffix); suffix != nil {

--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infraflow
+
+import (
+	"fmt"
+	"strings"
+
+	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
+	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	// TagKeyName is the name tag key
+	TagKeyName = "Name"
+	// TagKeyClusterTemplate is the template for the cluster tag key
+	TagKeyClusterTemplate = "kubernetes.io/cluster/%s"
+	// TagKeyRolePublicELB is the tag key for the public ELB
+	TagKeyRolePublicELB = "kubernetes.io/role/elb"
+	// TagKeyRolePrivateELB is the tag key for the internal ELB
+	TagKeyRolePrivateELB = "kubernetes.io/role/internal-elb"
+	// TagValueCluster is the tag value for the cluster tag
+	TagValueCluster = "1"
+	// TagValueUse is the tag value for the ELB tag keys
+	TagValueUse = "use"
+
+	// IdentifierVPC is the key for the VPC id
+	IdentifierVPC = "VPC"
+	// IdentifierDHCPOptions is the key for the id of the DHCPOptions resource
+	IdentifierDHCPOptions = "DHCPOptions"
+	// IdentifierDefaultSecurityGroup is the key for the id of the default security group
+	IdentifierDefaultSecurityGroup = "DefaultSecurityGroup"
+	// IdentifierInternetGateway is the key for the id of the internet gateway resource
+	IdentifierInternetGateway = "InternetGateway"
+	// IdentifierMainRouteTable is the key for the id of the main route table
+	IdentifierMainRouteTable = "MainRouteTable"
+	// IdentifierNodesSecurityGroup is the key for the id of the nodes security group
+	IdentifierNodesSecurityGroup = "NodesSecurityGroup"
+	// IdentifierZoneSubnetWorkers is the key for the id of the workers subnet
+	IdentifierZoneSubnetWorkers = "SubnetWorkers"
+	// IdentifierZoneSubnetPublic is the key for the id of the public utility subnet
+	IdentifierZoneSubnetPublic = "SubnetPublicUtility"
+	// IdentifierZoneSubnetPrivate is the key for the id of the private utility subnet
+	IdentifierZoneSubnetPrivate = "SubnetPrivateUtility"
+	// IdentifierZoneSuffix is the key for the suffix used for a zone
+	IdentifierZoneSuffix = "Suffix"
+	// IdentifierZoneNATGWElasticIP is the key for the id of the elastic IP resource used for the NAT gateway
+	IdentifierZoneNATGWElasticIP = "NATGatewayElasticIP"
+	// IdentifierZoneNATGateway is the key for the id of the NAT gateway resource
+	IdentifierZoneNATGateway = "NATGateway"
+	// IdentifierZoneRouteTable is the key for the id of route table of the zone
+	IdentifierZoneRouteTable = "ZoneRouteTable"
+	// IdentifierZoneSubnetPublicRouteTableAssoc is the key for the id of the public route table association resource
+	IdentifierZoneSubnetPublicRouteTableAssoc = "SubnetPublicRouteTableAssoc"
+	// IdentifierZoneSubnetPrivateRouteTableAssoc is the key for the id of the private c route table association resource
+	IdentifierZoneSubnetPrivateRouteTableAssoc = "SubnetPrivateRouteTableAssoc"
+	// IdentifierZoneSubnetWorkersRouteTableAssoc is key for the id of the workers route table association resource
+	IdentifierZoneSubnetWorkersRouteTableAssoc = "SubnetWorkersRouteTableAssoc"
+	// NameIAMRole is the key for the name of the IAM role
+	NameIAMRole = "IAMRoleName"
+	// NameIAMInstanceProfile is the key for the name of the IAM instance profile
+	NameIAMInstanceProfile = "IAMInstanceProfileName"
+	// NameIAMRolePolicy is the key for the name of the IAM role policy
+	NameIAMRolePolicy = "IAMRolePolicyName"
+	// NameKeyPair is the key for the name of the EC2 key pair resource
+	NameKeyPair = "KeyPair"
+	// ARNIAMRole is the key for the ARN of the IAM role
+	ARNIAMRole = "IAMRoleARN"
+	// KeyPairFingerprint is the key to store the fingerprint of the key pair
+	KeyPairFingerprint = "KeyPairFingerprint"
+	// KeyPairSpecFingerprint is the key to store the fingerprint of the public key from the spec
+	KeyPairSpecFingerprint = "KeyPairSpecFingerprint"
+
+	// ChildIdVPCEndpoints is the child key for the VPC endpoints
+	ChildIdVPCEndpoints = "VPCEndpoints"
+	// ChildIdZones is the child key for the zones
+	ChildIdZones = "Zones"
+
+	// ObjectMainRouteTable is the object key used for caching the main route table object
+	ObjectMainRouteTable = "MainRouteTable"
+	// ObjectZoneRouteTable is the object key used for caching the zone route table object
+	ObjectZoneRouteTable = "ZoneRouteTable"
+
+	// MarkerMigratedFromTerraform is the key for marking the state for successful state migration from Terraformer
+	MarkerMigratedFromTerraform = "MigratedFromTerraform"
+	// MarkerTerraformCleanedUp is the key for marking the state for successful cleanup of Terraformer resources.
+	MarkerTerraformCleanedUp = "TerraformCleanedUp"
+	// MarkerLoadBalancersAndSecurityGroupsDestroyed is the key for marking the state that orphan load balancers
+	// and security groups have already been destroyed
+	MarkerLoadBalancersAndSecurityGroupsDestroyed = "LoadBalancersAndSecurityGroupsDestroyed"
+)
+
+// FlowContext contains the logic to reconcile or delete the AWS infrastructure.
+type FlowContext struct {
+	shared.BasicFlowContext
+	state      shared.Whiteboard
+	namespace  string
+	infraSpec  extensionsv1alpha1.InfrastructureSpec
+	config     *awsapi.InfrastructureConfig
+	client     awsclient.Interface
+	updater    awsclient.Updater
+	commonTags awsclient.Tags
+}
+
+// NewFlowContext creates a new FlowContext object
+func NewFlowContext(log logr.Logger, awsClient awsclient.Interface,
+	infra *extensionsv1alpha1.Infrastructure, config *awsapi.InfrastructureConfig,
+	oldState shared.FlatMap, persistor shared.FlowStatePersistor) (*FlowContext, error) {
+
+	whiteboard := shared.NewWhiteboard()
+	if oldState != nil {
+		whiteboard.ImportFromFlatMap(oldState)
+	}
+
+	flowContext := &FlowContext{
+		BasicFlowContext: *shared.NewBasicFlowContext(log, whiteboard, persistor),
+		state:            whiteboard,
+		namespace:        infra.Namespace,
+		infraSpec:        infra.Spec,
+		config:           config,
+		client:           awsClient,
+		updater:          awsclient.NewUpdater(awsClient, config.IgnoreTags),
+	}
+	flowContext.commonTags = awsclient.Tags{
+		flowContext.tagKeyCluster(): TagValueCluster,
+		TagKeyName:                  infra.Namespace,
+	}
+	if config.Networks.VPC.ID != nil {
+		flowContext.state.SetPtr(IdentifierVPC, config.Networks.VPC.ID)
+	}
+	return flowContext, nil
+}
+
+// GetInfrastructureConfig returns the InfrastructureConfig object
+func (c *FlowContext) GetInfrastructureConfig() *awsapi.InfrastructureConfig {
+	return c.config
+}
+
+func (c *FlowContext) hasVPC() bool {
+	return !c.state.IsAlreadyDeleted(IdentifierVPC)
+}
+
+func (c *FlowContext) commonTagsWithSuffix(suffix string) awsclient.Tags {
+	tags := c.commonTags.Clone()
+	tags[TagKeyName] = fmt.Sprintf("%s-%s", c.namespace, suffix)
+	return tags
+}
+
+func (c *FlowContext) tagKeyCluster() string {
+	return fmt.Sprintf(TagKeyClusterTemplate, c.namespace)
+}
+
+func (c *FlowContext) clusterTags() awsclient.Tags {
+	tags := awsclient.Tags{}
+	tags[c.tagKeyCluster()] = TagValueCluster
+	return tags
+}
+
+func (c *FlowContext) vpcEndpointServiceNamePrefix() string {
+	return fmt.Sprintf("com.amazonaws.%s.", c.infraSpec.Region)
+}
+
+func (c *FlowContext) extractVpcEndpointName(item *awsclient.VpcEndpoint) string {
+	return strings.TrimPrefix(item.ServiceName, c.vpcEndpointServiceNamePrefix())
+}
+
+func (c *FlowContext) zoneSuffixHelpers(zoneName string) *ZoneSuffixHelper {
+	zoneChild := c.getSubnetZoneChild(zoneName)
+	if suffix := zoneChild.Get(IdentifierZoneSuffix); suffix != nil {
+		return &ZoneSuffixHelper{suffix: *suffix}
+	}
+	zones := c.state.GetChild(ChildIdZones)
+	existing := sets.String{}
+	for _, key := range zones.GetChildrenKeys() {
+		otherChild := zones.GetChild(key)
+		if suffix := otherChild.Get(IdentifierZoneSuffix); suffix != nil {
+			existing.Insert(*suffix)
+		}
+	}
+	for i := 0; ; i++ {
+		suffix := fmt.Sprintf("z%d", i)
+		if !existing.Has(suffix) {
+			zoneChild.Set(IdentifierZoneSuffix, suffix)
+			return &ZoneSuffixHelper{suffix: suffix}
+		}
+	}
+}
+
+// ZoneSuffixHelper provides methods to create suffices for various resources
+type ZoneSuffixHelper struct {
+	suffix string
+}
+
+// GetSuffixSubnetWorkers builds the suffix for the workers subnet
+func (h *ZoneSuffixHelper) GetSuffixSubnetWorkers() string {
+	return fmt.Sprintf("nodes-%s", h.suffix)
+}
+
+// GetSuffixSubnetPublic builds the suffix for the public utility subnet
+func (h *ZoneSuffixHelper) GetSuffixSubnetPublic() string {
+	return fmt.Sprintf("public-utility-%s", h.suffix)
+}
+
+// GetSuffixSubnetPrivate builds the suffix for the private utility subnet
+func (h *ZoneSuffixHelper) GetSuffixSubnetPrivate() string {
+	return fmt.Sprintf("private-utility-%s", h.suffix)
+}
+
+// GetSuffixElasticIP builds the suffix for the elastic IP of the NAT gateway
+func (h *ZoneSuffixHelper) GetSuffixElasticIP() string {
+	return fmt.Sprintf("eip-natgw-%s", h.suffix)
+}
+
+// GetSuffixNATGateway builds the suffix for the NAT gateway
+func (h *ZoneSuffixHelper) GetSuffixNATGateway() string {
+	return fmt.Sprintf("natgw-%s", h.suffix)
+}

--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -18,12 +18,13 @@ import (
 	"fmt"
 	"strings"
 
-	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
-	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
-	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
+	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
 )
 
 const (

--- a/pkg/controller/infrastructure/infraflow/delete.go
+++ b/pkg/controller/infrastructure/infraflow/delete.go
@@ -19,12 +19,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gardener/gardener/extensions/pkg/util"
+	"github.com/gardener/gardener/pkg/utils/flow"
+
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
 	. "github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
-
-	"github.com/gardener/gardener/extensions/pkg/util"
-	"github.com/gardener/gardener/pkg/utils/flow"
 )
 
 // Delete creates and runs the flow to delete the AWS infrastructure.

--- a/pkg/controller/infrastructure/infraflow/delete.go
+++ b/pkg/controller/infrastructure/infraflow/delete.go
@@ -1,0 +1,353 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infraflow
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
+	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
+	. "github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
+
+	"github.com/gardener/gardener/extensions/pkg/util"
+	"github.com/gardener/gardener/pkg/utils/flow"
+)
+
+// Delete creates and runs the flow to delete the AWS infrastructure.
+func (c *FlowContext) Delete(ctx context.Context) error {
+	if c.state.IsEmpty() {
+		// nothing to do, e.g. if cluster was created with wrong credentials
+		return nil
+	}
+	g := c.buildDeleteGraph()
+	f := g.Compile()
+	if err := f.Run(ctx, flow.Opts{Log: c.Log}); err != nil {
+		return flow.Causes(err)
+	}
+	return nil
+}
+
+func (c *FlowContext) buildDeleteGraph() *flow.Graph {
+	g := flow.NewGraph("AWS infrastructure destruction")
+
+	deleteVPC := c.config.Networks.VPC.ID == nil
+
+	destroyLoadBalancersAndSecurityGroups := c.AddTask(g, "Destroying Kubernetes load balancers and security groups",
+		c.deleteKubernetesLoadBalancersAndSecurityGroups,
+		DoIf(c.hasVPC() && c.state.Get(MarkerLoadBalancersAndSecurityGroupsDestroyed) == nil), Timeout(5*time.Minute))
+
+	_ = c.AddTask(g, "delete key pair",
+		c.deleteKeyPair,
+		Timeout(defaultTimeout))
+
+	deleteIAMRolePolicy := c.AddTask(g, "delete IAM role policy",
+		c.deleteIAMRolePolicy,
+		Timeout(defaultTimeout))
+
+	deleteIAMInstanceProfile := c.AddTask(g, "delete IAM instance profile",
+		c.deleteIAMInstanceProfile,
+		Timeout(defaultTimeout), Dependencies(deleteIAMRolePolicy))
+
+	_ = c.AddTask(g, "delete IAM role",
+		c.deleteIAMRole,
+		Timeout(defaultTimeout), Dependencies(deleteIAMInstanceProfile, deleteIAMRolePolicy))
+
+	deleteZones := c.AddTask(g, "delete zones resources",
+		c.deleteZones,
+		DoIf(c.hasVPC()), Timeout(defaultLongTimeout))
+
+	deleteNodesSecurityGroup := c.AddTask(g, "delete nodes security group",
+		c.deleteNodesSecurityGroup,
+		DoIf(c.hasVPC()), Timeout(defaultTimeout), Dependencies(deleteZones))
+
+	deleteMainRouteTable := c.AddTask(g, "delete main route table",
+		c.deleteMainRouteTable,
+		DoIf(c.hasVPC()), Timeout(defaultTimeout), Dependencies(deleteZones))
+
+	deleteGatewayEndpoints := c.AddTask(g, "delete gateway endpoints",
+		c.deleteGatewayEndpoints,
+		DoIf(c.hasVPC()), Timeout(defaultTimeout))
+
+	deleteInternetGateway := c.AddTask(g, "delete internet gateway",
+		c.deleteInternetGateway,
+		DoIf(deleteVPC && c.hasVPC()), Timeout(defaultTimeout), Dependencies(deleteGatewayEndpoints, deleteMainRouteTable))
+
+	deleteDefaultSecurityGroup := c.AddTask(g, "delete default security group",
+		c.deleteDefaultSecurityGroup,
+		DoIf(deleteVPC && c.hasVPC()), Timeout(defaultTimeout), Dependencies(deleteGatewayEndpoints))
+
+	deleteVpc := c.AddTask(g, "delete VPC",
+		c.deleteVpc,
+		DoIf(deleteVPC && c.hasVPC()), Timeout(defaultTimeout),
+		Dependencies(deleteInternetGateway, deleteDefaultSecurityGroup, deleteNodesSecurityGroup, destroyLoadBalancersAndSecurityGroups))
+
+	_ = c.AddTask(g, "delete DHCP options for VPC",
+		c.deleteDhcpOptions,
+		DoIf(deleteVPC && !c.state.IsAlreadyDeleted(IdentifierDHCPOptions)), Timeout(defaultTimeout),
+		Dependencies(deleteVpc))
+
+	return g
+}
+
+func (c *FlowContext) deleteKubernetesLoadBalancersAndSecurityGroups(ctx context.Context) error {
+	if err := DestroyKubernetesLoadBalancersAndSecurityGroups(ctx, c.client, *c.state.Get(IdentifierVPC), c.namespace); err != nil {
+		return util.DetermineError(fmt.Errorf("Failed to destroy load balancers and security groups: %w", err), helper.KnownCodes)
+	}
+
+	c.state.Set(MarkerLoadBalancersAndSecurityGroupsDestroyed, "true")
+
+	return nil
+}
+
+// DestroyKubernetesLoadBalancersAndSecurityGroups tries to delete orphaned load balancers and security groups.
+func DestroyKubernetesLoadBalancersAndSecurityGroups(ctx context.Context, awsClient awsclient.Interface, vpcID, clusterName string) error {
+	for _, v := range []struct {
+		listFn   func(context.Context, string, string) ([]string, error)
+		deleteFn func(context.Context, string) error
+	}{
+		{awsClient.ListKubernetesELBs, awsClient.DeleteELB},
+		{awsClient.ListKubernetesELBsV2, awsClient.DeleteELBV2},
+		{awsClient.ListKubernetesSecurityGroups, awsClient.DeleteSecurityGroup},
+	} {
+		results, err := v.listFn(ctx, vpcID, clusterName)
+		if err != nil {
+			return err
+		}
+
+		for _, result := range results {
+			if err := v.deleteFn(ctx, result); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *FlowContext) deleteDefaultSecurityGroup(ctx context.Context) error {
+	// nothing to do, it is deleted automatically together with VPC
+	c.state.SetAsDeleted(IdentifierDefaultSecurityGroup)
+	return nil
+}
+
+func (c *FlowContext) deleteInternetGateway(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(IdentifierInternetGateway) {
+		return nil
+	}
+	log := c.LogFromContext(ctx)
+	current, err := findExisting(ctx, c.state.Get(IdentifierInternetGateway), c.commonTags,
+		c.client.GetInternetGateway, c.client.FindInternetGatewaysByTags)
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		log.Info("detaching...")
+		if err := c.client.DetachInternetGateway(ctx, *c.state.Get(IdentifierVPC), current.InternetGatewayId); err != nil {
+			return err
+		}
+		log.Info("deleting...", "InternetGatewayId", current.InternetGatewayId)
+		if err := c.client.DeleteInternetGateway(ctx, current.InternetGatewayId); err != nil {
+			return err
+		}
+		c.state.SetAsDeleted(IdentifierInternetGateway)
+	}
+	return nil
+}
+
+func (c *FlowContext) deleteGatewayEndpoints(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+	child := c.state.GetChild(ChildIdVPCEndpoints)
+	current, err := c.collectExistingVPCEndpoints(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, item := range current {
+		log.Info("deleting...", "ServiceName", item.ServiceName)
+		if err := c.client.DeleteVpcEndpoint(ctx, item.VpcEndpointId); err != nil {
+			return err
+		}
+		name := c.extractVpcEndpointName(item)
+		child.SetAsDeleted(name)
+	}
+	// update state of endpoints in state, but not found
+	for _, key := range child.Keys() {
+		child.SetAsDeleted(key)
+	}
+	return nil
+}
+
+func (c *FlowContext) deleteVpc(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(IdentifierVPC) {
+		return nil
+	}
+	log := c.LogFromContext(ctx)
+	current, err := findExisting(ctx, c.state.Get(IdentifierVPC), c.commonTags,
+		c.client.GetVpc, c.client.FindVpcsByTags)
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		log.Info("deleting...", "VpcId", current.VpcId)
+		if err := c.client.DeleteVpc(ctx, current.VpcId); err != nil {
+			return err
+		}
+	}
+	c.state.SetAsDeleted(IdentifierVPC)
+	return nil
+}
+
+func (c *FlowContext) deleteDhcpOptions(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(IdentifierDHCPOptions) {
+		return nil
+	}
+	log := c.LogFromContext(ctx)
+	current, err := findExisting(ctx, c.state.Get(IdentifierDHCPOptions), c.commonTags,
+		c.client.GetVpcDhcpOptions, c.client.FindVpcDhcpOptionsByTags)
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		log.Info("deleting...", "DhcpOptionsId", current.DhcpOptionsId)
+		if err := c.client.DeleteVpcDhcpOptions(ctx, current.DhcpOptionsId); err != nil {
+			return err
+		}
+		c.state.SetAsDeleted(IdentifierDHCPOptions)
+	}
+	return nil
+}
+
+func (c *FlowContext) deleteMainRouteTable(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(IdentifierMainRouteTable) {
+		return nil
+	}
+	log := c.LogFromContext(ctx)
+	current, err := findExisting(ctx, c.state.Get(IdentifierMainRouteTable), c.commonTags,
+		c.client.GetRouteTable, c.client.FindRouteTablesByTags)
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		log.Info("deleting...", "RouteTableId", current.RouteTableId)
+		if err := c.client.DeleteRouteTable(ctx, current.RouteTableId); err != nil {
+			return err
+		}
+	}
+	c.state.SetAsDeleted(IdentifierMainRouteTable)
+	return nil
+}
+
+func (c *FlowContext) deleteNodesSecurityGroup(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(IdentifierNodesSecurityGroup) {
+		return nil
+	}
+	log := c.LogFromContext(ctx)
+	groupName := fmt.Sprintf("%s-nodes", c.namespace)
+	current, err := findExisting(ctx, c.state.Get(IdentifierNodesSecurityGroup), c.commonTagsWithSuffix("nodes"),
+		c.client.GetSecurityGroup, c.client.FindSecurityGroupsByTags,
+		func(item *awsclient.SecurityGroup) bool { return item.GroupName == groupName })
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		log.Info("deleting...", "GroupId", current.GroupId)
+		if err := c.client.DeleteSecurityGroup(ctx, current.GroupId); err != nil {
+			return err
+		}
+	}
+	c.state.SetAsDeleted(IdentifierNodesSecurityGroup)
+	return nil
+}
+
+func (c *FlowContext) deleteZones(ctx context.Context) error {
+	current, err := c.collectExistingSubnets(ctx)
+	if err != nil {
+		return err
+	}
+	g := flow.NewGraph("AWS infrastructure destruction: zones")
+	if err := c.addZoneDeletionTasksBySubnets(g, current); err != nil {
+		return err
+	}
+	f := g.Compile()
+	if err := f.Run(ctx, flow.Opts{Log: c.Log}); err != nil {
+		return flow.Causes(err)
+	}
+	return nil
+}
+
+func (c *FlowContext) deleteIAMRole(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(NameIAMRole) {
+		return nil
+	}
+
+	log := c.LogFromContext(ctx)
+	roleName := fmt.Sprintf("%s-nodes", c.namespace)
+	log.Info("deleting...", "RoleName", roleName)
+	if err := c.client.DeleteIAMRole(ctx, roleName); err != nil {
+		return err
+	}
+	c.state.SetAsDeleted(NameIAMRole)
+	c.state.Set(ARNIAMRole, "")
+	return nil
+}
+
+func (c *FlowContext) deleteIAMInstanceProfile(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(NameIAMInstanceProfile) {
+		return nil
+	}
+	log := c.LogFromContext(ctx)
+	instanceProfileName := fmt.Sprintf("%s-nodes", c.namespace)
+	log.Info("deleting...", "InstanceProfileName", instanceProfileName)
+	if err := c.client.DeleteIAMInstanceProfile(ctx, instanceProfileName); err != nil {
+		return err
+	}
+	c.state.SetAsDeleted(NameIAMInstanceProfile)
+	return nil
+}
+
+func (c *FlowContext) deleteIAMRolePolicy(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(NameIAMRolePolicy) {
+		return nil
+	}
+	log := c.LogFromContext(ctx)
+	policyName := fmt.Sprintf("%s-nodes", c.namespace)
+	roleName := fmt.Sprintf("%s-nodes", c.namespace)
+	log.Info("removing from profile...")
+	if err := c.client.RemoveRoleFromIAMInstanceProfile(ctx, policyName, roleName); err != nil {
+		return err
+	}
+	log.Info("deleting...", "PolicyName", policyName, "RoleName", roleName)
+	if err := c.client.DeleteIAMRolePolicy(ctx, policyName, roleName); err != nil {
+		return err
+	}
+	c.state.SetAsDeleted(NameIAMRolePolicy)
+	return nil
+}
+
+func (c *FlowContext) deleteKeyPair(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(NameKeyPair) {
+		return nil
+	}
+	log := c.LogFromContext(ctx)
+	keyName := fmt.Sprintf("%s-ssh-publickey", c.namespace)
+	log.Info("deleting...", "KeyName", keyName)
+	if err := c.client.DeleteKeyPair(ctx, keyName); err != nil {
+		return err
+	}
+	c.state.SetAsDeleted(NameKeyPair)
+	return nil
+}

--- a/pkg/controller/infrastructure/infraflow/persistent_state.go
+++ b/pkg/controller/infrastructure/infraflow/persistent_state.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infraflow
+
+import (
+	"fmt"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
+	"k8s.io/apimachinery/pkg/util/json"
+)
+
+const (
+	// PersistentStateVersion is the current version used for persisting the state.
+	PersistentStateVersion = "1.0"
+)
+
+type persistentStateMarker struct {
+	FlowVersion string `json:"flowVersion"`
+}
+
+// PersistentState is the state which is persisted as part of the infrastructure status.
+type PersistentState struct {
+	FlowVersion string `json:"flowVersion"`
+
+	Data map[string]string `json:"data"`
+	/*
+		ZoneIds                map[string]string `json:"zoneIds,omitempty"`
+		KeyPairFingerprint     string            `json:"keyPairFingerprint,omitempty"`
+		KeyPairSpecFingerprint string            `json:"keyPairSpecFingerprint,omitempty"`
+		MigratedFromTerraform  bool              `json:"migratedFromTerraform,omitempty"`
+		TerraformCleanedUp     bool              `json:"terraformCleanedUp,omitempty"`
+	*/
+}
+
+// NewPersistentState creates empty PersistentState
+func NewPersistentState() *PersistentState {
+	return &PersistentState{
+		FlowVersion: PersistentStateVersion,
+		Data:        map[string]string{},
+		//		ZoneIds:     map[string]string{},
+	}
+}
+
+// NewPersistentStateFromJSON unmarshals PersistentState from JSON or YAML.
+// Returns nil if input contains no "flowVersion" field.
+func NewPersistentStateFromJSON(raw []byte) (*PersistentState, error) {
+	// first check if state is from flow or Terraformer
+	marker := &persistentStateMarker{}
+	if err := json.Unmarshal(raw, marker); err != nil {
+		return nil, err
+	}
+	if marker.FlowVersion == "" {
+		// no flow state
+		return nil, nil
+	}
+
+	state := &PersistentState{}
+	if err := json.Unmarshal(raw, state); err != nil {
+		return nil, err
+	}
+	if !state.HasValidVersion() {
+		return nil, fmt.Errorf("unsupported flowVersion %s", state.FlowVersion)
+	}
+
+	if state.Data == nil {
+		state.Data = map[string]string{}
+	}
+	return state, nil
+}
+
+// NewPersistentStateFromFlatMap create new PersistentState and initialises data from input.
+func NewPersistentStateFromFlatMap(flatState shared.FlatMap) *PersistentState {
+	state := NewPersistentState()
+
+	/*
+		data := shared.NewWhiteboard()
+		data.ImportFromFlatMap(flatState)
+		state.KeyPairFingerprint = safestr(data.Get(KeyPairFingerprint))
+		state.KeyPairSpecFingerprint = safestr(data.Get(KeyPairSpecFingerprint))
+		state.MigratedFromTerraform = safestr(data.Get(MarkerMigratedFromTerraform)) == "true"
+		state.TerraformCleanedUp = safestr(data.Get(MarkerTerraformCleanedUp)) == "true"
+		zonesChild := data.GetChild(ChildIdZones)
+		for _, zoneKey := range zonesChild.GetChildrenKeys() {
+			suffix := zonesChild.GetChild(zoneKey).Get(IdentifierZoneSuffix)
+			if suffix != nil {
+				state.ZoneIds[zoneKey] = *suffix
+			}
+		}
+	*/
+	state.Data = copyMap(flatState)
+	return state
+}
+
+// HasValidVersion checks if flow version is supported.
+func (s *PersistentState) HasValidVersion() bool {
+	return s != nil && s.FlowVersion == PersistentStateVersion
+}
+
+// ToFlatMap returns a copy of state as FlatMap
+func (s *PersistentState) ToFlatMap() shared.FlatMap {
+	/*
+		data := shared.NewWhiteboard()
+
+		if s.KeyPairFingerprint != "" {
+			data.Set(KeyPairFingerprint, s.KeyPairFingerprint)
+		}
+		if s.KeyPairSpecFingerprint != "" {
+			data.Set(KeyPairSpecFingerprint, s.KeyPairSpecFingerprint)
+		}
+		if s.MigratedFromTerraform {
+			data.Set(MarkerMigratedFromTerraform, "true")
+		}
+		if s.TerraformCleanedUp {
+			data.Set(MarkerTerraformCleanedUp, "true")
+		}
+		zonesChild := data.GetChild(ChildIdZones)
+		for key, value := range s.ZoneIds {
+			zonesChild.GetChild(key).Set(IdentifierZoneSuffix, value)
+		}
+		return data.ExportAsFlatMap()
+	*/
+	return copyMap(s.Data)
+}
+
+// ToJSON marshals state as JSON
+func (s *PersistentState) ToJSON() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+// MigratedFromTerraform returns trus if marker MarkerMigratedFromTerraform is set.
+func (s *PersistentState) MigratedFromTerraform() bool {
+	return s.Data[MarkerMigratedFromTerraform] == "true"
+}
+
+// SetMigratedFromTerraform sets the marker MarkerMigratedFromTerraform
+func (s *PersistentState) SetMigratedFromTerraform() {
+	s.Data[MarkerMigratedFromTerraform] = "true"
+}
+
+// TerraformCleanedUp returns trus if marker MarkerTerraformCleanedUp is set.
+func (s *PersistentState) TerraformCleanedUp() bool {
+	return s.Data[MarkerTerraformCleanedUp] == "true"
+}
+
+// SetTerraformCleanedUp sets the marker MarkerTerraformCleanedUp
+func (s *PersistentState) SetTerraformCleanedUp() {
+	s.Data[MarkerTerraformCleanedUp] = "true"
+}
+
+func safestr(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/pkg/controller/infrastructure/infraflow/persistent_state.go
+++ b/pkg/controller/infrastructure/infraflow/persistent_state.go
@@ -18,10 +18,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
-	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
 )
 
 const (

--- a/pkg/controller/infrastructure/infraflow/persistent_state.go
+++ b/pkg/controller/infrastructure/infraflow/persistent_state.go
@@ -16,62 +16,63 @@ package infraflow
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
 const (
 	// PersistentStateVersion is the current version used for persisting the state.
-	PersistentStateVersion = "1.0"
+	PersistentStateVersion = "v1alpha1"
+	// PersistentStateAPIVersion is the APIVersion used for the persistent state
+	PersistentStateAPIVersion = aws.GroupName + "/" + PersistentStateVersion
+	// PersistentStateKind is the kind name for the persistent state
+	PersistentStateKind = "FlowState"
 )
-
-type persistentStateMarker struct {
-	FlowVersion string `json:"flowVersion"`
-}
 
 // PersistentState is the state which is persisted as part of the infrastructure status.
 type PersistentState struct {
-	FlowVersion string `json:"flowVersion"`
+	metav1.TypeMeta
 
 	Data map[string]string `json:"data"`
-	/*
-		ZoneIds                map[string]string `json:"zoneIds,omitempty"`
-		KeyPairFingerprint     string            `json:"keyPairFingerprint,omitempty"`
-		KeyPairSpecFingerprint string            `json:"keyPairSpecFingerprint,omitempty"`
-		MigratedFromTerraform  bool              `json:"migratedFromTerraform,omitempty"`
-		TerraformCleanedUp     bool              `json:"terraformCleanedUp,omitempty"`
-	*/
 }
 
 // NewPersistentState creates empty PersistentState
 func NewPersistentState() *PersistentState {
 	return &PersistentState{
-		FlowVersion: PersistentStateVersion,
-		Data:        map[string]string{},
-		//		ZoneIds:     map[string]string{},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: PersistentStateAPIVersion,
+			Kind:       PersistentStateKind,
+		},
+		Data: map[string]string{},
 	}
 }
 
 // NewPersistentStateFromJSON unmarshals PersistentState from JSON or YAML.
-// Returns nil if input contains no "flowVersion" field.
+// Returns nil if input contains no kind field with value "FlowState".
 func NewPersistentStateFromJSON(raw []byte) (*PersistentState, error) {
 	// first check if state is from flow or Terraformer
-	marker := &persistentStateMarker{}
+	marker := &metav1.TypeMeta{}
 	if err := json.Unmarshal(raw, marker); err != nil {
 		return nil, err
 	}
-	if marker.FlowVersion == "" {
+	if marker.Kind == "" {
 		// no flow state
 		return nil, nil
+	}
+	if marker.Kind != PersistentStateKind || !strings.HasPrefix(marker.APIVersion, aws.GroupName) {
+		return nil, fmt.Errorf("unknown kind or group: kind=%s, apiVersion=%s", marker.Kind, marker.APIVersion)
 	}
 
 	state := &PersistentState{}
 	if err := json.Unmarshal(raw, state); err != nil {
 		return nil, err
 	}
-	if !state.HasValidVersion() {
-		return nil, fmt.Errorf("unsupported flowVersion %s", state.FlowVersion)
+	if valid, err := state.HasValidVersion(); !valid {
+		return nil, err
 	}
 
 	if state.Data == nil {
@@ -83,54 +84,21 @@ func NewPersistentStateFromJSON(raw []byte) (*PersistentState, error) {
 // NewPersistentStateFromFlatMap create new PersistentState and initialises data from input.
 func NewPersistentStateFromFlatMap(flatState shared.FlatMap) *PersistentState {
 	state := NewPersistentState()
-
-	/*
-		data := shared.NewWhiteboard()
-		data.ImportFromFlatMap(flatState)
-		state.KeyPairFingerprint = safestr(data.Get(KeyPairFingerprint))
-		state.KeyPairSpecFingerprint = safestr(data.Get(KeyPairSpecFingerprint))
-		state.MigratedFromTerraform = safestr(data.Get(MarkerMigratedFromTerraform)) == "true"
-		state.TerraformCleanedUp = safestr(data.Get(MarkerTerraformCleanedUp)) == "true"
-		zonesChild := data.GetChild(ChildIdZones)
-		for _, zoneKey := range zonesChild.GetChildrenKeys() {
-			suffix := zonesChild.GetChild(zoneKey).Get(IdentifierZoneSuffix)
-			if suffix != nil {
-				state.ZoneIds[zoneKey] = *suffix
-			}
-		}
-	*/
 	state.Data = copyMap(flatState)
 	return state
 }
 
 // HasValidVersion checks if flow version is supported.
-func (s *PersistentState) HasValidVersion() bool {
-	return s != nil && s.FlowVersion == PersistentStateVersion
+func (s *PersistentState) HasValidVersion() (valid bool, err error) {
+	valid = s != nil && s.Kind == PersistentStateKind && s.APIVersion == PersistentStateAPIVersion
+	if !valid {
+		err = fmt.Errorf("unsupported APIVersion %s for kind %s", s.APIVersion, s.Kind)
+	}
+	return
 }
 
 // ToFlatMap returns a copy of state as FlatMap
 func (s *PersistentState) ToFlatMap() shared.FlatMap {
-	/*
-		data := shared.NewWhiteboard()
-
-		if s.KeyPairFingerprint != "" {
-			data.Set(KeyPairFingerprint, s.KeyPairFingerprint)
-		}
-		if s.KeyPairSpecFingerprint != "" {
-			data.Set(KeyPairSpecFingerprint, s.KeyPairSpecFingerprint)
-		}
-		if s.MigratedFromTerraform {
-			data.Set(MarkerMigratedFromTerraform, "true")
-		}
-		if s.TerraformCleanedUp {
-			data.Set(MarkerTerraformCleanedUp, "true")
-		}
-		zonesChild := data.GetChild(ChildIdZones)
-		for key, value := range s.ZoneIds {
-			zonesChild.GetChild(key).Set(IdentifierZoneSuffix, value)
-		}
-		return data.ExportAsFlatMap()
-	*/
 	return copyMap(s.Data)
 }
 
@@ -157,11 +125,4 @@ func (s *PersistentState) TerraformCleanedUp() bool {
 // SetTerraformCleanedUp sets the marker MarkerTerraformCleanedUp
 func (s *PersistentState) SetTerraformCleanedUp() {
 	s.Data[MarkerTerraformCleanedUp] = "true"
-}
-
-func safestr(p *string) string {
-	if p == nil {
-		return ""
-	}
-	return *p
 }

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -1,0 +1,1393 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infraflow
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"fmt"
+	"reflect"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
+	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
+	. "github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
+)
+
+const (
+	defaultTimeout     = 90 * time.Second
+	defaultLongTimeout = 3 * time.Minute
+)
+
+// Reconcile creates and runs the flow to reconcile the AWS infrastructure.
+func (c *FlowContext) Reconcile(ctx context.Context) error {
+	g := c.buildReconcileGraph()
+	f := g.Compile()
+	if err := f.Run(ctx, flow.Opts{Log: c.Log}); err != nil {
+		return flow.Causes(err)
+	}
+	return nil
+}
+
+func (c *FlowContext) buildReconcileGraph() *flow.Graph {
+	createVPC := c.config.Networks.VPC.ID == nil
+	g := flow.NewGraph("AWS infrastructure reconcilation")
+
+	ensureDhcpOptions := c.AddTask(g, "ensure DHCP options for VPC",
+		c.ensureDhcpOptions,
+		DoIf(createVPC), Timeout(defaultTimeout))
+
+	ensureVpc := c.AddTask(g, "ensure VPC",
+		c.ensureVpc,
+		Timeout(defaultTimeout), Dependencies(ensureDhcpOptions))
+
+	ensureDefaultSecurityGroup := c.AddTask(g, "ensure default security group",
+		c.ensureDefaultSecurityGroup,
+		DoIf(createVPC), Timeout(defaultTimeout), Dependencies(ensureVpc))
+
+	ensureInternetGateway := c.AddTask(g, "ensure internet gateway",
+		c.ensureInternetGateway,
+		DoIf(createVPC), Timeout(defaultTimeout), Dependencies(ensureVpc))
+
+	_ = c.AddTask(g, "ensure gateway endpoints",
+		c.ensureGatewayEndpoints,
+		Timeout(defaultTimeout), Dependencies(ensureVpc, ensureDefaultSecurityGroup, ensureInternetGateway))
+
+	ensureMainRouteTable := c.AddTask(g, "ensure main route table",
+		c.ensureMainRouteTable,
+		Timeout(defaultTimeout), Dependencies(ensureVpc, ensureDefaultSecurityGroup, ensureInternetGateway))
+
+	ensureNodesSecurityGroup := c.AddTask(g, "ensure nodes security group",
+		c.ensureNodesSecurityGroup,
+		Timeout(defaultTimeout), Dependencies(ensureVpc))
+
+	_ = c.AddTask(g, "ensure zones resources",
+		c.ensureZones,
+		Timeout(defaultLongTimeout), Dependencies(ensureVpc, ensureNodesSecurityGroup, ensureMainRouteTable))
+
+	ensureIAMRole := c.AddTask(g, "ensure IAM role",
+		c.ensureIAMRole,
+		Timeout(defaultTimeout))
+
+	_ = c.AddTask(g, "ensure IAM instance profile",
+		c.ensureIAMInstanceProfile,
+		Timeout(defaultTimeout), Dependencies(ensureIAMRole))
+
+	_ = c.AddTask(g, "ensure IAM role policy",
+		c.ensureIAMRolePolicy,
+		Timeout(defaultTimeout), Dependencies(ensureIAMRole))
+
+	_ = c.AddTask(g, "ensure key pair",
+		c.ensureKeyPair,
+		Timeout(defaultTimeout))
+
+	return g
+}
+
+func (c *FlowContext) getDesiredDhcpOptions() *awsclient.DhcpOptions {
+	dhcpDomainName := "ec2.internal"
+	if c.infraSpec.Region != "us-east-1" {
+		dhcpDomainName = fmt.Sprintf("%s.compute.internal", c.infraSpec.Region)
+	}
+
+	return &awsclient.DhcpOptions{
+		Tags: c.commonTags,
+		DhcpConfigurations: map[string][]string{
+			"domain-name":         {dhcpDomainName},
+			"domain-name-servers": {"AmazonProvidedDNS"},
+		},
+	}
+}
+
+func (c *FlowContext) ensureDhcpOptions(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+	desired := c.getDesiredDhcpOptions()
+	current, err := findExisting(ctx, c.state.Get(IdentifierDHCPOptions), c.commonTags,
+		c.client.GetVpcDhcpOptions, c.client.FindVpcDhcpOptionsByTags)
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		c.state.Set(IdentifierDHCPOptions, current.DhcpOptionsId)
+		if _, err := c.updater.UpdateEC2Tags(ctx, current.DhcpOptionsId, c.commonTags, current.Tags); err != nil {
+			return err
+		}
+	} else {
+		log.Info("creating...")
+		created, err := c.client.CreateVpcDhcpOptions(ctx, desired)
+		if err != nil {
+			return err
+		}
+		c.state.Set(IdentifierDHCPOptions, created.DhcpOptionsId)
+	}
+
+	return nil
+}
+
+func (c *FlowContext) ensureVpc(ctx context.Context) error {
+	if c.config.Networks.VPC.ID != nil {
+		return c.ensureExistingVpc(ctx)
+	}
+	return c.ensureManagedVpc(ctx)
+}
+
+func (c *FlowContext) ensureManagedVpc(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+	log.Info("using managed VPC")
+	desired := &awsclient.VPC{
+		Tags:               c.commonTags,
+		EnableDnsSupport:   true,
+		EnableDnsHostnames: true,
+		DhcpOptionsId:      c.state.Get(IdentifierDHCPOptions),
+	}
+	if c.config.Networks.VPC.CIDR == nil {
+		return fmt.Errorf("missing VPC CIDR")
+	}
+	desired.CidrBlock = *c.config.Networks.VPC.CIDR
+	current, err := findExisting(ctx, c.state.Get(IdentifierVPC), c.commonTags,
+		c.client.GetVpc, c.client.FindVpcsByTags)
+	if err != nil {
+		return err
+	}
+
+	if current != nil {
+		c.state.Set(IdentifierVPC, current.VpcId)
+		if _, err := c.updater.UpdateVpc(ctx, desired, current); err != nil {
+			return err
+		}
+	} else {
+		log.Info("creating...")
+		created, err := c.client.CreateVpc(ctx, desired)
+		if err != nil {
+			return err
+		}
+		c.state.Set(IdentifierVPC, created.VpcId)
+		if _, err := c.updater.UpdateVpc(ctx, desired, created); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *FlowContext) ensureExistingVpc(ctx context.Context) error {
+	vpcID := *c.config.Networks.VPC.ID
+	log := c.LogFromContext(ctx)
+	log.Info("using configured VPC", "vpc", vpcID)
+	current, err := c.client.GetVpc(ctx, vpcID)
+	if err != nil {
+		return err
+	}
+	if current == nil {
+		return fmt.Errorf("VPC %s has not been found", vpcID)
+	}
+	c.state.Set(IdentifierVPC, vpcID)
+	if err := c.validateVpc(ctx, current); err != nil {
+		return err
+	}
+	gw, err := c.client.FindInternetGatewayByVPC(ctx, vpcID)
+	if err != nil {
+		return fmt.Errorf("Internet Gateway not found for VPC %s", vpcID)
+	}
+	c.state.Set(IdentifierInternetGateway, gw.InternetGatewayId)
+	return nil
+}
+
+func (c *FlowContext) validateVpc(ctx context.Context, item *awsclient.VPC) error {
+	if !item.EnableDnsHostnames {
+		return fmt.Errorf("VPC attribute enableDnsHostnames must be set")
+	}
+	if !item.EnableDnsSupport {
+		return fmt.Errorf("VPC attribute enableDnsSupport must be set")
+	}
+	if item.DhcpOptionsId == nil {
+		return fmt.Errorf("missing DhcpOptions for VPC")
+	}
+	options, err := c.client.GetVpcDhcpOptions(ctx, *item.DhcpOptionsId)
+	if err != nil {
+		return err
+	}
+	if options == nil {
+		return fmt.Errorf("DhcpOptions for VPC not found: %s", *item.DhcpOptionsId)
+	}
+	desired := c.getDesiredDhcpOptions()
+	for k, v := range desired.DhcpConfigurations {
+		if !reflect.DeepEqual(options.DhcpConfigurations[k], v) {
+			return fmt.Errorf("missing DhcpConfiguration '%s'='%s' (actual: %s)",
+				k, strings.Join(v, ","), strings.Join(options.DhcpConfigurations[k], ","))
+		}
+	}
+	return nil
+}
+
+func (c *FlowContext) ensureDefaultSecurityGroup(ctx context.Context) error {
+	current, err := c.client.FindDefaultSecurityGroupByVpcId(ctx, *c.state.Get(IdentifierVPC))
+	if err != nil {
+		return err
+	}
+	if current == nil {
+		return fmt.Errorf("default security group not found")
+	}
+
+	c.state.Set(IdentifierDefaultSecurityGroup, current.GroupId)
+	desired := current.Clone()
+	desired.Rules = nil
+	if _, err := c.updater.UpdateSecurityGroup(ctx, desired, current); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *FlowContext) ensureInternetGateway(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+	desired := &awsclient.InternetGateway{
+		Tags:  c.commonTags,
+		VpcId: c.state.Get(IdentifierVPC),
+	}
+	current, err := findExisting(ctx, c.state.Get(IdentifierInternetGateway), c.commonTags,
+		c.client.GetInternetGateway, c.client.FindInternetGatewaysByTags)
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		c.state.Set(IdentifierInternetGateway, current.InternetGatewayId)
+		if err := c.client.AttachInternetGateway(ctx, *c.state.Get(IdentifierVPC), current.InternetGatewayId); err != nil {
+			return err
+		}
+		if _, err := c.updater.UpdateEC2Tags(ctx, current.InternetGatewayId, c.commonTags, current.Tags); err != nil {
+			return err
+		}
+	} else {
+		log.Info("creating...")
+		created, err := c.client.CreateInternetGateway(ctx, desired)
+		if err != nil {
+			return err
+		}
+		c.state.Set(IdentifierInternetGateway, created.InternetGatewayId)
+		if err := c.client.AttachInternetGateway(ctx, *c.state.Get(IdentifierVPC), created.InternetGatewayId); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *FlowContext) ensureGatewayEndpoints(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+	child := c.state.GetChild(ChildIdVPCEndpoints)
+	var desired []*awsclient.VpcEndpoint
+	for _, endpoint := range c.config.Networks.VPC.GatewayEndpoints {
+		desired = append(desired, &awsclient.VpcEndpoint{
+			Tags:        c.commonTagsWithSuffix(fmt.Sprintf("gw-%s", endpoint)),
+			VpcId:       c.state.Get(IdentifierVPC),
+			ServiceName: c.vpcEndpointServiceNamePrefix() + endpoint,
+		})
+	}
+	current, err := c.collectExistingVPCEndpoints(ctx)
+	if err != nil {
+		return err
+	}
+
+	toBeDeleted, toBeCreated, toBeChecked := diffByID(desired, current, c.extractVpcEndpointName)
+	for _, item := range toBeDeleted {
+		vpcEndpointName := c.extractVpcEndpointName(item)
+		for _, zoneKey := range child.GetChildrenKeys() {
+			zoneChild := child.GetChild(zoneKey)
+			if routeTableId := zoneChild.Get(IdentifierZoneRouteTable); routeTableId != nil {
+				if err := c.client.DeleteVpcEndpointRouteTableAssociation(ctx, *routeTableId, item.VpcEndpointId); err != nil {
+					return err
+				}
+			}
+		}
+		if err := c.client.DeleteVpcEndpoint(ctx, item.VpcEndpointId); err != nil {
+			return err
+		}
+		child.SetPtr(vpcEndpointName, nil)
+	}
+	for _, item := range toBeCreated {
+		log.Info("creating...", "serviceName", item.ServiceName)
+		created, err := c.client.CreateVpcEndpoint(ctx, item)
+		if err != nil {
+			return err
+		}
+		child.Set(c.extractVpcEndpointName(item), created.VpcEndpointId)
+		if _, err := c.updater.UpdateEC2Tags(ctx, created.VpcEndpointId, item.Tags, created.Tags); err != nil {
+			return err
+		}
+	}
+	for _, pair := range toBeChecked {
+		child.Set(c.extractVpcEndpointName(pair.current), pair.current.VpcEndpointId)
+		if _, err := c.updater.UpdateEC2Tags(ctx, pair.current.VpcEndpointId, pair.desired.Tags, pair.current.Tags); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *FlowContext) collectExistingVPCEndpoints(ctx context.Context) ([]*awsclient.VpcEndpoint, error) {
+	child := c.state.GetChild(ChildIdVPCEndpoints)
+	var ids []string
+	for _, id := range child.AsMap() {
+		ids = append(ids, id)
+	}
+	var current []*awsclient.VpcEndpoint
+	if len(ids) > 0 {
+		found, err := c.client.GetVpcEndpoints(ctx, ids)
+		if err != nil {
+			return nil, err
+		}
+		current = found
+	}
+	foundByTags, err := c.client.FindVpcEndpointsByTags(ctx, c.clusterTags())
+	if err != nil {
+		return nil, err
+	}
+outer:
+	for _, item := range foundByTags {
+		for _, currentItem := range current {
+			if item.VpcEndpointId == currentItem.VpcEndpointId {
+				continue outer
+			}
+		}
+		current = append(current, item)
+	}
+	return current, nil
+}
+
+func (c *FlowContext) ensureMainRouteTable(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+	cidrBlock := "0.0.0.0/0"
+	desired := &awsclient.RouteTable{
+		Tags:  c.commonTags,
+		VpcId: c.state.Get(IdentifierVPC),
+		Routes: []*awsclient.Route{
+			{
+				DestinationCidrBlock: pointer.String(cidrBlock),
+				GatewayId:            c.state.Get(IdentifierInternetGateway),
+			},
+		},
+	}
+	current, err := findExisting(ctx, c.state.Get(IdentifierMainRouteTable), c.commonTags,
+		c.client.GetRouteTable, c.client.FindRouteTablesByTags)
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		c.state.Set(IdentifierMainRouteTable, current.RouteTableId)
+		c.state.SetObject(ObjectMainRouteTable, current)
+		log.Info("updating route table...")
+		if _, err := c.updater.UpdateRouteTable(ctx, log, desired, current, cidrBlock); err != nil {
+			return err
+		}
+	} else {
+		log.Info("creating...")
+		created, err := c.client.CreateRouteTable(ctx, desired)
+		if err != nil {
+			return err
+		}
+		c.state.Set(IdentifierMainRouteTable, created.RouteTableId)
+		c.state.SetObject(ObjectMainRouteTable, created)
+		log.Info("updating route table...")
+		if _, err := c.updater.UpdateRouteTable(ctx, log, desired, created); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *FlowContext) ensureNodesSecurityGroup(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+	groupName := fmt.Sprintf("%s-nodes", c.namespace)
+	desired := &awsclient.SecurityGroup{
+		Tags:        c.commonTagsWithSuffix("nodes"),
+		GroupName:   groupName,
+		VpcId:       c.state.Get(IdentifierVPC),
+		Description: pointer.String("Security group for nodes"),
+		Rules: []*awsclient.SecurityGroupRule{
+			{
+				Type:     awsclient.SecurityGroupRuleTypeIngress,
+				Protocol: "-1",
+				Self:     true,
+			},
+			{
+				Type:       awsclient.SecurityGroupRuleTypeIngress,
+				FromPort:   30000,
+				ToPort:     32767,
+				Protocol:   "tcp",
+				CidrBlocks: []string{"0.0.0.0/0"},
+			},
+			{
+				Type:       awsclient.SecurityGroupRuleTypeIngress,
+				FromPort:   30000,
+				ToPort:     32767,
+				Protocol:   "udp",
+				CidrBlocks: []string{"0.0.0.0/0"},
+			},
+			{
+				Type:       awsclient.SecurityGroupRuleTypeEgress,
+				Protocol:   "-1",
+				CidrBlocks: []string{"0.0.0.0/0"},
+			},
+		},
+	}
+	for _, zone := range c.config.Networks.Zones {
+		desired.Rules = append(desired.Rules,
+			&awsclient.SecurityGroupRule{
+				Type:       awsclient.SecurityGroupRuleTypeIngress,
+				FromPort:   30000,
+				ToPort:     32767,
+				Protocol:   "tcp",
+				CidrBlocks: []string{zone.Internal},
+			},
+			&awsclient.SecurityGroupRule{
+				Type:       awsclient.SecurityGroupRuleTypeIngress,
+				FromPort:   30000,
+				ToPort:     32767,
+				Protocol:   "udp",
+				CidrBlocks: []string{zone.Internal},
+			},
+			&awsclient.SecurityGroupRule{
+				Type:       awsclient.SecurityGroupRuleTypeIngress,
+				FromPort:   30000,
+				ToPort:     32767,
+				Protocol:   "tcp",
+				CidrBlocks: []string{zone.Public},
+			},
+			&awsclient.SecurityGroupRule{
+				Type:       awsclient.SecurityGroupRuleTypeIngress,
+				FromPort:   30000,
+				ToPort:     32767,
+				Protocol:   "udp",
+				CidrBlocks: []string{zone.Public},
+			})
+	}
+	current, err := findExisting(ctx, c.state.Get(IdentifierNodesSecurityGroup), c.commonTagsWithSuffix("nodes"),
+		c.client.GetSecurityGroup, c.client.FindSecurityGroupsByTags,
+		func(item *awsclient.SecurityGroup) bool { return item.GroupName == groupName })
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		c.state.Set(IdentifierNodesSecurityGroup, current.GroupId)
+		if _, err := c.updater.UpdateSecurityGroup(ctx, desired, current); err != nil {
+			return err
+		}
+	} else {
+		log.Info("creating...")
+		created, err := c.client.CreateSecurityGroup(ctx, desired)
+		if err != nil {
+			return err
+		}
+		c.state.Set(IdentifierNodesSecurityGroup, created.GroupId)
+		current, err = c.client.GetSecurityGroup(ctx, created.GroupId)
+		if err != nil {
+			return err
+		}
+		if _, err := c.updater.UpdateSecurityGroup(ctx, desired, current); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *FlowContext) ensureZones(ctx context.Context) error {
+	var desired []*awsclient.Subnet
+	for _, zone := range c.config.Networks.Zones {
+		helper := c.zoneSuffixHelpers(zone.Name)
+		tagsWorkers := c.commonTagsWithSuffix(helper.GetSuffixSubnetWorkers())
+		tagsPublic := c.commonTagsWithSuffix(helper.GetSuffixSubnetPublic())
+		tagsPublic[TagKeyRolePublicELB] = TagValueUse
+		tagsPrivate := c.commonTagsWithSuffix(helper.GetSuffixSubnetPrivate())
+		tagsPrivate[TagKeyRolePrivateELB] = TagValueUse
+		desired = append(desired,
+			&awsclient.Subnet{
+				Tags:             tagsWorkers,
+				VpcId:            c.state.Get(IdentifierVPC),
+				CidrBlock:        zone.Workers,
+				AvailabilityZone: zone.Name,
+			},
+			&awsclient.Subnet{
+				Tags:             tagsPublic,
+				VpcId:            c.state.Get(IdentifierVPC),
+				CidrBlock:        zone.Public,
+				AvailabilityZone: zone.Name,
+			},
+			&awsclient.Subnet{
+				Tags:             tagsPrivate,
+				VpcId:            c.state.Get(IdentifierVPC),
+				CidrBlock:        zone.Internal,
+				AvailabilityZone: zone.Name,
+			})
+	}
+	// update flow state if subnet suffixes have been added
+	if err := c.PersistState(ctx, true); err != nil {
+		return err
+	}
+	current, err := c.collectExistingSubnets(ctx)
+	if err != nil {
+		return err
+	}
+	toBeDeleted, toBeCreated, toBeChecked := diffByID(desired, current, func(item *awsclient.Subnet) string {
+		return item.AvailabilityZone + "-" + item.CidrBlock
+	})
+
+	g := flow.NewGraph("AWS infrastructure reconcilation: zones")
+
+	if err := c.addZoneDeletionTasksBySubnets(g, toBeDeleted); err != nil {
+		return err
+	}
+
+	dependencies := newZoneDependencies()
+	for _, item := range toBeCreated {
+		taskID, err := c.addSubnetReconcileTasks(g, item, nil)
+		if err != nil {
+			return err
+		}
+		dependencies.Append(item.AvailabilityZone, taskID)
+	}
+	for _, pair := range toBeChecked {
+		taskID, err := c.addSubnetReconcileTasks(g, pair.desired, pair.current)
+		if err != nil {
+			return err
+		}
+		dependencies.Append(pair.desired.AvailabilityZone, taskID)
+	}
+	for _, item := range c.config.Networks.Zones {
+		zone := item
+		c.addZoneReconcileTasks(g, &zone, dependencies.Get(zone.Name))
+	}
+	f := g.Compile()
+	if err := f.Run(ctx, flow.Opts{Log: c.Log}); err != nil {
+		return flow.Causes(err)
+	}
+	return nil
+}
+
+func (c *FlowContext) addZoneDeletionTasksBySubnets(g *flow.Graph, toBeDeleted []*awsclient.Subnet) error {
+	toBeDeletedZones := sets.NewString()
+	for _, item := range toBeDeleted {
+		toBeDeletedZones.Insert(getZoneName(item))
+	}
+	dependencies := newZoneDependencies()
+	for zoneName := range toBeDeletedZones {
+		taskID := c.addZoneDeletionTasks(g, zoneName)
+		dependencies.Append(zoneName, taskID)
+	}
+	for _, item := range toBeDeleted {
+		if err := c.addSubnetDeletionTasks(g, item, dependencies.Get(item.AvailabilityZone)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *FlowContext) collectExistingSubnets(ctx context.Context) ([]*awsclient.Subnet, error) {
+	child := c.state.GetChild(ChildIdZones)
+	var ids []string
+	for _, zoneKey := range child.GetChildrenKeys() {
+		zoneChild := child.GetChild(zoneKey)
+		if id := zoneChild.Get(IdentifierZoneSubnetWorkers); id != nil {
+			ids = append(ids, *id)
+		}
+		if id := zoneChild.Get(IdentifierZoneSubnetPublic); id != nil {
+			ids = append(ids, *id)
+		}
+		if id := zoneChild.Get(IdentifierZoneSubnetPrivate); id != nil {
+			ids = append(ids, *id)
+		}
+	}
+	var current []*awsclient.Subnet
+	if len(ids) > 0 {
+		found, err := c.client.GetSubnets(ctx, ids)
+		if err != nil {
+			return nil, err
+		}
+		current = found
+	}
+	foundByTags, err := c.client.FindSubnetsByTags(ctx, c.clusterTags())
+	if err != nil {
+		return nil, err
+	}
+outer:
+	for _, item := range foundByTags {
+		for _, currentItem := range current {
+			if item.SubnetId == currentItem.SubnetId {
+				continue outer
+			}
+		}
+		current = append(current, item)
+	}
+	return current, nil
+}
+
+func (c *FlowContext) addSubnetReconcileTasks(g *flow.Graph, desired, current *awsclient.Subnet) (flow.TaskIDer, error) {
+	zoneName, subnetKey, err := c.getSubnetKey(desired)
+	if err != nil {
+		return nil, err
+	}
+	suffix := fmt.Sprintf("%s-%s", zoneName, subnetKey)
+	return c.AddTask(g, "ensure subnet "+suffix,
+		c.ensureSubnet(subnetKey, desired, current),
+		Timeout(defaultTimeout)), nil
+}
+
+func (c *FlowContext) addZoneReconcileTasks(g *flow.Graph, zone *aws.Zone, dependencies []flow.TaskIDer) {
+	ensureElasticIP := c.AddTask(g, "ensure NAT gateway elastic IP "+zone.Name,
+		c.ensureElasticIP(zone),
+		Timeout(defaultTimeout), Dependencies(dependencies...))
+
+	ensureNATGateway := c.AddTask(g, "ensure NAT gateway "+zone.Name,
+		c.ensureNATGateway(zone),
+		Timeout(defaultLongTimeout), Dependencies(dependencies...), Dependencies(ensureElasticIP))
+
+	ensureRoutingTable := c.AddTask(g, "ensure route table "+zone.Name,
+		c.ensurePrivateRoutingTable(zone.Name),
+		Timeout(defaultTimeout), Dependencies(dependencies...), Dependencies(ensureNATGateway))
+
+	_ = c.AddTask(g, "ensure route table associations "+zone.Name,
+		c.ensureRoutingTableAssociations(zone.Name),
+		Timeout(defaultTimeout), Dependencies(dependencies...), Dependencies(ensureRoutingTable))
+
+	_ = c.AddTask(g, "ensure VPC endpoints route table associations "+zone.Name,
+		c.ensureVPCEndpointsRoutingTableAssociations(zone.Name),
+		Timeout(defaultTimeout), Dependencies(dependencies...), Dependencies(ensureRoutingTable))
+}
+
+func (c *FlowContext) addZoneDeletionTasks(g *flow.Graph, zoneName string) flow.TaskIDer {
+	deleteRoutingTableAssocs := c.AddTask(g, "delete route table associations "+zoneName,
+		c.deleteRoutingTableAssociations(zoneName),
+		Timeout(defaultTimeout))
+
+	deleteRoutingTable := c.AddTask(g, "delete route table "+zoneName,
+		c.deletePrivateRoutingTable(zoneName),
+		Timeout(defaultTimeout), Dependencies(deleteRoutingTableAssocs))
+
+	deleteNATGateway := c.AddTask(g, "delete NAT gateway "+zoneName,
+		c.deleteNATGateway(zoneName),
+		Timeout(defaultLongTimeout), Dependencies(deleteRoutingTable))
+
+	_ = c.AddTask(g, "delete NAT gateway elastic IP "+zoneName,
+		c.deleteElasticIP(zoneName),
+		Timeout(defaultTimeout), Dependencies(deleteNATGateway))
+
+	return deleteNATGateway
+}
+
+func (c *FlowContext) addSubnetDeletionTasks(g *flow.Graph, item *awsclient.Subnet, dependencies []flow.TaskIDer) error {
+	zoneName, subnetKey, err := c.getSubnetKey(item)
+	if err != nil {
+		return err
+	}
+	suffix := fmt.Sprintf("%s-%s", zoneName, subnetKey)
+	_ = c.AddTask(g, "delete subnet resource "+suffix,
+		c.deleteSubnet(subnetKey, item),
+		Timeout(defaultTimeout), Dependencies(dependencies...))
+	return nil
+}
+
+func (c *FlowContext) deleteSubnet(subnetKey string, item *awsclient.Subnet) flow.TaskFn {
+	zoneChild := c.getSubnetZoneChildByItem(item)
+	return func(ctx context.Context) error {
+		if zoneChild.IsAlreadyDeleted(subnetKey) {
+			return nil
+		}
+		log := c.LogFromContext(ctx)
+		log.Info("deleting...", "SubnetID", item.SubnetId)
+		waiter := informOnWaiting(log, 10*time.Second, "still deleting...", "SubnetID", item.SubnetId)
+		err := c.client.DeleteSubnet(ctx, item.SubnetId)
+		waiter.Done(err)
+		if err != nil {
+			return err
+		}
+		zoneChild.SetAsDeleted(subnetKey)
+		return nil
+	}
+}
+
+func (c *FlowContext) ensureSubnet(subnetKey string, desired, current *awsclient.Subnet) flow.TaskFn {
+	zoneChild := c.getSubnetZoneChildByItem(desired)
+	if current == nil {
+		return func(ctx context.Context) error {
+			log := c.LogFromContext(ctx)
+			log.Info("creating...")
+			created, err := c.client.CreateSubnet(ctx, desired)
+			if err != nil {
+				return err
+			}
+			zoneChild.Set(subnetKey, created.SubnetId)
+			return nil
+		}
+	}
+	return func(ctx context.Context) error {
+		zoneChild.Set(subnetKey, current.SubnetId)
+		modified, err := c.updater.UpdateSubnet(ctx, desired, current)
+		if err != nil {
+			return err
+		}
+		if modified {
+			log := c.LogFromContext(ctx)
+			log.Info("updated")
+		}
+		return nil
+	}
+}
+
+func (c *FlowContext) ensureElasticIP(zone *aws.Zone) flow.TaskFn {
+	return func(ctx context.Context) error {
+		if zone.ElasticIPAllocationID != nil {
+			return nil
+		}
+		log := c.LogFromContext(ctx)
+		helper := c.zoneSuffixHelpers(zone.Name)
+		child := c.getSubnetZoneChild(zone.Name)
+		id := child.Get(IdentifierZoneNATGWElasticIP)
+		desired := &awsclient.ElasticIP{
+			Tags: c.commonTagsWithSuffix(helper.GetSuffixElasticIP()),
+			Vpc:  true,
+		}
+		current, err := findExisting(ctx, id, desired.Tags, c.client.GetElasticIP, c.client.FindElasticIPsByTags)
+		if err != nil {
+			return err
+		}
+
+		if current != nil {
+			child.Set(IdentifierZoneNATGWElasticIP, current.AllocationId)
+			if _, err := c.updater.UpdateEC2Tags(ctx, current.AllocationId, desired.Tags, current.Tags); err != nil {
+				return err
+			}
+		} else {
+			log.Info("creating...")
+			created, err := c.client.CreateElasticIP(ctx, desired)
+			if err != nil {
+				return err
+			}
+			child.Set(IdentifierZoneNATGWElasticIP, created.AllocationId)
+		}
+
+		return nil
+	}
+}
+
+func (c *FlowContext) deleteElasticIP(zoneName string) flow.TaskFn {
+	return func(ctx context.Context) error {
+		child := c.getSubnetZoneChild(zoneName)
+		if child.IsAlreadyDeleted(IdentifierZoneNATGWElasticIP) {
+			return nil
+		}
+		helper := c.zoneSuffixHelpers(zoneName)
+		tags := c.commonTagsWithSuffix(helper.GetSuffixElasticIP())
+		current, err := findExisting(ctx, child.Get(IdentifierZoneNATGWElasticIP), tags, c.client.GetElasticIP, c.client.FindElasticIPsByTags)
+		if err != nil {
+			return err
+		}
+		if current != nil {
+			log := c.LogFromContext(ctx)
+			log.Info("deleting...", "AllocationId", current.AllocationId)
+			waiter := informOnWaiting(log, 10*time.Second, "still deleting...", "AllocationId", current.AllocationId)
+			err = c.client.DeleteElasticIP(ctx, current.AllocationId)
+			waiter.Done(err)
+			if err != nil {
+				return err
+			}
+		}
+		child.SetAsDeleted(IdentifierZoneNATGWElasticIP)
+		return nil
+	}
+}
+
+func (c *FlowContext) ensureNATGateway(zone *aws.Zone) flow.TaskFn {
+	return func(ctx context.Context) error {
+		log := c.LogFromContext(ctx)
+		child := c.getSubnetZoneChild(zone.Name)
+		helper := c.zoneSuffixHelpers(zone.Name)
+		desired := &awsclient.NATGateway{
+			Tags:     c.commonTagsWithSuffix(helper.GetSuffixNATGateway()),
+			SubnetId: *child.Get(IdentifierZoneSubnetPublic),
+		}
+		if zone.ElasticIPAllocationID != nil {
+			desired.EIPAllocationId = *zone.ElasticIPAllocationID
+		} else {
+			desired.EIPAllocationId = *child.Get(IdentifierZoneNATGWElasticIP)
+		}
+		current, err := findExisting(ctx, child.Get(IdentifierZoneNATGateway), desired.Tags, c.client.GetNATGateway, c.client.FindNATGatewaysByTags,
+			func(item *awsclient.NATGateway) bool {
+				return !strings.EqualFold(item.State, ec2.StateDeleting) && !strings.EqualFold(item.State, ec2.StateFailed)
+			})
+		if err != nil {
+			return err
+		}
+
+		if current != nil {
+			child.Set(IdentifierZoneNATGateway, current.NATGatewayId)
+			if _, err := c.updater.UpdateEC2Tags(ctx, current.NATGatewayId, desired.Tags, current.Tags); err != nil {
+				return err
+			}
+		} else {
+			child.Set(IdentifierZoneNATGateway, "")
+			log.Info("creating...")
+			waiter := informOnWaiting(log, 10*time.Second, "still creating...")
+			created, err := c.client.CreateNATGateway(ctx, desired)
+			if created != nil {
+				waiter.UpdateMessage("waiting until available...")
+				if perr := c.PersistState(ctx, true); perr != nil {
+					log.Info("persisting state failed", "error", perr)
+				}
+				child.Set(IdentifierZoneNATGateway, created.NATGatewayId)
+				err = c.client.WaitForNATGatewayAvailable(ctx, created.NATGatewayId)
+			}
+			waiter.Done(err)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+func (c *FlowContext) deleteNATGateway(zoneName string) flow.TaskFn {
+	return func(ctx context.Context) error {
+		child := c.getSubnetZoneChild(zoneName)
+		if child.IsAlreadyDeleted(IdentifierZoneNATGateway) {
+			return nil
+		}
+		log := c.LogFromContext(ctx)
+		helper := c.zoneSuffixHelpers(zoneName)
+		tags := c.commonTagsWithSuffix(helper.GetSuffixNATGateway())
+		current, err := findExisting(ctx, child.Get(IdentifierZoneNATGateway), tags, c.client.GetNATGateway, c.client.FindNATGatewaysByTags,
+			func(item *awsclient.NATGateway) bool {
+				return !strings.EqualFold(item.State, ec2.StateDeleting) && !strings.EqualFold(item.State, ec2.StateFailed)
+			})
+		if err != nil {
+			return err
+		}
+		if current != nil {
+			log.Info("deleting...", "NATGatewayId", current.NATGatewayId)
+			waiter := informOnWaiting(log, 10*time.Second, "still deleting...", "NATGatewayId", current.NATGatewayId)
+			err := c.client.DeleteNATGateway(ctx, current.NATGatewayId)
+			waiter.Done(err)
+			if err != nil {
+				return err
+			}
+		}
+		child.SetAsDeleted(IdentifierZoneNATGateway)
+		return nil
+	}
+}
+
+func (c *FlowContext) ensurePrivateRoutingTable(zoneName string) flow.TaskFn {
+	return func(ctx context.Context) error {
+		log := c.LogFromContext(ctx)
+		child := c.getSubnetZoneChild(zoneName)
+		id := child.Get(IdentifierZoneRouteTable)
+		cidrBlock := "0.0.0.0/0"
+		desired := &awsclient.RouteTable{
+			Tags:  c.commonTagsWithSuffix(fmt.Sprintf("private-%s", zoneName)),
+			VpcId: c.state.Get(IdentifierVPC),
+			Routes: []*awsclient.Route{
+				{
+					DestinationCidrBlock: pointer.String(cidrBlock),
+					NatGatewayId:         child.Get(IdentifierZoneNATGateway),
+				},
+			},
+		}
+		current, err := findExisting(ctx, id, desired.Tags, c.client.GetRouteTable, c.client.FindRouteTablesByTags)
+		if err != nil {
+			return err
+		}
+
+		if current != nil {
+			child.Set(IdentifierZoneRouteTable, current.RouteTableId)
+			child.SetObject(ObjectZoneRouteTable, current)
+			if _, err := c.updater.UpdateRouteTable(ctx, log, desired, current); err != nil {
+				return err
+			}
+		} else {
+			log.Info("creating...", "zone", zoneName)
+			created, err := c.client.CreateRouteTable(ctx, desired)
+			if err != nil {
+				return err
+			}
+			child.Set(IdentifierZoneRouteTable, created.RouteTableId)
+			child.SetObject(ObjectZoneRouteTable, created)
+			if _, err := c.updater.UpdateRouteTable(ctx, log, desired, created, cidrBlock); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+func (c *FlowContext) deletePrivateRoutingTable(zoneName string) flow.TaskFn {
+	return func(ctx context.Context) error {
+		log := c.LogFromContext(ctx)
+		child := c.getSubnetZoneChild(zoneName)
+		if child.IsAlreadyDeleted(IdentifierZoneRouteTable) {
+			return nil
+		}
+		tags := c.commonTagsWithSuffix(fmt.Sprintf("private-%s", zoneName))
+		current, err := findExisting(ctx, child.Get(IdentifierZoneRouteTable), tags, c.client.GetRouteTable, c.client.FindRouteTablesByTags)
+		if err != nil {
+			return err
+		}
+		if current != nil {
+			log.Info("deleting...", "RouteTableId", current.RouteTableId)
+			if err := c.client.DeleteRouteTable(ctx, current.RouteTableId); err != nil {
+				return err
+			}
+		}
+		child.SetAsDeleted(IdentifierZoneRouteTable)
+		return nil
+	}
+}
+
+func (c *FlowContext) ensureRoutingTableAssociations(zoneName string) flow.TaskFn {
+	return func(ctx context.Context) error {
+		if err := c.ensureZoneRoutingTableAssociation(ctx, zoneName, false,
+			IdentifierZoneSubnetPublic, IdentifierZoneSubnetPublicRouteTableAssoc); err != nil {
+			return err
+		}
+		if err := c.ensureZoneRoutingTableAssociation(ctx, zoneName, true,
+			IdentifierZoneSubnetPrivate, IdentifierZoneSubnetPrivateRouteTableAssoc); err != nil {
+			return err
+		}
+		if err := c.ensureZoneRoutingTableAssociation(ctx, zoneName, true,
+			IdentifierZoneSubnetWorkers, IdentifierZoneSubnetWorkersRouteTableAssoc); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func (c *FlowContext) ensureZoneRoutingTableAssociation(ctx context.Context, zoneName string,
+	zoneRouteTable bool, subnetKey, assocKey string) error {
+	child := c.getSubnetZoneChild(zoneName)
+	assocID := child.Get(assocKey)
+	if assocID != nil {
+		return nil
+	}
+	subnetID := child.Get(subnetKey)
+	if subnetID == nil {
+		return fmt.Errorf("missing subnet id")
+	}
+	var obj any
+	if zoneRouteTable {
+		obj = child.GetObject(ObjectZoneRouteTable)
+	} else {
+		obj = c.state.GetObject(ObjectMainRouteTable)
+	}
+	if obj == nil {
+		return fmt.Errorf("missing route table object")
+	}
+	routeTable := obj.(*awsclient.RouteTable)
+	for _, assoc := range routeTable.Associations {
+		if reflect.DeepEqual(assoc.SubnetId, subnetID) {
+			child.Set(assocKey, assoc.RouteTableAssociationId)
+			return nil
+		}
+	}
+	log := c.LogFromContext(ctx)
+	log.Info("creating...")
+	assocID, err := c.client.CreateRouteTableAssociation(ctx, routeTable.RouteTableId, *subnetID)
+	if err != nil {
+		return err
+	}
+	child.Set(assocKey, *assocID)
+	return nil
+}
+
+func (c *FlowContext) ensureVPCEndpointsRoutingTableAssociations(zoneName string) flow.TaskFn {
+	return func(ctx context.Context) error {
+		for _, endpoint := range c.config.Networks.VPC.GatewayEndpoints {
+			if err := c.ensureVPCEndpointZoneRoutingTableAssociation(ctx, zoneName, endpoint); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func (c *FlowContext) ensureVPCEndpointZoneRoutingTableAssociation(ctx context.Context, zoneName, endpointName string) error {
+	child := c.getSubnetZoneChild(zoneName)
+	subnetID := child.Get(IdentifierZoneSubnetWorkers)
+	if subnetID == nil {
+		return fmt.Errorf("missing subnet id")
+	}
+	vpcEndpointID := c.state.GetChild(ChildIdVPCEndpoints).Get(endpointName)
+	if vpcEndpointID == nil {
+		return fmt.Errorf("missing VPC endpoint: %s", endpointName)
+	}
+	obj := child.GetObject(ObjectZoneRouteTable)
+	if obj == nil {
+		return fmt.Errorf("missing route table object")
+	}
+	routeTable := obj.(*awsclient.RouteTable)
+	for _, route := range routeTable.Routes {
+		if reflect.DeepEqual(route.GatewayId, vpcEndpointID) {
+			return nil
+		}
+	}
+	log := c.LogFromContext(ctx)
+	log.Info("creating...", "endpoint", endpointName)
+
+	if err := c.client.CreateVpcEndpointRouteTableAssociation(ctx, routeTable.RouteTableId, *vpcEndpointID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *FlowContext) deleteRoutingTableAssociations(zoneName string) flow.TaskFn {
+	return func(ctx context.Context) error {
+		if err := c.deleteZoneRoutingTableAssociation(ctx, zoneName, false,
+			IdentifierZoneSubnetPublic, IdentifierZoneSubnetPublicRouteTableAssoc); err != nil {
+			return err
+		}
+		if err := c.deleteZoneRoutingTableAssociation(ctx, zoneName, true,
+			IdentifierZoneSubnetPrivate, IdentifierZoneSubnetPrivateRouteTableAssoc); err != nil {
+			return err
+		}
+		if err := c.deleteZoneRoutingTableAssociation(ctx, zoneName, true,
+			IdentifierZoneSubnetWorkers, IdentifierZoneSubnetWorkersRouteTableAssoc); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func (c *FlowContext) deleteZoneRoutingTableAssociation(ctx context.Context, zoneName string,
+	zoneRouteTable bool, subnetKey, assocKey string) error {
+	child := c.getSubnetZoneChild(zoneName)
+	if child.IsAlreadyDeleted(assocKey) {
+		return nil
+	}
+	subnetID := child.Get(subnetKey)
+	if subnetID == nil {
+		return fmt.Errorf("missing subnet id")
+	}
+	assocID := child.Get(assocKey)
+	if assocID == nil {
+		// unclear situation: load route table to search for association
+		var routeTableID *string
+		if zoneRouteTable {
+			routeTableID = child.Get(IdentifierZoneRouteTable)
+		} else {
+			routeTableID = c.state.Get(IdentifierMainRouteTable)
+		}
+		if routeTableID != nil {
+			routeTable, err := c.client.GetRouteTable(ctx, *routeTableID)
+			if err != nil {
+				return err
+			}
+			for _, assoc := range routeTable.Associations {
+				if reflect.DeepEqual(subnetID, assoc.SubnetId) {
+					assocID = &assoc.RouteTableAssociationId
+					break
+				}
+			}
+		}
+	}
+	if assocID == nil {
+		child.SetAsDeleted(assocKey)
+		return nil
+	}
+	log := c.LogFromContext(ctx)
+	log.Info("deleting...", "RouteTableAssociationId", *assocID)
+	if err := c.client.DeleteRouteTableAssociation(ctx, *assocID); err != nil {
+		return err
+	}
+	child.SetAsDeleted(assocKey)
+	return nil
+}
+
+func (c *FlowContext) ensureIAMRole(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+	desired := &awsclient.IAMRole{
+		RoleName: fmt.Sprintf("%s-nodes", c.namespace),
+		Path:     "/",
+		AssumeRolePolicyDocument: `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}`,
+	}
+	current, err := c.client.GetIAMRole(ctx, desired.RoleName)
+	if err != nil {
+		return err
+	}
+
+	if current != nil {
+		c.state.Set(NameIAMRole, current.RoleName)
+		c.state.Set(ARNIAMRole, current.ARN)
+		if _, err := c.updater.UpdateIAMRole(ctx, desired, current); err != nil {
+			return err
+		}
+	} else {
+		log.Info("creating...")
+		created, err := c.client.CreateIAMRole(ctx, desired)
+		if err != nil {
+			return err
+		}
+		c.state.Set(NameIAMRole, created.RoleName)
+		c.state.Set(ARNIAMRole, created.ARN)
+	}
+
+	return nil
+}
+
+func (c *FlowContext) ensureIAMInstanceProfile(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+	desired := &awsclient.IAMInstanceProfile{
+		InstanceProfileName: fmt.Sprintf("%s-nodes", c.namespace),
+		Path:                "/",
+		RoleName:            fmt.Sprintf("%s-nodes", c.namespace),
+	}
+	current, err := c.client.GetIAMInstanceProfile(ctx, desired.InstanceProfileName)
+	if err != nil {
+		return err
+	}
+
+	if current != nil {
+		c.state.Set(NameIAMInstanceProfile, current.InstanceProfileName)
+		if _, err := c.updater.UpdateIAMInstanceProfile(ctx, desired, current); err != nil {
+			return err
+		}
+	} else {
+		log.Info("creating...")
+		created, err := c.client.CreateIAMInstanceProfile(ctx, desired)
+		if err != nil {
+			return err
+		}
+		c.state.Set(NameIAMInstanceProfile, created.InstanceProfileName)
+		if _, err := c.updater.UpdateIAMInstanceProfile(ctx, desired, created); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+const iamRolePolicyTemplate = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }{{ if .enableECRAccess }},
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:GetRepositoryPolicy",
+        "ecr:DescribeRepositories",
+        "ecr:ListImages",
+        "ecr:BatchGetImage"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }{{ end }}
+  ]
+}`
+
+func (c *FlowContext) ensureIAMRolePolicy(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+	enableECRAccess := true
+	if v := c.config.EnableECRAccess; v != nil {
+		enableECRAccess = *v
+	}
+	t, err := template.New("policyDocument").Parse(iamRolePolicyTemplate)
+	if err != nil {
+		return fmt.Errorf("parsing policyDocument template failed: %s", err)
+	}
+	var buffer bytes.Buffer
+	if err := t.Execute(&buffer, map[string]any{"enableECRAccess": enableECRAccess}); err != nil {
+		return fmt.Errorf("executing policyDocument template failed: %s", err)
+	}
+
+	name := fmt.Sprintf("%s-nodes", c.namespace)
+	desired := &awsclient.IAMRolePolicy{
+		PolicyName:     name,
+		RoleName:       name,
+		PolicyDocument: buffer.String(),
+	}
+	current, err := c.client.GetIAMRolePolicy(ctx, desired.PolicyName, desired.RoleName)
+	if err != nil {
+		return err
+	}
+
+	if current != nil {
+		c.state.Set(NameIAMRolePolicy, name)
+		if current.PolicyDocument != desired.PolicyDocument {
+			if err := c.client.PutIAMRolePolicy(ctx, desired); err != nil {
+				return err
+			}
+		}
+	} else {
+		log.Info("creating...")
+		if err := c.client.PutIAMRolePolicy(ctx, desired); err != nil {
+			return err
+		}
+		c.state.Set(NameIAMRolePolicy, name)
+	}
+
+	return nil
+}
+
+func (c *FlowContext) ensureKeyPair(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+	desired := &awsclient.KeyPairInfo{
+		Tags:    c.commonTags,
+		KeyName: fmt.Sprintf("%s-ssh-publickey", c.namespace),
+	}
+	current, err := c.client.GetKeyPair(ctx, desired.KeyName)
+	if err != nil {
+		return err
+	}
+
+	specFingerprint := fmt.Sprintf("%x", md5.Sum(c.infraSpec.SSHPublicKey))
+	if current != nil {
+		// check for foreign key replacement
+		if fingerprint := c.state.Get(KeyPairFingerprint); fingerprint == nil || *fingerprint != current.KeyFingerprint {
+			log.Info("deleting as modified by unknown")
+			if err := c.client.DeleteKeyPair(ctx, current.KeyName); err != nil {
+				return err
+			}
+			current = nil
+		}
+	}
+	if current != nil {
+		// check for key replacement in spec
+		if fingerprint := c.state.Get(KeyPairSpecFingerprint); fingerprint == nil || *fingerprint != specFingerprint {
+			log.Info("deleting as replaced in spec")
+			if err := c.client.DeleteKeyPair(ctx, current.KeyName); err != nil {
+				return err
+			}
+			current = nil
+		}
+	}
+
+	if current != nil {
+		c.state.Set(NameKeyPair, desired.KeyName)
+	} else {
+		log.Info("creating")
+		info, err := c.client.ImportKeyPair(ctx, desired.KeyName, c.infraSpec.SSHPublicKey, c.commonTags)
+		if err != nil {
+			return err
+		}
+		c.state.Set(NameKeyPair, info.KeyName)
+		c.state.Set(KeyPairFingerprint, info.KeyFingerprint)
+		c.state.Set(KeyPairSpecFingerprint, specFingerprint)
+	}
+
+	return nil
+}
+
+func (c *FlowContext) getSubnetZoneChildByItem(item *awsclient.Subnet) Whiteboard {
+	return c.getSubnetZoneChild(getZoneName(item))
+}
+
+func (c *FlowContext) getSubnetZoneChild(zoneName string) Whiteboard {
+	return c.state.GetChild(ChildIdZones).GetChild(zoneName)
+}
+
+func (c *FlowContext) getSubnetKey(item *awsclient.Subnet) (zoneName, subnetKey string, err error) {
+	zone := c.getZone(item)
+	if zone == nil {
+		// zone may have been deleted from spec, need to find subnetKey on other ways
+		zoneName = item.AvailabilityZone
+		if item.SubnetId != "" {
+			zoneChild := c.getSubnetZoneChild(zoneName)
+			for _, key := range []string{IdentifierZoneSubnetWorkers, IdentifierZoneSubnetPublic, IdentifierZoneSubnetPrivate} {
+				if s := zoneChild.Get(key); s != nil && *s == item.SubnetId {
+					subnetKey = key
+					return
+				}
+			}
+		}
+		if item.Tags != nil && item.Tags[TagKeyName] != "" {
+			value := item.Tags[TagKeyName]
+			helper := c.zoneSuffixHelpers(zone.Name)
+			for _, key := range []string{IdentifierZoneSubnetWorkers, IdentifierZoneSubnetPublic, IdentifierZoneSubnetPrivate} {
+				switch key {
+				case IdentifierZoneSubnetWorkers:
+					if value == helper.GetSuffixSubnetWorkers() {
+						subnetKey = key
+						return
+					}
+				case IdentifierZoneSubnetPublic:
+					if value == helper.GetSuffixSubnetPublic() {
+						subnetKey = key
+						return
+					}
+				case IdentifierZoneSubnetPrivate:
+					if value == helper.GetSuffixSubnetPrivate() {
+						subnetKey = key
+						return
+					}
+				}
+			}
+		}
+		err = fmt.Errorf("subnetKey could not calculated from subnet item")
+		return
+	}
+	zoneName = zone.Name
+	switch item.CidrBlock {
+	case zone.Workers:
+		subnetKey = IdentifierZoneSubnetWorkers
+	case zone.Public:
+		subnetKey = IdentifierZoneSubnetPublic
+	case zone.Internal:
+		subnetKey = IdentifierZoneSubnetPrivate
+	}
+	return
+}
+
+func (c *FlowContext) getZone(item *awsclient.Subnet) *aws.Zone {
+	zoneName := getZoneName(item)
+	for _, zone := range c.config.Networks.Zones {
+		if zone.Name == zoneName {
+			return &zone
+		}
+	}
+	return nil
+}
+
+func getZoneName(item *awsclient.Subnet) string {
+	return item.AvailabilityZone
+}

--- a/pkg/controller/infrastructure/infraflow/shared/basic_context.go
+++ b/pkg/controller/infrastructure/infraflow/shared/basic_context.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/go-logr/logr"
+	"k8s.io/utils/pointer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// TaskOption contains options for created flow tasks
+type TaskOption struct {
+	Dependencies []flow.TaskIDer
+	Timeout      time.Duration
+	DoIf         *bool
+}
+
+// Dependencies creates a TaskOption for dependencies
+func Dependencies(dependencies ...flow.TaskIDer) TaskOption {
+	return TaskOption{Dependencies: dependencies}
+}
+
+// Timeout creates a TaskOption for Timeout
+func Timeout(timeout time.Duration) TaskOption {
+	return TaskOption{Timeout: timeout}
+}
+
+// DoIf creates a TaskOption for DoIf
+func DoIf(condition bool) TaskOption {
+	return TaskOption{DoIf: pointer.Bool(condition)}
+}
+
+// FlowStatePersistor persists the flat map to the provider status
+type FlowStatePersistor func(ctx context.Context, flatMap FlatMap) error
+
+// BasicFlowContext provides logic for persisting the state and add tasks to the flow graph.
+type BasicFlowContext struct {
+	Log logr.Logger
+
+	exporter                StateExporter
+	persistorLock           sync.Mutex
+	flowStatePersistor      FlowStatePersistor
+	lastPersistedGeneration int64
+	lastPersistedAt         time.Time
+	PersistInterval         time.Duration
+}
+
+// StateExporter knows how to export the internal state to a flat string map.
+type StateExporter interface {
+	// CurrentGeneration is a counter which increments on changes of the internal state.
+	CurrentGeneration() int64
+	// Exports all or parts of the internal state to a flat string map.
+	ExportAsFlatMap() FlatMap
+}
+
+// NewBasicFlowContext creates a new `BasicFlowContext`.
+func NewBasicFlowContext(log logr.Logger, exporter StateExporter, persistor FlowStatePersistor) *BasicFlowContext {
+	flowContext := &BasicFlowContext{
+		Log:                log,
+		exporter:           exporter,
+		flowStatePersistor: persistor,
+		PersistInterval:    10 * time.Second,
+	}
+	return flowContext
+}
+
+// PersistState persists the internal state to the provider status if it has changed and force is true
+// or it has not been persisted during the `PersistInterval`.
+func (c *BasicFlowContext) PersistState(ctx context.Context, force bool) error {
+	c.persistorLock.Lock()
+	defer c.persistorLock.Unlock()
+
+	if !force && c.lastPersistedAt.Add(c.PersistInterval).After(time.Now()) {
+		return nil
+	}
+	currentGeneration := c.exporter.CurrentGeneration()
+	if c.lastPersistedGeneration == currentGeneration {
+		return nil
+	}
+	if c.flowStatePersistor != nil {
+		newState := c.exporter.ExportAsFlatMap()
+		if err := c.flowStatePersistor(ctx, newState); err != nil {
+			return err
+		}
+	}
+	c.lastPersistedGeneration = currentGeneration
+	c.lastPersistedAt = time.Now()
+	return nil
+}
+
+// LogFromContext returns the log from the context when called within a task function added with the `AddTask` method.
+func (c *BasicFlowContext) LogFromContext(ctx context.Context) logr.Logger {
+	if log, err := logr.FromContext(ctx); err != nil {
+		return c.Log
+	} else {
+		return log
+	}
+}
+
+// AddTask adds a wrapped task for the given task function and options.
+func (c *BasicFlowContext) AddTask(g *flow.Graph, name string, fn flow.TaskFn, options ...TaskOption) flow.TaskIDer {
+	allOptions := TaskOption{}
+	for _, opt := range options {
+		if len(opt.Dependencies) > 0 {
+			allOptions.Dependencies = append(allOptions.Dependencies, opt.Dependencies...)
+		}
+		if opt.Timeout > 0 {
+			allOptions.Timeout = opt.Timeout
+		}
+		if opt.DoIf != nil {
+			condition := true
+			if allOptions.DoIf != nil {
+				condition = *allOptions.DoIf
+			}
+			condition = condition && *opt.DoIf
+			allOptions.DoIf = pointer.Bool(condition)
+		}
+	}
+
+	tunedFn := fn
+	if allOptions.DoIf != nil {
+		tunedFn = tunedFn.DoIf(*allOptions.DoIf)
+		if !*allOptions.DoIf {
+			name = "[Skipped] " + name
+		}
+	}
+	if allOptions.Timeout > 0 {
+		tunedFn = tunedFn.Timeout(allOptions.Timeout)
+	}
+	task := flow.Task{
+		Name: name,
+		Fn:   c.wrapTaskFn(g.Name(), name, tunedFn),
+	}
+
+	if len(allOptions.Dependencies) > 0 {
+		task.Dependencies = flow.NewTaskIDs(allOptions.Dependencies...)
+	}
+
+	return g.Add(task)
+}
+
+func (c *BasicFlowContext) wrapTaskFn(flowName, taskName string, fn flow.TaskFn) flow.TaskFn {
+	return func(ctx context.Context) error {
+		taskCtx := logf.IntoContext(ctx, c.Log.WithValues("flow", flowName, "task", taskName))
+		err := fn(taskCtx)
+		if err != nil {
+			// don't wrap error with '%w', as otherwise the error context get lost
+			err = fmt.Errorf("failed to %s: %s", taskName, err)
+		}
+		if perr := c.PersistState(taskCtx, false); perr != nil {
+			if err != nil {
+				c.Log.Error(perr, "persisting state failed")
+			} else {
+				err = perr
+			}
+		}
+		return err
+	}
+}

--- a/pkg/controller/infrastructure/infraflow/shared/basic_context_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/basic_context_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/go-logr/logr"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type testFlowContext struct {
+	shared.BasicFlowContext
+	state shared.Whiteboard
+}
+
+func newTestFlowContext(log logr.Logger, state shared.Whiteboard, persistor shared.FlowStatePersistor) *testFlowContext {
+	return &testFlowContext{
+		BasicFlowContext: *shared.NewBasicFlowContext(log, state, persistor),
+		state:            state,
+	}
+}
+
+var _ = Describe("BasicFlowContext", func() {
+	It("should create and run a graph flow", func() {
+		var (
+			logBuffer           bytes.Buffer
+			log                 = zap.New(zap.WriteTo(&logBuffer))
+			state               = shared.NewWhiteboard()
+			forcePersistorError = false
+			forceTask3Error     = false
+			persistedData       shared.FlatMap
+			persistCallCount    = 0
+			persistor           = func(ctx context.Context, data shared.FlatMap) error {
+				if forcePersistorError {
+					return fmt.Errorf("forced persistor error")
+				}
+				persistedData = shared.FlatMap{}
+				for k, v := range data {
+					persistedData[k] = v
+				}
+				persistCallCount++
+				return nil
+			}
+			ctx           = context.Background()
+			err           error
+			expectedData1 = shared.FlatMap{
+				"key1": "id1",
+				"key2": "id2b",
+			}
+		)
+
+		c := newTestFlowContext(log, state, persistor)
+		c.PersistInterval = 10 * time.Millisecond
+
+		By("persists only if needed", func() {
+			c.state.Set("key1", "id1")
+			err = c.PersistState(ctx, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(persistCallCount).To(Equal(1))
+
+			// no immediate persistence with force = false
+			c.state.Set("key2", "id2")
+			err = c.PersistState(ctx, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(persistCallCount).To(Equal(1))
+
+			// persist after interval
+			time.Sleep(c.PersistInterval)
+			err = c.PersistState(ctx, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(persistCallCount).To(Equal(2))
+
+			// immediate persistence with force = true
+			c.state.Set("key2", "id2b")
+			err = c.PersistState(ctx, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(persistCallCount).To(Equal(3))
+			Expect(persistedData).To(Equal(expectedData1))
+
+			// no change, no persist call in backend
+			err = c.PersistState(ctx, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(persistCallCount).To(Equal(3))
+		})
+
+		By("logs with context", func() {
+			g := flow.NewGraph("test")
+			task1 := c.AddTask(g, "task1",
+				func(ctx context.Context) error {
+					c.state.Set("task1", "done")
+					return nil
+				},
+				shared.DoIf(false), shared.DoIf(true))
+			task2 := c.AddTask(g, "task2",
+				func(ctx context.Context) error {
+					c.state.Set("task2", "done")
+					task1Log := c.LogFromContext(ctx)
+					task1Log.Info("message from task2")
+					return nil
+				},
+				shared.Dependencies(task1))
+			_ = c.AddTask(g, "task3",
+				func(ctx context.Context) error {
+					c.state.SetPtr("afterTask2", c.state.Get("task2"))
+					time.Sleep(c.PersistInterval)
+					c.state.Set("task3", "done")
+					if forceTask3Error {
+						return fmt.Errorf("forceTask3Error")
+					}
+					return nil
+				},
+				shared.DoIf(true), shared.Dependencies(task2), shared.DoIf(true))
+
+			f := g.Compile()
+			Expect(f.Len()).To(Equal(3))
+
+			forcePersistorError = true
+			forceTask3Error = false
+			err = f.Run(ctx, flow.Opts{Log: log})
+			Expect(err.Error()).To(ContainSubstring(`flow "test" encountered task errors: [task "task3" failed: forced persistor error]`))
+
+			Expect(c.state.Get("task1")).To(BeNil())
+			Expect(c.state.Get("task2")).To(Equal(pointer.String("done")))
+			Expect(c.state.Get("afterTask2")).To(Equal(c.state.Get("task2")))
+			Expect(c.state.Get("task3")).To(Equal(pointer.String("done")))
+			Expect(logBuffer.String()).To(ContainSubstring(`"task":"[Skipped] task1"`))
+			Expect(logBuffer.String()).To(ContainSubstring(`"task":"task2"`))
+			Expect(logBuffer.String()).To(ContainSubstring(`"msg":"message from task2"`))
+			Expect(logBuffer.String()).To(ContainSubstring(`"task":"task3"`))
+
+			forcePersistorError = false
+			forceTask3Error = true
+			c.state.Set("task1", "")
+			err = f.Run(ctx, flow.Opts{Log: log})
+			Expect(err.Error()).To(ContainSubstring(`flow "test" encountered task errors: [task "task3" failed: failed to task3: forceTask3Error]`))
+
+			forcePersistorError = false
+			forceTask3Error = false
+			c.state.Set("task1", "")
+			err = f.Run(ctx, flow.Opts{Log: log})
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/pkg/controller/infrastructure/infraflow/shared/basic_context_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/basic_context_test.go
@@ -22,13 +22,12 @@ import (
 
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 type testFlowContext struct {

--- a/pkg/controller/infrastructure/infraflow/shared/shared_suite_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/shared_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAws(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Infraflow Shared Test Suite")
+}

--- a/pkg/controller/infrastructure/infraflow/shared/tf_state.go
+++ b/pkg/controller/infrastructure/infraflow/shared/tf_state.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gardener/gardener/extensions/pkg/terraformer"
+)
+
+const (
+	// ModeManaged is mode value for managed resources.
+	ModeManaged = "managed"
+	// AttributeKeyId is the key for the id attribute
+	AttributeKeyId = "id"
+	// AttributeKeyName is the key for the name attribute
+	AttributeKeyName = "name"
+)
+
+// TerraformState holds the unmarshalled terraformer state.
+type TerraformState struct {
+	Version          int                 `json:"version"`
+	TerraformVersion string              `json:"terraform_version"`
+	Serial           int                 `json:"serial"`
+	Lineage          string              `json:"lineage"`
+	Outputs          map[string]TFOutput `json:"outputs,omitempty"`
+	Resources        []TFResource        `json:"resources,omitempty"`
+}
+
+// TFOutput holds the value and type for a terraformer state output variable.
+type TFOutput struct {
+	Value string `json:"value"`
+	Type  string `json:"type"`
+}
+
+// TFResource holds the attributes of a terraformer state resource.
+type TFResource struct {
+	Mode      string `json:"mode"`
+	Type      string `json:"type"`
+	Name      string `json:"name"`
+	Provider  string `json:"provider"`
+	Instances []TFInstance
+}
+
+// TFInstance holds the attributes of a terraformer state resource instance.
+type TFInstance struct {
+	SchemaVersion       int                    `json:"schema_version"`
+	Attributes          map[string]interface{} `json:"attributes,omitempty"`
+	SensitiveAttributes []string               `json:"sensitive_attributes,omitempty"`
+	Private             string                 `json:"private,omitempty"`
+	Dependencies        []string               `json:"dependencies"`
+}
+
+// LoadTerraformStateFromConfigMapData loads and unmarshalls the state from a config map data.
+func LoadTerraformStateFromConfigMapData(data map[string]string) (*TerraformState, error) {
+	content := data["terraform.tfstate"]
+	if content == "" {
+		return nil, fmt.Errorf("key 'terraform.tfstate' not found")
+	}
+
+	return UnmarshalTerraformState([]byte(content))
+}
+
+// UnmarshalTerraformStateFromTerraformer unmarshalls the Terraformer state from the raw state.
+func UnmarshalTerraformStateFromTerraformer(state *terraformer.RawState) (*TerraformState, error) {
+	var (
+		tfState *TerraformState
+		err     error
+		data    []byte
+	)
+
+	switch state.Encoding {
+	case "base64":
+		data, err = base64.StdEncoding.DecodeString(state.Data)
+		if err != nil {
+			return nil, fmt.Errorf("could not decode terraform raw state data: %w", err)
+		}
+	case "none":
+		data = []byte(state.Data)
+	default:
+		return nil, fmt.Errorf("unknown encoding of Terraformer raw state: %s", state.Encoding)
+	}
+	if tfState, err = UnmarshalTerraformState(data); err != nil {
+		return nil, fmt.Errorf("could not decode terraform state: %w", err)
+	}
+	return tfState, nil
+}
+
+// UnmarshalTerraformState unmarshalls the terraformer state from a byte array.
+func UnmarshalTerraformState(data []byte) (*TerraformState, error) {
+	state := &TerraformState{}
+	if err := json.Unmarshal(data, state); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+// FindManagedResourceInstances finds all instances for a resource identified by type and name.
+func (ts *TerraformState) FindManagedResourceInstances(tfType, resourceName string) []TFInstance {
+	for i := range ts.Resources {
+		resource := &ts.Resources[i]
+		if resource.Mode == ModeManaged && resource.Type == tfType && resource.Name == resourceName {
+			return resource.Instances
+		}
+	}
+	return nil
+}
+
+// FindManagedResourcesByType finds all instances for all resources of the given type.
+func (ts *TerraformState) FindManagedResourcesByType(tfType string) []*TFResource {
+	var result []*TFResource
+	for i := range ts.Resources {
+		resource := &ts.Resources[i]
+		if resource.Mode == ModeManaged && resource.Type == tfType {
+			result = append(result, resource)
+		}
+	}
+	return result
+}
+
+// GetManagedResourceInstanceID returns the value of the id attribute of the only instance of a resource identified by type and name.
+// It returns nil if either the resource is not found or the resource has not exactly one instance.
+func (ts *TerraformState) GetManagedResourceInstanceID(tfType, resourceName string) *string {
+	return ts.GetManagedResourceInstanceAttribute(tfType, resourceName, AttributeKeyId)
+}
+
+// GetManagedResourceInstanceName returns the value of the name attribute of the only instance of a resource identified by type and name.
+// It returns nil if either the resource is not found or the resource has not exactly one instance.
+func (ts *TerraformState) GetManagedResourceInstanceName(tfType, resourceName string) *string {
+	return ts.GetManagedResourceInstanceAttribute(tfType, resourceName, AttributeKeyName)
+}
+
+// GetManagedResourceInstanceAttribute returns the value of the given attribute keys of the only instance of a resource identified by type and name.
+// It returns nil if either the resource is not found or the resource has not exactly one instance or the attribute key is not existing.
+func (ts *TerraformState) GetManagedResourceInstanceAttribute(tfType, resourceName, attributeKey string) *string {
+	instances := ts.FindManagedResourceInstances(tfType, resourceName)
+	if len(instances) == 1 {
+		if value, ok := AttributeAsString(instances[0].Attributes, attributeKey); ok {
+			return &value
+		}
+	}
+	return nil
+}
+
+// GetManagedResourceInstances returns a map resource name to instance id for all resources of the given type.
+// Only resources are included which have exactly one instance.
+func (ts *TerraformState) GetManagedResourceInstances(tfType string) map[string]string {
+	result := map[string]string{}
+	for _, item := range ts.FindManagedResourcesByType(tfType) {
+		if len(item.Instances) == 1 {
+			if value, ok := AttributeAsString(item.Instances[0].Attributes, AttributeKeyId); ok {
+				result[item.Name] = value
+			}
+		}
+	}
+	return result
+}
+
+// AttributeAsString returns the string value for the given key. `found` is only true if the map contains the key and the value is a string.
+func AttributeAsString(attributes map[string]interface{}, key string) (svalue string, found bool) {
+	if attributes == nil {
+		return
+	}
+	value, ok := attributes[key]
+	if !ok {
+		return
+	}
+	if s, ok := value.(string); ok {
+		svalue = s
+		found = true
+	}
+	return
+}

--- a/pkg/controller/infrastructure/infraflow/shared/tf_state_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/tf_state_test.go
@@ -1,0 +1,244 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared_test
+
+import (
+	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
+	"github.com/gardener/gardener/extensions/pkg/terraformer"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("TerraformState", func() {
+	It("should unmarshall terraformer state", func() {
+		var ()
+
+		rawState := &terraformer.RawState{
+			Data:     tfstate,
+			Encoding: "none",
+		}
+
+		tf, err := shared.UnmarshalTerraformStateFromTerraformer(rawState)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(tf.Outputs["vpc_id"]).To(Equal(shared.TFOutput{Type: "string", Value: "vpc-0123456"}))
+
+		tables := tf.FindManagedResourcesByType("aws_route_table")
+		Expect(len(tables)).To(Equal(2))
+
+		Expect(tf.GetManagedResourceInstanceID("aws_route_table", "routetable_private_utility_z0")).
+			To(Equal(pointer.String("rtb-77777")))
+
+		Expect(tf.GetManagedResourceInstanceName("aws_iam_role", "nodes")).
+			To(Equal(pointer.String("shoot--foo--bar-nodes")))
+
+		Expect(tf.GetManagedResourceInstanceAttribute("aws_nat_gateway", "natgw_z0", "private_ip")).
+			To(Equal(pointer.String("10.180.46.81")))
+
+		Expect(tf.GetManagedResourceInstanceAttribute("aws_nat_gateway", "natgw_z0", "foobar")).
+			To(BeNil())
+
+		Expect(tf.GetManagedResourceInstances("aws_route_table")).
+			To(Equal(map[string]string{
+				"routetable_main":               "rtb-66666",
+				"routetable_private_utility_z0": "rtb-77777",
+			}))
+	})
+})
+
+const tfstate = `{
+  "version": 4,
+  "terraform_version": "0.15.5",
+  "serial": 83,
+  "lineage": "674a5a9a-d0e5-eee1-ce57-d820c4313bf0",
+  "outputs": {
+    "vpc_id": {
+      "value": "vpc-0123456",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_iam_role",
+      "name": "nodes",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "shoot--foo--bar-nodes-id",
+            "max_session_duration": 3600,
+            "name": "shoot--foo--bar-nodes"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_nat_gateway",
+      "name": "natgw_z0",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "allocation_id": "eipalloc-07aaaaa",
+            "connectivity_type": "public",
+            "id": "nat-22222",
+            "network_interface_id": "eni-33333",
+            "private_ip": "10.180.46.81",
+            "public_ip": "1.2.3.4",
+            "subnet_id": "subnet-44444",
+            "tags": {
+              "Name": "shoot--foo--bar-natgw-z0",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            },
+            "tags_all": {
+              "Name": "shoot--foo--bar-natgw-z0",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "xxx",
+          "dependencies": [
+            "aws_eip.eip_natgw_z0",
+            "aws_subnet.public_utility_z0",
+            "aws_vpc.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "routetable_main",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "rtb-66666",
+            "owner_id": "999999",
+            "propagating_vgws": [],
+            "route": [
+              {
+                "cidr_block": "0.0.0.0/0"
+              }
+            ],
+            "tags": {
+              "Name": "shoot--foo--bar",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            },
+            "tags_all": {
+              "Name": "shoot--foo--bar",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            },
+            "timeouts": {
+              "create": "5m",
+              "delete": null,
+              "update": null
+            },
+            "vpc_id": "vpc-0123456"
+          },
+          "sensitive_attributes": [],
+          "private": "xxx",
+          "dependencies": [
+            "aws_vpc.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "routetable_private_utility_z0",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "rtb-77777",
+            "owner_id": "999999",
+            "route": [
+              {
+                "cidr_block": "0.0.0.0/0",
+                "nat_gateway_id": "nat-22222"
+              }
+            ],
+            "tags": {
+              "Name": "shoot--foo--bar-private-eu-west-1a",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            },
+            "tags_all": {
+              "Name": "shoot--foo--bar-private-eu-west-1a",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            },
+            "timeouts": {
+              "create": "5m",
+              "delete": null,
+              "update": null
+            },
+            "vpc_id": "vpc-0123456"
+          },
+          "sensitive_attributes": [],
+          "private": "xxx",
+          "dependencies": [
+            "aws_vpc.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "vpc",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:eu-west-1:999999:vpc/vpc-0123456",
+            "assign_generated_ipv6_cidr_block": false,
+            "cidr_block": "10.180.0.0/16",
+            "default_security_group_id": "sg-11111",
+            "enable_classiclink": false,
+            "enable_classiclink_dns_support": false,
+            "enable_dns_hostnames": true,
+            "enable_dns_support": true,
+            "id": "vpc-0123456",
+            "instance_tenancy": "default",
+            "ipv6_association_id": "",
+            "ipv6_cidr_block": "",
+            "main_route_table_id": "rtb-77888",
+            "owner_id": "999999",
+            "tags": {
+              "Name": "shoot--foo--bar",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            },
+            "tags_all": {
+              "Name": "shoot--foo--bar",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    }
+  ]
+}
+`

--- a/pkg/controller/infrastructure/infraflow/shared/tf_state_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/tf_state_test.go
@@ -15,11 +15,12 @@
 package shared_test
 
 import (
-	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
 )
 
 var _ = Describe("TerraformState", func() {

--- a/pkg/controller/infrastructure/infraflow/shared/whiteboard.go
+++ b/pkg/controller/infrastructure/infraflow/shared/whiteboard.go
@@ -1,0 +1,269 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"k8s.io/utils/pointer"
+)
+
+const (
+	// Separator is used to on translating keys to/from flat maps
+	Separator = "/"
+	// deleted is a special value to mark a resource id as deleted
+	deleted = "<deleted>"
+)
+
+// FlatMap is a semantic name for string map used for importing and exporting
+type FlatMap map[string]string
+
+// Whiteboard is a hierarchical key/value store for the internal state.
+// It is safe to be used concurrently.
+// Additionally, it can cache objects for use in subsequent flow task.
+type Whiteboard interface {
+	IsEmpty() bool
+
+	// GetChild returns a sub-whiteboard for the given key. If no child exists with this name, it is created automatically.
+	// Each child has its own lock.
+	GetChild(key string) Whiteboard
+	// HasChild returns true if there is a non-empty child for that key
+	HasChild(key string) bool
+	// GetChildrenKeys returns all children keys
+	GetChildrenKeys() []string
+
+	// Get returns a valid value or nil (never "" or special deleted value)
+	Get(key string) *string
+	Set(key, id string)
+	SetPtr(key string, id *string)
+	IsAlreadyDeleted(key string) bool
+	SetAsDeleted(key string)
+	// Keys returns all stored keys, even for deleted ones
+	Keys() []string
+	// AsMap returns a map with all valid key/values
+	AsMap() map[string]string
+
+	GetObject(key string) any
+	SetObject(key string, obj any)
+
+	// ImportFromFlatMap reconstructs the hierarchical structure from a flat map containing path-like keys
+	ImportFromFlatMap(data FlatMap)
+	// ExportAsFlatMap exports the hierarchical structure to a flat map with path-like keys. Objects are ignored.
+	ExportAsFlatMap() FlatMap
+
+	// CurrentGeneration returns current generation, which increments with any change
+	CurrentGeneration() int64
+}
+
+type whiteboard struct {
+	sync.Mutex
+
+	children   map[string]*whiteboard
+	data       map[string]string
+	objects    map[string]any
+	generation *atomic.Int64
+}
+
+var _ Whiteboard = &whiteboard{}
+
+// NewWhiteboard creates an empty whiteboard.
+func NewWhiteboard() Whiteboard {
+	return newWhiteboard(&atomic.Int64{})
+}
+
+func newWhiteboard(generation *atomic.Int64) *whiteboard {
+	return &whiteboard{
+		children:   map[string]*whiteboard{},
+		data:       map[string]string{},
+		objects:    map[string]any{},
+		generation: generation,
+	}
+}
+
+func (w *whiteboard) CurrentGeneration() int64 {
+	return w.generation.Load()
+}
+
+func (w *whiteboard) IsEmpty() bool {
+	w.Lock()
+	defer w.Unlock()
+
+	if len(w.data) != 0 || len(w.objects) != 0 {
+		return false
+	}
+	for _, child := range w.children {
+		if !child.IsEmpty() {
+			return false
+		}
+	}
+	return true
+}
+
+func (w *whiteboard) GetChild(key string) Whiteboard {
+	return w.getChild(key)
+}
+
+func (w *whiteboard) getChild(key string) *whiteboard {
+	w.Lock()
+	defer w.Unlock()
+
+	child := w.children[key]
+	if child == nil {
+		child = newWhiteboard(w.generation)
+		w.children[key] = child
+	}
+	return child
+}
+
+func (w *whiteboard) HasChild(key string) bool {
+	w.Lock()
+	defer w.Unlock()
+
+	child := w.children[key]
+	return child != nil && !child.IsEmpty()
+}
+
+func (w *whiteboard) GetChildrenKeys() []string {
+	w.Lock()
+	defer w.Unlock()
+
+	return sortedKeys(w.children)
+}
+
+func (w *whiteboard) GetObject(key string) any {
+	w.Lock()
+	defer w.Unlock()
+	return w.objects[key]
+}
+
+func (w *whiteboard) SetObject(key string, obj any) {
+	w.Lock()
+	defer w.Unlock()
+	w.objects[key] = obj
+}
+
+func (w *whiteboard) Keys() []string {
+	w.Lock()
+	defer w.Unlock()
+
+	return sortedKeys(w.data)
+}
+
+func (w *whiteboard) AsMap() map[string]string {
+	w.Lock()
+	defer w.Unlock()
+
+	m := map[string]string{}
+	for key, value := range w.data {
+		if IsValidValue(value) {
+			m[key] = value
+		}
+	}
+	return m
+}
+
+func (w *whiteboard) Get(key string) *string {
+	w.Lock()
+	defer w.Unlock()
+	id := w.data[key]
+	if !IsValidValue(id) {
+		return nil
+	}
+	return &id
+}
+
+func (w *whiteboard) Set(key, id string) {
+	w.Lock()
+	defer w.Unlock()
+	oldId := w.data[key]
+	if id != "" {
+		w.data[key] = id
+	} else {
+		delete(w.data, key)
+	}
+	if oldId != id {
+		w.modified()
+	}
+}
+
+func (w *whiteboard) SetPtr(key string, id *string) {
+	w.Set(key, pointer.StringDeref(id, ""))
+}
+
+func (w *whiteboard) IsAlreadyDeleted(key string) bool {
+	w.Lock()
+	defer w.Unlock()
+	return w.data[key] == deleted
+}
+
+func (w *whiteboard) SetAsDeleted(key string) {
+	w.Set(key, deleted)
+}
+
+func (w *whiteboard) ImportFromFlatMap(data FlatMap) {
+	for key, value := range data {
+		parts := strings.Split(key, Separator)
+		level := w
+		for i := 0; i < len(parts)-1; i++ {
+			level = level.getChild(parts[i])
+		}
+		level.Set(parts[len(parts)-1], value)
+	}
+}
+
+func (w *whiteboard) ExportAsFlatMap() FlatMap {
+	data := map[string]string{}
+	w.copyMap(data, "")
+	fillDataFromChildren(data, "", w)
+	return data
+}
+
+func (w *whiteboard) copyMap(data map[string]string, prefix string) {
+	w.Lock()
+	defer w.Unlock()
+	for k, v := range w.data {
+		data[prefix+k] = v
+	}
+}
+
+func fillDataFromChildren(data map[string]string, parentPrefix string, parent *whiteboard) {
+	for _, childKey := range parent.GetChildrenKeys() {
+		child := parent.getChild(childKey)
+		childPrefix := parentPrefix + childKey + Separator
+		child.copyMap(data, childPrefix)
+		fillDataFromChildren(data, childPrefix, child)
+	}
+}
+
+func (w *whiteboard) modified() {
+	w.generation.Add(1)
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	var keys []string
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// IsValidValue returns true if an exported value is valid, i.e. not empty and not special value for deleted.
+func IsValidValue(value string) bool {
+	return value != "" && value != deleted
+}

--- a/pkg/controller/infrastructure/infraflow/shared/whiteboard_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/whiteboard_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared_test
+
+import (
+	"k8s.io/utils/pointer"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Whiteboard", func() {
+	It("should create hierarchical whiteboard from flat map", func() {
+		var (
+			data = shared.FlatMap{
+				"key1":                  "id1",
+				"key2":                  "id2",
+				"child1/subchild1/key1": "id111",
+				"child1/subchild2/key1": "id121",
+				"child2/key2":           "id22",
+			}
+			expectedData = shared.FlatMap{
+				"key1":                  "<deleted>",
+				"key2":                  "id2a",
+				"key3":                  "id3",
+				"child1/subchild1/key1": "id111b",
+				"child2/key2":           "id22",
+			}
+			expectedMap = map[string]string{
+				"key2": "id2a",
+				"key3": "id3",
+			}
+			expectedKeys = []string{"key1", "key2", "key3"}
+		)
+
+		w := shared.NewWhiteboard()
+		w.IsEmpty()
+		w.ImportFromFlatMap(data)
+		Expect(w.Get("key1")).NotTo(BeNil())
+		Expect(*w.Get("key1")).To(Equal("id1"))
+		Expect(w.Get("key2")).NotTo(BeNil())
+		Expect(*w.Get("key2")).To(Equal("id2"))
+		Expect(w.Get("child1")).To(BeNil())
+		Expect(w.GetChild("child1").IsEmpty()).To(BeFalse())
+		Expect(w.GetChild("child1").GetChild("subchild1").Get("key1")).To(Equal(pointer.String("id111")))
+		Expect(w.GetChild("child1").GetChild("subchild2").Get("key1")).To(Equal(pointer.String("id121")))
+		Expect(w.GetChild("child2").IsEmpty()).To(BeFalse())
+		Expect(w.GetChild("child2").Get("key2")).To(Equal(pointer.String("id22")))
+		Expect(w.GetChild("child3").IsEmpty()).To(BeTrue())
+		generation1 := w.CurrentGeneration()
+		w.Set("key2", "id2")
+		Expect(w.CurrentGeneration()).To(Equal(generation1))
+		w.GetChild("child1").GetChild("subchild1").Set("key1", "id111")
+		Expect(w.CurrentGeneration()).To(Equal(generation1))
+		w.Set("key2", "id2a")
+		generation2 := w.CurrentGeneration()
+		Expect(generation2 > generation1).To(BeTrue())
+		w.GetChild("child1").GetChild("subchild1").Set("key1", "id111b")
+		Expect(w.CurrentGeneration() > generation2).To(BeTrue())
+
+		Expect(w.GetChild("child1").GetChild("subchild2").IsAlreadyDeleted("key1")).To(BeFalse())
+		w.GetChild("child1").GetChild("subchild2").Set("key1", "")
+		Expect(w.GetChild("child1").GetChild("subchild2").IsAlreadyDeleted("key1")).To(BeFalse())
+
+		Expect(w.Get("key1")).NotTo(BeNil())
+		Expect(w.IsAlreadyDeleted("key1")).To(BeFalse())
+		w.SetAsDeleted("key1")
+		Expect(w.Get("key1")).To(BeNil())
+		Expect(w.IsAlreadyDeleted("key1")).To(BeTrue())
+
+		Expect(w.Get("key3")).To(BeNil())
+		w.SetPtr("key3", pointer.String("id3"))
+		Expect(w.Get("key3")).NotTo(BeNil())
+
+		Expect(w.HasChild("child1")).To(BeTrue())
+		Expect(w.HasChild("child3")).To(BeFalse())
+
+		Expect(w.AsMap()).To(Equal(expectedMap))
+
+		Expect(w.Keys()).To(Equal(expectedKeys))
+
+		generation3 := w.CurrentGeneration()
+		w.SetObject("obj1", expectedKeys)
+		Expect(w.GetObject("obj1")).To(Equal(expectedKeys))
+		Expect(w.CurrentGeneration()).To(Equal(generation3))
+
+		exported := w.ExportAsFlatMap()
+		Expect(exported).To(Equal(expectedData))
+	})
+})

--- a/pkg/controller/infrastructure/infraflow/shared/whiteboard_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/whiteboard_test.go
@@ -15,12 +15,11 @@
 package shared_test
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Whiteboard", func() {

--- a/pkg/controller/infrastructure/infraflow/utils.go
+++ b/pkg/controller/infrastructure/infraflow/utils.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infraflow
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/go-logr/logr"
+	"go.uber.org/atomic"
+)
+
+type zoneDependencies map[string][]flow.TaskIDer
+
+func newZoneDependencies() zoneDependencies {
+	return zoneDependencies{}
+}
+
+func (d zoneDependencies) Append(zoneName string, taskIDers ...flow.TaskIDer) {
+	taskIDs := d[zoneName]
+	if taskIDs == nil {
+		taskIDs = []flow.TaskIDer{}
+		d[zoneName] = taskIDs
+	}
+	d[zoneName] = append(d[zoneName], taskIDers...)
+}
+
+func (d zoneDependencies) Get(zoneName string) []flow.TaskIDer {
+	return d[zoneName]
+}
+
+func diffByID[T any](desired, current []T, unique func(item T) string) (toBeDeleted, toBeCreated []T, toBeChecked []struct{ desired, current T }) {
+outerDelete:
+	for _, c := range current {
+		cuniq := unique(c)
+		for _, d := range desired {
+			if cuniq == unique(d) {
+				toBeChecked = append(toBeChecked, struct{ desired, current T }{
+					desired: d,
+					current: c,
+				})
+				continue outerDelete
+			}
+		}
+		toBeDeleted = append(toBeDeleted, c)
+	}
+outerCreate:
+	for _, d := range desired {
+		duniq := unique(d)
+		for _, c := range current {
+			if duniq == unique(c) {
+				continue outerCreate
+			}
+		}
+		toBeCreated = append(toBeCreated, d)
+	}
+	return
+}
+
+func findExisting[T any](ctx context.Context, id *string, tags awsclient.Tags,
+	getter func(ctx context.Context, id string) (*T, error),
+	finder func(ctx context.Context, tags awsclient.Tags) ([]*T, error),
+	selector ...func(item *T) bool) (*T, error) {
+
+	if id != nil {
+		found, err := getter(ctx, *id)
+		if err != nil {
+			return nil, err
+		}
+		if found != nil && (len(selector) == 0 || selector[0](found)) {
+			return found, nil
+		}
+	}
+
+	found, err := finder(ctx, tags)
+	if err != nil {
+		return nil, err
+	}
+	if len(found) == 0 {
+		return nil, nil
+	}
+	if len(selector) > 0 {
+		for _, item := range found {
+			if selector[0](item) {
+				return item, nil
+			}
+		}
+		return nil, nil
+	}
+	return found[0], nil
+}
+
+type waiter struct {
+	log           logr.Logger
+	start         time.Time
+	period        time.Duration
+	message       atomic.String
+	keysAndValues []any
+	done          chan struct{}
+}
+
+func informOnWaiting(log logr.Logger, period time.Duration, message string, keysAndValues ...any) *waiter {
+	w := &waiter{
+		log:           log,
+		start:         time.Now(),
+		period:        period,
+		keysAndValues: keysAndValues,
+		done:          make(chan struct{}),
+	}
+	w.message.Store(message)
+	go w.run()
+	return w
+}
+
+func (w *waiter) UpdateMessage(message string) {
+	w.message.Store(message)
+}
+
+func (w *waiter) run() {
+	ticker := time.NewTicker(w.period)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-w.done:
+			return
+		case <-ticker.C:
+			delta := int(time.Since(w.start).Seconds())
+			w.log.Info(fmt.Sprintf("%s [%ds]", w.message.Load(), delta), w.keysAndValues...)
+		}
+	}
+}
+
+func (w *waiter) Done(err error) {
+	w.done <- struct{}{}
+	if err != nil {
+		w.log.Info("failed: " + err.Error())
+	} else {
+		w.log.Info("succeeded")
+	}
+}
+
+func copyMap(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+	dst := map[string]string{}
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}

--- a/pkg/controller/infrastructure/infraflow/utils.go
+++ b/pkg/controller/infrastructure/infraflow/utils.go
@@ -19,10 +19,11 @@ import (
 	"fmt"
 	"time"
 
-	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/go-logr/logr"
 	"go.uber.org/atomic"
+
+	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
 )
 
 type zoneDependencies map[string][]flow.TaskIDer

--- a/pkg/controller/infrastructure/tf_migration.go
+++ b/pkg/controller/infrastructure/tf_migration.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infrastructure
+
+import (
+	"fmt"
+	"strings"
+
+	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
+	"github.com/gardener/gardener/extensions/pkg/terraformer"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func migrateTerraformStateToFlowState(rawExtension *runtime.RawExtension, zones []awsapi.Zone) (*infraflow.PersistentState, error) {
+	var (
+		tfRawState *terraformer.RawState
+		tfState    *shared.TerraformState
+		err        error
+	)
+
+	flowState := infraflow.NewPersistentState()
+
+	if rawExtension == nil {
+		return flowState, nil
+	}
+
+	if tfRawState, err = getTerraformerRawState(rawExtension); err != nil {
+		return nil, err
+	}
+	if tfState, err = shared.UnmarshalTerraformStateFromTerraformer(tfRawState); err != nil {
+		return nil, err
+	}
+
+	if tfState.Outputs == nil {
+		return flowState, nil
+	}
+
+	value := tfState.Outputs[aws.VPCIDKey].Value
+	if value != "" {
+		setFlowStateData(flowState, infraflow.IdentifierVPC, &value)
+	}
+	setFlowStateData(flowState, infraflow.IdentifierDHCPOptions,
+		tfState.GetManagedResourceInstanceID("aws_vpc_dhcp_options", "vpc_dhcp_options"))
+	setFlowStateData(flowState, infraflow.IdentifierDefaultSecurityGroup,
+		tfState.GetManagedResourceInstanceID("aws_default_security_group", "default"))
+	setFlowStateData(flowState, infraflow.IdentifierInternetGateway,
+		tfState.GetManagedResourceInstanceID("aws_internet_gateway", "igw"))
+	setFlowStateData(flowState, infraflow.IdentifierMainRouteTable,
+		tfState.GetManagedResourceInstanceID("aws_route_table", "public"))
+	setFlowStateData(flowState, infraflow.IdentifierNodesSecurityGroup,
+		tfState.GetManagedResourceInstanceID("aws_security_group", "nodes"))
+
+	if instances := tfState.GetManagedResourceInstances("aws_vpc_endpoint"); len(instances) > 0 {
+		for name, id := range instances {
+			key := infraflow.ChildIdVPCEndpoints + shared.Separator + strings.TrimPrefix(name, "vpc_gwep_")
+			setFlowStateData(flowState, key, &id)
+		}
+	}
+
+	tfNamePrefixes := []string{"nodes_", "private_utility_", "public_utility"}
+	flowNames := []string{infraflow.IdentifierZoneSubnetWorkers, infraflow.IdentifierZoneSubnetPrivate, infraflow.IdentifierZoneSubnetPublic}
+	for i, zone := range zones {
+		keyPrefix := infraflow.ChildIdZones + shared.Separator + zone.Name + shared.Separator
+		suffix := fmt.Sprintf("z%d", i)
+		setFlowStateData(flowState, keyPrefix+infraflow.IdentifierZoneSuffix, &suffix)
+
+		for j := 0; j < len(tfNamePrefixes); j++ {
+			setFlowStateData(flowState, keyPrefix+flowNames[j],
+				tfState.GetManagedResourceInstanceID("aws_subnet", tfNamePrefixes[j]+suffix))
+		}
+		setFlowStateData(flowState, keyPrefix+infraflow.IdentifierZoneNATGWElasticIP,
+			tfState.GetManagedResourceInstanceID("aws_eip", "eip_natgw_"+suffix))
+		setFlowStateData(flowState, keyPrefix+infraflow.IdentifierZoneNATGateway,
+			tfState.GetManagedResourceInstanceID("aws_nat_gateway", "natgw_"+suffix))
+		setFlowStateData(flowState, keyPrefix+infraflow.IdentifierZoneNATGateway,
+			tfState.GetManagedResourceInstanceID("aws_route_table", "private_utility_"+suffix))
+
+		setFlowStateData(flowState, keyPrefix+infraflow.IdentifierZoneSubnetPublicRouteTableAssoc,
+			tfState.GetManagedResourceInstanceID("aws_route_table_association", "routetable_main_association_public_utility_"+suffix))
+		setFlowStateData(flowState, keyPrefix+infraflow.IdentifierZoneSubnetPrivateRouteTableAssoc,
+			tfState.GetManagedResourceInstanceID("aws_route_table_association", "routetable_private_utility_"+suffix+"_association_private_utility_"+suffix))
+		setFlowStateData(flowState, keyPrefix+infraflow.IdentifierZoneSubnetWorkersRouteTableAssoc,
+			tfState.GetManagedResourceInstanceID("aws_route_table_association", "routetable_private_utility_"+suffix+"_association_nodes_"+suffix))
+	}
+
+	setFlowStateData(flowState, infraflow.NameIAMRole,
+		tfState.GetManagedResourceInstanceName("aws_iam_role", "nodes"))
+	setFlowStateData(flowState, infraflow.NameIAMInstanceProfile,
+		tfState.GetManagedResourceInstanceName("aws_iam_instance_profile", "nodes"))
+	setFlowStateData(flowState, infraflow.NameIAMRolePolicy,
+		tfState.GetManagedResourceInstanceName("aws_iam_role_policy", "nodes"))
+	setFlowStateData(flowState, infraflow.ARNIAMRole,
+		tfState.GetManagedResourceInstanceAttribute("aws_iam_role", "nodes", "arn"))
+
+	setFlowStateData(flowState, infraflow.NameKeyPair,
+		tfState.GetManagedResourceInstanceAttribute("aws_key_pair", "nodes", "key_pair_id"))
+
+	flowState.SetMigratedFromTerraform()
+
+	return flowState, nil
+}
+
+func setFlowStateData(state *infraflow.PersistentState, key string, id *string) {
+	if id == nil {
+		delete(state.Data, key)
+	} else {
+		state.Data[key] = *id
+	}
+}
+
+func getTerraformerRawState(state *runtime.RawExtension) (*terraformer.RawState, error) {
+	if state == nil {
+		return nil, nil
+	}
+	tfRawState, err := terraformer.UnmarshalRawState(state)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode terraform raw state: %+v", err)
+	}
+	return tfRawState, nil
+}

--- a/pkg/controller/infrastructure/tf_migration.go
+++ b/pkg/controller/infrastructure/tf_migration.go
@@ -18,12 +18,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gardener/gardener/extensions/pkg/terraformer"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"
-	"github.com/gardener/gardener/extensions/pkg/terraformer"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func migrateTerraformStateToFlowState(rawExtension *runtime.RawExtension, zones []awsapi.Zone) (*infraflow.PersistentState, error) {

--- a/pkg/webhook/infrastructure/add.go
+++ b/pkg/webhook/infrastructure/add.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infrastructure
+
+import (
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
+)
+
+const (
+	// WebhookName is the used for the Infrastructure webhook.
+	WebhookName = "infrastructure"
+	webhookPath = "infrastructure"
+)
+
+var logger = log.Log.WithName("infrastructure-webhook")
+
+// AddToManager creates an Infrastructure webhook adds the webhook to the manager.
+func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	logger.Info("Adding webhook to manager")
+
+	types := []extensionswebhook.Type{
+		{Obj: &extensionsv1alpha1.Infrastructure{}},
+	}
+
+	handler, err := extensionswebhook.NewBuilder(mgr, logger).WithMutator(New(logger), types...).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("Creating webhook")
+	return &extensionswebhook.Webhook{
+		Name:     WebhookName,
+		Target:   extensionswebhook.TargetSeed,
+		Provider: aws.Type,
+		Types:    types,
+		Webhook:  &admission.Webhook{Handler: handler, RecoverPanic: true},
+		Path:     webhookPath,
+		Selector: buildSelector(aws.Type),
+	}, nil
+}
+
+func buildSelector(provider string) *metav1.LabelSelector {
+	return &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      v1beta1constants.LabelShootProvider,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{provider},
+			},
+		},
+	}
+}

--- a/pkg/webhook/infrastructure/mutate.go
+++ b/pkg/webhook/infrastructure/mutate.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infrastructure
+
+import (
+	"context"
+	"fmt"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	extensionscontextwebhook "github.com/gardener/gardener/extensions/pkg/webhook/context"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
+)
+
+type mutator struct {
+	logger logr.Logger
+	client client.Client
+}
+
+// New returns a new Infrastructure mutator that uses mutateFunc to perform the mutation.
+func New(logger logr.Logger) extensionswebhook.Mutator {
+	return &mutator{
+		logger: logger,
+	}
+}
+
+// InjectClient injects the given client into the ensurer.
+func (m *mutator) InjectClient(client client.Client) error {
+	m.client = client
+	return nil
+}
+
+// Mutate mutates the given object on creation and adds the annotation `aws.provider.extensions.gardener.cloud/use-flow=true`
+// if the seed has the label `aws.provider.extensions.gardener.cloud/use-flow` == `new`.
+func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
+	if old != nil || new.GetDeletionTimestamp() != nil {
+		return nil
+	}
+
+	newInfra, ok := new.(*extensionsv1alpha1.Infrastructure)
+	if !ok {
+		return fmt.Errorf("could not mutate: object is not of type Infrastructure")
+	}
+
+	gctx := extensionscontextwebhook.NewGardenContext(m.client, new)
+	cluster, err := gctx.GetCluster(ctx)
+	if err != nil {
+		return err
+	}
+
+	if cluster.Seed.Labels[aws.SeedLabelKeyUseFlow] == aws.SeedLabelUseFlowValueNew {
+		if newInfra.Annotations == nil {
+			newInfra.Annotations = map[string]string{}
+		}
+		newInfra.Annotations[aws.AnnotationKeyUseFlow] = "true"
+	}
+
+	return nil
+}

--- a/pkg/webhook/infrastructure/mutate_test.go
+++ b/pkg/webhook/infrastructure/mutate_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infrastructure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gardener/gardener/extensions/pkg/controller"
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
+)
+
+const (
+	shootNamespace = "shoot--foo--bar"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Infrastructure Webhook Suite")
+}
+
+var _ = Describe("Mutate", func() {
+	var ctrl *gomock.Controller
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#UseFlowAnnotation", func() {
+		var (
+			mutator extensionswebhook.Mutator
+			cluster *controller.Cluster
+			ctx     context.Context
+		)
+
+		Context("create", func() {
+			BeforeEach(func() {
+				mutator = New(logger)
+				ctx = context.TODO()
+				c := mockclient.NewMockClient(ctrl)
+				c.EXPECT().Get(ctx, client.ObjectKey{Name: shootNamespace}, gomock.AssignableToTypeOf(&extensionsv1alpha1.Cluster{})).
+					DoAndReturn(
+						func(_ context.Context, _ types.NamespacedName, obj *extensionsv1alpha1.Cluster, _ ...client.GetOption) error {
+							sheedJSON, err := json.Marshal(cluster.Seed)
+							Expect(err).NotTo(HaveOccurred())
+							*obj = extensionsv1alpha1.Cluster{
+								ObjectMeta: cluster.ObjectMeta,
+								Spec: extensionsv1alpha1.ClusterSpec{
+									Seed: runtime.RawExtension{Raw: sheedJSON},
+								},
+							}
+							return nil
+						})
+				err := mutator.(inject.Client).InjectClient(c)
+				Expect(err).NotTo(HaveOccurred())
+				cluster = &controller.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: shootNamespace,
+					},
+					Seed: &gardencorev1beta1.Seed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   shootNamespace,
+							Labels: map[string]string{},
+						},
+					},
+				}
+			})
+
+			It("should add use-flow annotation if seed label is set to new", func() {
+				cluster.Seed.Labels[aws.SeedLabelKeyUseFlow] = aws.SeedLabelUseFlowValueNew
+				newInfra := &extensionsv1alpha1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dummy",
+						Namespace: shootNamespace,
+					},
+				}
+
+				err := mutator.Mutate(ctx, newInfra, nil)
+
+				Expect(err).To(BeNil())
+				Expect(err).To(BeNil())
+				Expect(newInfra.Annotations[aws.AnnotationKeyUseFlow]).To(Equal("true"))
+			})
+
+			It("should do nothing if seed label is set to true", func() {
+				cluster.Seed.Labels[aws.SeedLabelKeyUseFlow] = "true"
+				newInfra := &extensionsv1alpha1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dummy",
+						Namespace: shootNamespace,
+					},
+				}
+				err := mutator.Mutate(ctx, newInfra, nil)
+				Expect(err).To(BeNil())
+				Expect(newInfra.Annotations[aws.AnnotationKeyUseFlow]).To(Equal(""))
+			})
+		})
+
+		Context("update", func() {
+			BeforeEach(func() {
+				mutator = New(logger)
+				cluster = &controller.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: shootNamespace,
+					},
+				}
+			})
+
+			It("should do nothing on update", func() {
+				newInfra := &extensionsv1alpha1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dummy",
+						Namespace: shootNamespace,
+					},
+				}
+				err := mutator.Mutate(ctx, newInfra, newInfra)
+				Expect(err).To(BeNil())
+				Expect(newInfra.Annotations[aws.AnnotationKeyUseFlow]).To(Equal(""))
+			})
+		})
+	})
+})

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -33,8 +33,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow"
-	"github.com/gardener/gardener-extension-provider-aws/test/integration"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
@@ -65,6 +63,8 @@ import (
 	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
 	. "github.com/gardener/gardener-extension-provider-aws/pkg/aws/matchers"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow"
+	"github.com/gardener/gardener-extension-provider-aws/test/integration"
 )
 
 type flowUsage int

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -57,6 +57,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	awsapi "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	awsinstall "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/install"
 	awsv1alpha1 "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
@@ -226,7 +227,7 @@ var _ = Describe("Infrastructure tests", func() {
 
 		It("should successfully create and delete (terraformer)", func() {
 			providerConfig := newProviderConfig(awsv1alpha1.VPC{
-				CIDR:             pointer.StringPtr(vpcCIDR),
+				CIDR:             pointer.String(vpcCIDR),
 				GatewayEndpoints: []string{s3GatewayEndpoint},
 			})
 
@@ -239,7 +240,7 @@ var _ = Describe("Infrastructure tests", func() {
 
 		It("should successfully create and delete (migration from terraformer)", func() {
 			providerConfig := newProviderConfig(awsv1alpha1.VPC{
-				CIDR:             pointer.StringPtr(vpcCIDR),
+				CIDR:             pointer.String(vpcCIDR),
 				GatewayEndpoints: []string{s3GatewayEndpoint},
 			})
 
@@ -429,7 +430,7 @@ var _ = Describe("Infrastructure tests", func() {
 
 		It("should fail creation but succeed deletion (flow)", func() {
 			providerConfig := newProviderConfig(awsv1alpha1.VPC{
-				CIDR: pointer.StringPtr(vpcCIDR),
+				CIDR: pointer.String(vpcCIDR),
 			})
 
 			namespaceName, err := generateNamespaceName()
@@ -655,7 +656,7 @@ func runTest(ctx context.Context, log logr.Logger, c client.Client, namespaceNam
 	infraCopy := infra.DeepCopy()
 	metav1.SetMetaDataAnnotation(&infra.ObjectMeta, "gardener.cloud/operation", "reconcile")
 	if flow == fuMigrateFromTerraformer {
-		metav1.SetMetaDataAnnotation(&infra.ObjectMeta, infrastructure.AnnotationKeyUseFlow, "true")
+		metav1.SetMetaDataAnnotation(&infra.ObjectMeta, awsapi.AnnotationKeyUseFlow, "true")
 	}
 	Expect(c.Patch(ctx, infra, client.MergeFrom(infraCopy))).To(Succeed())
 
@@ -749,7 +750,7 @@ func newInfrastructure(namespace string, providerConfig *awsv1alpha1.Infrastruct
 		},
 	}
 	if useFlow {
-		infra.Annotations = map[string]string{infrastructure.AnnotationKeyUseFlow: "true"}
+		infra.Annotations = map[string]string{awsapi.AnnotationKeyUseFlow: "true"}
 	}
 	return infra, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Reconciliation and deletion of infrastructure resources are managed directly with a graph flow and using AWS SDK client API instead of using Terraformer.
Migration for existing infrastructure resources is implemented, too.

**Which issue(s) this PR fixes**:
Fixes #457

**Special notes for your reviewer**:
Currently, to activate the flow based infra management, the shoot or the infrastructure resource must be annotated with
`aws.provider.extensions.gardener.cloud/use-flow=true`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Flow-based infrastructure reconciliation without Terraformer
```
