### PR TITLE
Fix deployment strategy of aws-custom-route-controller

### DIFF
--- a/charts/internal/seed-controlplane/charts/aws-custom-route-controller/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/aws-custom-route-controller/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     matchLabels:
       app: kubernetes
       role: aws-custom-route-controller
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:
@@ -32,8 +34,6 @@ spec:
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}
     spec:
-      strategy:
-        type: Recreate
       priorityClassName: gardener-system-300
       serviceAccountName: aws-custom-route-controller
       terminationGracePeriodSeconds: 5


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:
Fixed wrong placement of the deployment strategy in the deployment spec.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
