### PR TITLE
Add validation for `domain-name` of custom dhcp options used in VPCs.

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -262,15 +262,8 @@ func (c *Client) GetDHCPOptions(ctx context.Context, vpcID string) (map[string]s
 
 	if len(describeDhcpOptionsOutput.DhcpOptions) > 0 {
 		for _, dhcpConfiguration := range describeDhcpOptionsOutput.DhcpOptions[0].DhcpConfigurations {
-			if len(dhcpConfiguration.Values) > 0 {
-				if *dhcpConfiguration.Key == "domain-name-servers" {
-					result[*dhcpConfiguration.Key] = ""
-					for _, value := range dhcpConfiguration.Values {
-						if *value.Value == "AmazonProvidedDNS" {
-							result[*dhcpConfiguration.Key] = "AmazonProvidedDNS"
-						}
-					}
-				} else {
+			if *dhcpConfiguration.Key == "domain-name" && dhcpConfiguration.Values != nil {
+				if len(dhcpConfiguration.Values) > 0 {
 					result[*dhcpConfiguration.Key] = *dhcpConfiguration.Values[0].Value
 				}
 			}

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -264,10 +264,8 @@ func (c *Client) GetDHCPOptions(ctx context.Context, vpcID string) (map[string]s
 	result := make(map[string]string)
 	if len(describeDhcpOptionsOutput.DhcpOptions) > 0 {
 		for _, dhcpConfiguration := range describeDhcpOptionsOutput.DhcpOptions[0].DhcpConfigurations {
-			if dhcpConfiguration.Key != nil && *dhcpConfiguration.Key == "domain-name" && dhcpConfiguration.Values != nil {
-				if len(dhcpConfiguration.Values) > 0 && dhcpConfiguration.Values[0].Value != nil {
-					result[*dhcpConfiguration.Key] = *dhcpConfiguration.Values[0].Value
-				}
+			if dhcpConfiguration.Key != nil && *dhcpConfiguration.Key == "domain-name" && len(dhcpConfiguration.Values) > 0 && dhcpConfiguration.Values[0].Value != nil {
+				result[*dhcpConfiguration.Key] = *dhcpConfiguration.Values[0].Value
 			}
 		}
 	}

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -261,9 +261,18 @@ func (c *Client) GetDHCPOptions(ctx context.Context, vpcID string) (map[string]s
 	}
 
 	if len(describeDhcpOptionsOutput.DhcpOptions) > 0 {
-		for _, DhcpConfiguration := range describeDhcpOptionsOutput.DhcpOptions[0].DhcpConfigurations {
-			if len(DhcpConfiguration.Values) > 0 {
-				result[*DhcpConfiguration.Key] = *DhcpConfiguration.Values[0].Value
+		for _, dhcpConfiguration := range describeDhcpOptionsOutput.DhcpOptions[0].DhcpConfigurations {
+			if len(dhcpConfiguration.Values) > 0 {
+				if *dhcpConfiguration.Key == "domain-name-servers" {
+					result[*dhcpConfiguration.Key] = ""
+					for _, value := range dhcpConfiguration.Values {
+						if *value.Value == "AmazonProvidedDNS" {
+							result[*dhcpConfiguration.Key] = "AmazonProvidedDNS"
+						}
+					}
+				} else {
+					result[*dhcpConfiguration.Key] = *dhcpConfiguration.Values[0].Value
+				}
 			}
 		}
 	}

--- a/pkg/aws/client/mock/mocks.go
+++ b/pkg/aws/client/mock/mocks.go
@@ -163,6 +163,21 @@ func (mr *MockInterfaceMockRecorder) GetAccountID(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountID", reflect.TypeOf((*MockInterface)(nil).GetAccountID), arg0)
 }
 
+// GetDHCPOptions mocks base method.
+func (m *MockInterface) GetDHCPOptions(arg0 context.Context, arg1 string) (map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDHCPOptions", arg0, arg1)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDHCPOptions indicates an expected call of GetDHCPOptions.
+func (mr *MockInterfaceMockRecorder) GetDHCPOptions(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDHCPOptions", reflect.TypeOf((*MockInterface)(nil).GetDHCPOptions), arg0, arg1)
+}
+
 // GetDNSHostedZones mocks base method.
 func (m *MockInterface) GetDNSHostedZones(arg0 context.Context) (map[string]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -36,6 +36,7 @@ type Interface interface {
 	GetAccountID(ctx context.Context) (string, error)
 	GetVPCInternetGateway(ctx context.Context, vpcID string) (string, error)
 	GetVPCAttribute(ctx context.Context, vpcID string, attribute string) (bool, error)
+	GetDHCPOptions(ctx context.Context, vpcID string) (map[string]string, error)
 	GetElasticIPsAssociationIDForAllocationIDs(ctx context.Context, allocationIDs []string) (map[string]*string, error)
 	GetNATGatewayAddressAllocations(ctx context.Context, shootNamespace string) (sets.String, error)
 

--- a/pkg/controller/infrastructure/configvalidator.go
+++ b/pkg/controller/infrastructure/configvalidator.go
@@ -132,13 +132,11 @@ func (c *configValidator) validateVPC(ctx context.Context, awsClient awsclient.I
 		return allErrs
 	}
 
-	if domainNameServers, ok := dhcpOptions["domain-name-servers"]; ok && domainNameServers == "AmazonProvidedDNS" {
-		if domainName, ok := dhcpOptions["domain-name"]; !ok {
-			allErrs = append(allErrs, field.Invalid(fldPath, vpcID, "domain-name needed when domain-name-servers are specified"))
-		} else {
-			if (region == "us-east-1" && domainName != "ec2.internal") || (region != "us-east-1" && domainName != region+".compute.internal") {
-				allErrs = append(allErrs, field.Invalid(fldPath, vpcID, fmt.Sprintf("Invalid domain name: %s", domainName)))
-			}
+	if domainName, ok := dhcpOptions["domain-name"]; !ok {
+		allErrs = append(allErrs, field.Invalid(fldPath, vpcID, "missing domain-name value"))
+	} else {
+		if (region == "us-east-1" && domainName != "ec2.internal") || (region != "us-east-1" && domainName != region+".compute.internal") {
+			allErrs = append(allErrs, field.Invalid(fldPath, vpcID, fmt.Sprintf("invalid domain name: %s", domainName)))
 		}
 	}
 

--- a/pkg/controller/infrastructure/configvalidator.go
+++ b/pkg/controller/infrastructure/configvalidator.go
@@ -133,11 +133,9 @@ func (c *configValidator) validateVPC(ctx context.Context, awsClient awsclient.I
 	}
 
 	if domainName, ok := dhcpOptions["domain-name"]; !ok {
-		allErrs = append(allErrs, field.Invalid(fldPath, vpcID, "missing domain-name value"))
-	} else {
-		if (region == "us-east-1" && domainName != "ec2.internal") || (region != "us-east-1" && domainName != region+".compute.internal") {
-			allErrs = append(allErrs, field.Invalid(fldPath, vpcID, fmt.Sprintf("invalid domain name: %s", domainName)))
-		}
+		allErrs = append(allErrs, field.Invalid(fldPath, vpcID, "missing domain-name value in DHCP options used by the VPC"))
+	} else if (region == "us-east-1" && domainName != "ec2.internal") || (region != "us-east-1" && domainName != region+".compute.internal") {
+		allErrs = append(allErrs, field.Invalid(fldPath, vpcID, fmt.Sprintf("invalid domain-name specified in DHCP options used by VPC: %s", domainName)))
 	}
 
 	return allErrs


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
This PR adds validation for `domain-name` of custom dhcp options used in VPCs.

**Which issue(s) this PR fixes**:
Fixes #615

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Added validation for `domain-name` of custom dhcp options used in VPCs
```
