### PR TITLE
Scale down if custom-route-controller is disabled after creation

### DIFF
--- a/charts/internal/seed-controlplane/values.yaml
+++ b/charts/internal/seed-controlplane/values.yaml
@@ -5,5 +5,5 @@ cloud-controller-manager:
   enabled: true
 csi-driver-controller:
   enabled: false
-aws-custom-routes-controller:
+aws-custom-route-controller:
   enabled: false

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -533,7 +533,7 @@ func getCRCChartValues(
 
 	values := map[string]interface{}{
 		"enabled":     enabled,
-		"replicas":    extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
+		"replicas":    extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown || !enabled, 1),
 		"clusterName": cp.Namespace,
 		"podNetwork":  extensionscontroller.GetPodNetwork(cluster),
 		"podAnnotations": map[string]interface{}{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:
If a shoot is created with `aws-custom-route-controller` enabled and the controller is disabled later by setting `cloudControllerManager.useCustomRouteController=false` in the `ControlPlaneConfig`, the deployment is not removed.
The control plane deployment cannot deal with such cases. Looks like a minor edge case to me, therefore the fix just scales down the deployment.

Additionally a non-relevant typo was fixed in `charts/internal/seed-controlplane/values.yaml` 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
