### PR TITLE
fix crc deployment

### DIFF
--- a/charts/internal/seed-controlplane/charts/aws-custom-route-controller/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/aws-custom-route-controller/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
               items:
               - key: kubeconfig
                 path: kubeconfig
-              name: {{ .Values.genericTokenKubeconfigSecretName }}
+              name: {{ .Values.global.genericTokenKubeconfigSecretName }}
               optional: false
           - secret:
               items:

--- a/charts/internal/seed-controlplane/charts/aws-custom-route-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/aws-custom-route-controller/values.yaml
@@ -9,9 +9,6 @@ podLabels: {}
 
 providerName: provider-foo
 
-# injected by generic worker actuator
-genericTokenKubeconfigSecretName: generic-token-kubeconfig
-
 metricsPort: 10258
 healthzPort: 10259
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:

Fixes an issue with CRC's kubeconfig secret having incorrect name.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
