### PR TITLE
Enable custom aws route controller manager if no provider config is specified.

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -667,25 +667,25 @@ func (c *controlPlaneMutator) Mutate(ctx context.Context, new, old client.Object
 		if greaterEqual122 {
 			switch x.Name {
 			case cluster.Shoot.Name:
+				config := &awsv1alpha1.ControlPlaneConfig{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: awsv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "ControlPlaneConfig",
+					},
+				}
 				if x.Spec.ProviderConfig != nil && x.Spec.ProviderConfig.Raw != nil {
-					config := &awsv1alpha1.ControlPlaneConfig{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: awsv1alpha1.SchemeGroupVersion.String(),
-							Kind:       "ControlPlaneConfig",
-						},
-					}
 					if _, _, err := decoder.Decode(x.Spec.ProviderConfig.Raw, nil, config); err != nil {
 						return err
 					}
-					if config.CloudControllerManager == nil {
-						config.CloudControllerManager = &awsv1alpha1.CloudControllerManagerConfig{}
-					}
-					if config.CloudControllerManager.UseCustomRouteController == nil {
-						extensionswebhook.LogMutation(c.logger, x.Kind, x.Namespace, x.Name)
-						config.CloudControllerManager.UseCustomRouteController = pointer.Bool(true)
-						x.Spec.ProviderConfig = &runtime.RawExtension{
-							Object: config,
-						}
+				}
+				if config.CloudControllerManager == nil {
+					config.CloudControllerManager = &awsv1alpha1.CloudControllerManagerConfig{}
+				}
+				if config.CloudControllerManager.UseCustomRouteController == nil {
+					extensionswebhook.LogMutation(c.logger, x.Kind, x.Namespace, x.Name)
+					config.CloudControllerManager.UseCustomRouteController = pointer.Bool(true)
+					x.Spec.ProviderConfig = &runtime.RawExtension{
+						Object: config,
 					}
 				}
 			}

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -838,6 +838,20 @@ done
 			Expect(*controlPlane.Spec.ProviderConfig.Object.(*awsv1alpha1.ControlPlaneConfig).CloudControllerManager.UseCustomRouteController).To(BeTrue())
 		})
 
+		It("should enable for kubernetes >= 1.22 without provider config", func() {
+			controlPlane.Spec.DefaultSpec = extensionsv1alpha1.DefaultSpec{}
+			oldControlPlane := controlPlane.DeepCopy()
+
+			client.EXPECT().Get(ctx, clusterKey, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(newCluster))
+
+			err := mutator.Mutate(ctx, controlPlane, nil)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(oldControlPlane).To(Not(Equal(controlPlane)))
+			Expect(controlPlane.Spec.ProviderConfig.Object).ToNot(BeNil())
+			Expect(*controlPlane.Spec.ProviderConfig.Object.(*awsv1alpha1.ControlPlaneConfig).CloudControllerManager).ToNot(BeNil())
+			Expect(*controlPlane.Spec.ProviderConfig.Object.(*awsv1alpha1.ControlPlaneConfig).CloudControllerManager.UseCustomRouteController).To(BeTrue())
+		})
+
 		It("should not enable on update", func() {
 			oldControlPlane := controlPlane.DeepCopy()
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform aws

**What this PR does / why we need it**:
Enable custom aws route controller manager if no provider config is specified.

The custom aws route controller manager is essential to the shoot cluster working without overlay network. Therefore, it needs to be enabled regardless if there is a provider configuration or not. Otherwise, shoot clusters will get no overlay, but no pod routes.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Correctly enable aws custom route controller if required to ensure overlay free cluster operation.
```
