### PR TITLE
Removes support for kubernetes < 1.17 for AWS extension provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.19 | 1.19.0+     | [![Gardener v1.19 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.19%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.19%20AWS) |
 | Kubernetes 1.18 | 1.18.0+     | [![Gardener v1.18 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.18%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.18%20AWS) |
 | Kubernetes 1.17 | 1.17.0+     | [![Gardener v1.17 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.17%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.17%20AWS) |
-| Kubernetes 1.16 | 1.16.0+     | [![Gardener v1.16 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.16%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.16%20AWS) |
-| Kubernetes 1.15 | 1.15.0+     | [1] |
-
-[1] Conformance tests are still executed and validated, unfortunately [no longer shown in TestGrid](https://github.com/kubernetes/test-infra/pull/18509#issuecomment-668204180).
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -5,10 +5,6 @@ images:
   tag: "v2.18.1"
 
 - name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/kubernetes
-  repository: k8s.gcr.io/hyperkube
-  targetVersion: "< 1.17"
-- name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-aws
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
   tag: "v1.17.17"

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
@@ -38,12 +38,7 @@ spec:
         image: {{ index .Values.images "cloud-controller-manager" }}
         imagePullPolicy: IfNotPresent
         command:
-        {{- if semverCompare "< 1.17" .Values.kubernetesVersion }}
-        - /hyperkube
-        - cloud-controller-manager
-        {{- else }}
         - /aws-cloud-controller-manager
-        {{- end }}
         - --allocate-node-cidrs=true
         - --cloud-provider=aws
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -1,6 +1,6 @@
 replicas: 1
 clusterName: shoot-foo-bar
-kubernetesVersion: 1.7.5
+kubernetesVersion: 1.23.9
 podNetwork: 192.168.0.0/16
 podAnnotations: {}
 podLabels: {}

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -368,7 +368,7 @@ spec:
     nodes: 10.250.0.0/16
     type: calico
   kubernetes:
-    version: 1.16.1
+    version: 1.24.3
   maintenance:
     autoUpdate:
       kubernetesVersion: true
@@ -435,7 +435,7 @@ spec:
     nodes: 10.250.0.0/16
     type: calico
   kubernetes:
-    version: 1.16.1
+    version: 1.24.3
   maintenance:
     autoUpdate:
       kubernetesVersion: true

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -44,9 +44,9 @@ spec:
   type: aws
   kubernetes:
     versions:
-    - version: 1.16.1
-    - version: 1.16.0
-      expirationDate: "2020-04-05T01:02:03Z"
+    - version: 1.24.3
+    - version: 1.23.8
+      expirationDate: "2022-10-31T23:59:59Z"
   machineImages:
   - name: coreos
     versions:

--- a/example/10-fake-shoot-controlplane.yaml
+++ b/example/10-fake-shoot-controlplane.yaml
@@ -126,9 +126,8 @@ spec:
     spec:
       containers:
       - command:
-        - /hyperkube
-        - apiserver
-        - --enable-admission-plugins=Priority,NamespaceLifecycle,LimitRanger,ServiceAccount,NodeRestriction,DefaultStorageClass,Initializers,DefaultTolerationSeconds,ResourceQuota,StorageObjectInUseProtection,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+        - /usr/local/bin/kube-apiserver
+        - --enable-admission-plugins=Priority,NamespaceLifecycle,LimitRanger,ServiceAccount,NodeRestriction,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota,StorageObjectInUseProtection,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
         - --disable-admission-plugins=PersistentVolumeLabel
         - --allow-privileged=true
         - --anonymous-auth=false
@@ -147,7 +146,7 @@ spec:
         - --tls-cert-file=/srv/kubernetes/apiserver/kube-apiserver.crt
         - --tls-private-key-file=/srv/kubernetes/apiserver/kube-apiserver.key
         - --v=2
-        image: k8s.gcr.io/hyperkube:v1.15.6
+        image: registry.k8s.io/kube-apiserver:v1.17.17
         imagePullPolicy: IfNotPresent
         name: kube-apiserver
         ports:

--- a/example/30-controlplane.yaml
+++ b/example/30-controlplane.yaml
@@ -36,7 +36,7 @@ spec:
       networking:
         pods: 10.250.0.0/19
       kubernetes:
-        version: 1.15.4
+        version: 1.24.3
       hibernation:
         enabled: false
     status:

--- a/example/30-controlplaneexposure.yaml
+++ b/example/30-controlplaneexposure.yaml
@@ -17,7 +17,7 @@ spec:
       networking:
         pods: 10.250.0.0/19
       kubernetes:
-        version: 1.15.4
+        version: 1.24.3
       hibernation:
         enabled: false
     status:

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -38,7 +38,7 @@ spec:
     kind: Shoot
     spec:
       kubernetes:
-        version: 1.15.4
+        version: 1.24.3
     status:
       lastOperation:
         state: Succeeded

--- a/hack/api-reference/api.json
+++ b/hack/api-reference/api.json
@@ -9,7 +9,7 @@
     "externalPackages": [
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         }
     ],
     "typeDisplayNamePrefixOverrides": {

--- a/hack/api-reference/config.json
+++ b/hack/api-reference/config.json
@@ -17,7 +17,7 @@
         },
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "github.com/gardener/gardener/extensions/pkg/apis/config",

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -157,7 +157,7 @@ var _ = Describe("ValuesProvider", func() {
 						Pods: &cidr,
 					},
 					Kubernetes: gardencorev1beta1.Kubernetes{
-						Version: "1.15.4",
+						Version: "1.17.1",
 					},
 				},
 			},
@@ -376,7 +376,7 @@ var _ = Describe("ValuesProvider", func() {
 				aws.CloudControllerManagerName:   enabledTrue,
 				aws.AWSCustomRouteControllerName: enabledFalse,
 				aws.CSINodeName: utils.MergeMaps(enabledFalse, map[string]interface{}{
-					"kubernetesVersion": "1.15.4",
+					"kubernetesVersion": "1.17.1",
 					"vpaEnabled":        false,
 					"webhookConfig": map[string]interface{}{
 						"url":      "https://" + aws.CSISnapshotValidation + "." + cp.Namespace + "/volumesnapshot",

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -397,11 +397,10 @@ func ensureKubeControllerManagerVolumeMounts(c *corev1.Container, version string
 	}
 
 	c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, cloudProviderConfigVolumeMount)
-	if mustMountEtcSSLFolder(version) {
-		c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, etcSSLVolumeMount)
-		// some distros have symlinks from /etc/ssl/certs to /usr/share/ca-certificates
-		c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, usrShareCaCertsVolumeMount)
-	}
+
+	c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, etcSSLVolumeMount)
+	// some distros have symlinks from /etc/ssl/certs to /usr/share/ca-certificates
+	c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, usrShareCaCertsVolumeMount)
 }
 
 func ensureKubeAPIServerVolumes(ps *corev1.PodSpec, csiEnabled, csiMigrationComplete bool) {
@@ -422,22 +421,10 @@ func ensureKubeControllerManagerVolumes(ps *corev1.PodSpec, version string, csiE
 	}
 
 	ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, cloudProviderConfigVolume)
-	if mustMountEtcSSLFolder(version) {
-		ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, etcSSLVolume)
-		// some distros have symlinks from /etc/ssl/certs to /usr/share/ca-certificates
-		ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, usrShareCaCertsVolume)
-	}
-}
 
