### PR TITLE
[release-v1.38] Automated cherry pick of #612: Enable custom aws route controller manager if no provider config is specified.

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -680,25 +680,25 @@ func (c *controlPlaneMutator) Mutate(ctx context.Context, new, old client.Object
 		if greaterEqual122 {
 			switch x.Name {
 			case cluster.Shoot.Name:
+				config := &awsv1alpha1.ControlPlaneConfig{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: awsv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "ControlPlaneConfig",
+					},
+				}
 				if x.Spec.ProviderConfig != nil && x.Spec.ProviderConfig.Raw != nil {
-					config := &awsv1alpha1.ControlPlaneConfig{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: awsv1alpha1.SchemeGroupVersion.String(),
-							Kind:       "ControlPlaneConfig",
-						},
-					}
 					if _, _, err := decoder.Decode(x.Spec.ProviderConfig.Raw, nil, config); err != nil {
 						return err
 					}
-					if config.CloudControllerManager == nil {
-						config.CloudControllerManager = &awsv1alpha1.CloudControllerManagerConfig{}
-					}
-					if config.CloudControllerManager.UseCustomRouteController == nil {
-						extensionswebhook.LogMutation(c.logger, x.Kind, x.Namespace, x.Name)
-						config.CloudControllerManager.UseCustomRouteController = pointer.Bool(true)
-						x.Spec.ProviderConfig = &runtime.RawExtension{
-							Object: config,
-						}
+				}
+				if config.CloudControllerManager == nil {
+					config.CloudControllerManager = &awsv1alpha1.CloudControllerManagerConfig{}
+				}
+				if config.CloudControllerManager.UseCustomRouteController == nil {
+					extensionswebhook.LogMutation(c.logger, x.Kind, x.Namespace, x.Name)
+					config.CloudControllerManager.UseCustomRouteController = pointer.Bool(true)
+					x.Spec.ProviderConfig = &runtime.RawExtension{
+						Object: config,
 					}
 				}
 			}

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -870,6 +870,20 @@ done
 			Expect(*controlPlane.Spec.ProviderConfig.Object.(*awsv1alpha1.ControlPlaneConfig).CloudControllerManager.UseCustomRouteController).To(BeTrue())
 		})
 
+		It("should enable for kubernetes >= 1.22 without provider config", func() {
+			controlPlane.Spec.DefaultSpec = extensionsv1alpha1.DefaultSpec{}
+			oldControlPlane := controlPlane.DeepCopy()
+
+			client.EXPECT().Get(ctx, clusterKey, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(newCluster))
+
+			err := mutator.Mutate(ctx, controlPlane, nil)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(oldControlPlane).To(Not(Equal(controlPlane)))
+			Expect(controlPlane.Spec.ProviderConfig.Object).ToNot(BeNil())
+			Expect(*controlPlane.Spec.ProviderConfig.Object.(*awsv1alpha1.ControlPlaneConfig).CloudControllerManager).ToNot(BeNil())
+			Expect(*controlPlane.Spec.ProviderConfig.Object.(*awsv1alpha1.ControlPlaneConfig).CloudControllerManager.UseCustomRouteController).To(BeTrue())
+		})
+
 		It("should not enable on update", func() {
 			oldControlPlane := controlPlane.DeepCopy()
 


### PR DESCRIPTION
/area/networking
/kind/bug

Cherry pick of #612 on release-v1.38.

#612: Enable custom aws route controller manager if no provider config is specified.

**Release Notes:**
```other operator
Correctly enable aws custom route controller if required to ensure overlay free cluster operation.
```