### PR TITLE
Add route table associations for VPC endpoints

### DIFF
--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -279,6 +279,14 @@ resource "aws_route_table_association" "routetable_private_utility_z{{ $index }}
   subnet_id      = aws_subnet.nodes_z{{ $index }}.id
   route_table_id = aws_route_table.routetable_private_utility_z{{ $index }}.id
 }
+
+{{ range $ep := $.vpc.gatewayEndpoints }}
+resource "aws_vpc_endpoint_route_table_association" "vpc_gwep_{{ $ep }}_z{{ $index }}" {
+  route_table_id  = aws_route_table.routetable_private_utility_z{{ $index }}.id
+  vpc_endpoint_id = aws_vpc_endpoint.vpc_gwep_{{ $ep }}.id
+}
+{{end}}
+
 {{end}}
 
 //=====================================================================

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -1000,6 +1000,13 @@ func verifyCreation(
 						"SubnetId": PointTo(Equal(internalSubnetID)),
 					})),
 				))
+				var prefixListId *string
+				for _, r := range routeTable.Routes {
+					if r.DestinationPrefixListId != nil {
+						prefixListId = r.DestinationPrefixListId
+						break
+					}
+				}
 				Expect(routeTable.Routes).To(ConsistOf([]*ec2.Route{
 					{
 						DestinationCidrBlock: cidr,
@@ -1012,6 +1019,12 @@ func verifyCreation(
 						NatGatewayId:         describeNatGatewaysOutput.NatGateways[0].NatGatewayId,
 						Origin:               awssdk.String("CreateRoute"),
 						State:                awssdk.String("active"),
+					},
+					{
+						DestinationPrefixListId: prefixListId,
+						GatewayId:               describeVpcEndpointsOutput.VpcEndpoints[0].VpcEndpointId,
+						Origin:                  awssdk.String("CreateRoute"),
+						State:                   awssdk.String("active"),
 					},
 				}))
 				Expect(routeTable.Tags).To(ConsistOf([]*ec2.Tag{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
The traffic to/from VPC endpoints like S3 is now routed internally by adding route table associations for them.

**Which issue(s) this PR fixes**:
Fixes #607

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add route table associations for VPC endpoints
```