-// Beginning with 1.17 Gardener no longer uses the hyperkube image for the Kubernetes control plane components.
-// The hyperkube image contained all the well-known root CAs, but the dedicated images don't. This is why we
-// mount the /etc/ssl folder from the host here.
-func mustMountEtcSSLFolder(version string) bool {
-	k8sVersionAtLeast117, err := versionutils.CompareVersions(version, ">=", "1.17")
-	if err != nil {
-		return false
-	}
-	return k8sVersionAtLeast117
+	ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, etcSSLVolume)
+	// some distros have symlinks from /etc/ssl/certs to /usr/share/ca-certificates
+	ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, usrShareCaCertsVolume)
 }
 
 func (e *ensurer) ensureChecksumAnnotations(ctx context.Context, template *corev1.PodTemplateSpec, namespace string, csiEnabled, csiMigrationComplete bool) error {

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -62,17 +62,6 @@ var _ = Describe("Ensurer", func() {
 		ctx  = context.TODO()
 
 		dummyContext   = gcontext.NewGardenContext(nil, nil)
-		eContextK8s116 = gcontext.NewInternalGardenContext(
-			&extensionscontroller.Cluster{
-				Shoot: &gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.16.0",
-						},
-					},
-				},
-			},
-		)
 		eContextK8s117 = gcontext.NewInternalGardenContext(
 			&extensionscontroller.Cluster{
 				Shoot: &gardencorev1beta1.Shoot{
@@ -215,16 +204,6 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		It("should add missing elements to kube-apiserver deployment (k8s < 1.17)", func() {
-			client.EXPECT().Get(ctx, secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
-			client.EXPECT().Get(ctx, cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
-
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s116, dep, nil)
-			Expect(err).To(Not(HaveOccurred()))
-
-			checkKubeAPIServerDeployment(dep, annotations, "1.16.0", false)
-		})
-
 		It("should add missing elements to kube-apiserver deployment (k8s = 1.17)", func() {
 			client.EXPECT().Get(ctx, secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 			client.EXPECT().Get(ctx, cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
@@ -294,10 +273,10 @@ var _ = Describe("Ensurer", func() {
 			client.EXPECT().Get(ctx, secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 			client.EXPECT().Get(ctx, cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
 
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s116, dep, nil)
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s117, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, annotations, "1.16.0", false)
+			checkKubeAPIServerDeployment(dep, annotations, "1.17.0", false)
 		})
 	})
 
@@ -333,16 +312,6 @@ var _ = Describe("Ensurer", func() {
 			ensurer = NewEnsurer(logger)
 			err := ensurer.(inject.Client).InjectClient(client)
 			Expect(err).To(Not(HaveOccurred()))
-		})
-
-		It("should add missing elements to kube-controller-manager deployment (k8s < 1.17)", func() {
-			client.EXPECT().Get(ctx, secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
-			client.EXPECT().Get(ctx, cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
-
-			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s116, dep, nil)
-			Expect(err).To(Not(HaveOccurred()))
-
-			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, "1.16.0", false)
 		})
 
 		It("should add missing elements to kube-controller-manager deployment (k8s = 1.17)", func() {
@@ -420,10 +389,10 @@ var _ = Describe("Ensurer", func() {
 			client.EXPECT().Get(ctx, secretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 			client.EXPECT().Get(ctx, cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
 
-			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s116, dep, nil)
+			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s117, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, "1.16.0", false)
+			checkKubeControllerManagerDeployment(dep, annotations, kubeControllerManagerLabels, "1.17.0", false)
 		})
 	})
 
@@ -710,7 +679,6 @@ done
 				Expect(opts).To(Equal(newUnitOptions))
 			},
 
-			Entry("kubelet version < 1.17", eContextK8s116, semver.MustParse("1.16.0"), "aws", false),
 			Entry("1.17 <= kubelet version < 1.18", eContextK8s117, semver.MustParse("1.17.0"), "aws", false),
 			Entry("1.18 <= kubelet version < 1.23", eContextK8s118, semver.MustParse("1.18.0"), "external", true),
 			Entry("kubelet version >= 1.23", eContextK8s118, semver.MustParse("1.23.0"), "external", false),
@@ -921,7 +889,6 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string
 }
 
 func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, labels map[string]string, k8sVersion string, needsCSIMigrationCompletedFeatureGates bool) {
-	k8sVersionLessThan117, _ := version.CompareVersions(k8sVersion, "<", "1.17")
 	k8sVersionAtLeast118, _ := version.CompareVersions(k8sVersion, ">=", "1.18")
 	k8sVersionAtLeast121, _ := version.CompareVersions(k8sVersion, ">=", "1.21")
 
@@ -940,12 +907,10 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, annotations, l
 		Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
 		Expect(dep.Spec.Template.Labels).To(Equal(labels))
 		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderConfigVolume))
-		if !k8sVersionLessThan117 {
-			Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
-			Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
-			Expect(c.VolumeMounts).To(ContainElement(usrShareCaCertsVolumeMount))
-			Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(usrShareCaCertsVolume))
-		}
+		Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
+		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
+		Expect(c.VolumeMounts).To(ContainElement(usrShareCaCertsVolumeMount))
+		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(usrShareCaCertsVolume))
 		if k8sVersionAtLeast118 {
 			Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationAWS=true"))
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-provider-aws/issues/595

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
provider-aws no longer supports Shoots with Кubernetes version < 1.17.
```
