### PR TITLE
Scale down of aws-custom-route-controller

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -530,10 +530,9 @@ func getCRCChartValues(
 	enabled := cpConfig.CloudControllerManager != nil &&
 		cpConfig.CloudControllerManager.UseCustomRouteController != nil &&
 		*cpConfig.CloudControllerManager.UseCustomRouteController
-
 	values := map[string]interface{}{
 		"enabled":     enabled,
-		"replicas":    extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown || !enabled, 1),
+		"replicas":    extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 		"clusterName": cp.Namespace,
 		"podNetwork":  extensionscontroller.GetPodNetwork(cluster),
 		"podAnnotations": map[string]interface{}{
@@ -543,6 +542,9 @@ func getCRCChartValues(
 			v1beta1constants.LabelPodMaintenanceRestart: "true",
 		},
 		"region": cp.Spec.Region,
+	}
+	if !enabled {
+		values["replicas"] = 0
 	}
 
 	return values, nil

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -260,7 +260,7 @@ var _ = Describe("ValuesProvider", func() {
 				},
 				"region":      "europe",
 				"enabled":     false,
-				"replicas":    1,
+				"replicas":    0,
 				"clusterName": "test",
 				"podNetwork":  "10.250.0.0/19",
 				"podAnnotations": map[string]interface{}{
@@ -326,6 +326,8 @@ var _ = Describe("ValuesProvider", func() {
 		It("should return correct control plane chart values (k8s >= 1.18) and custom route controller enabled", func() {
 			setCustomRouteControllerEnabled(cp)
 			crcChartValues["enabled"] = true
+			crcChartValues["replicas"] = 1
+
 			values, err := vp.GetControlPlaneChartValues(ctx, cp, clusterK8sAtLeast118, fakeSecretsManager, checksums, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-aws/issues/628

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
