### PR TITLE
Drop ccm memory limits

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -13,8 +13,6 @@ resources:
   requests:
     cpu: 24m
     memory: 100Mi
-  limits:
-    memory: 2.6Gi
 tlsCipherSuites: []
 secrets:
   server: cloud-controller-manager-server


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Remove the memory limits of the aws cloud-controller-manager as we saw rare cases were the limits are not sufficient during startup phase.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The memory limits of the aws cloud-controller-manager has been removed.
```
