### PR TITLE
Do not fail a request for a Shoot from the core.gardener.cloud/v1alpha1 API

### DIFF
--- a/charts/gardener-extension-admission-aws/charts/application/templates/mutatingwebhook-mutator.yaml
+++ b/charts/gardener-extension-admission-aws/charts/application/templates/mutatingwebhook-mutator.yaml
@@ -8,7 +8,6 @@ webhooks:
   - apiGroups:
     - "core.gardener.cloud"
     apiVersions:
-    - v1alpha1
     - v1beta1
     operations:
     - CREATE
@@ -16,6 +15,7 @@ webhooks:
     resources:
     - shoots
   failurePolicy: Fail
+  matchPolicy: Equivalent
   objectSelector:
     {{- if .Values.global.webhookConfig.useObjectSelector }}
     matchLabels:

--- a/charts/gardener-extension-admission-aws/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-aws/charts/application/templates/rbac.yaml
@@ -10,7 +10,6 @@ rules:
   - core.gardener.cloud
   resources:
   - cloudprofiles
-  - shoots
   verbs:
   - get
   - list

--- a/example/50-mutatingwebhookconfiguration.yaml
+++ b/example/50-mutatingwebhookconfiguration.yaml
@@ -8,7 +8,6 @@ webhooks:
   - apiGroups:
     - "core.gardener.cloud"
     apiVersions:
-    - v1alpha1
     - v1beta1
     operations:
     - CREATE
@@ -16,6 +15,7 @@ webhooks:
     resources:
     - shoots
   failurePolicy: Fail
+  matchPolicy: Equivalent
   # Please make sure you are running `gardener@v1.42` or later before enabling this object selector.
   objectSelector:
     matchLabels:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind regression
/kind bug
/platform aws

**What this PR does / why we need it**:
After https://github.com/gardener/gardener-extension-provider-aws/pull/635 CREATE/UPDATE requests for Shoots from the core.gardener.cloud/v1alpha1 API fail with:
```
$ k create -f ~/foo.yaml
Error from server: error when creating "foo.yaml": admission webhook "mutation.aws.provider.extensions.gardener.cloud" denied the request: unexpected request kind core.gardener.cloud/v1alpha1, Kind=Shoot
```

This PR removes the v1alpha1 from the mutatingwebhook spec and relies on the `matchPolicy: Equivalent` field of the webhook that will take care to convert the v1alpha1 obj to v1beta1. Ref https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy

Similar to https://github.com/gardener/gardener-extension-provider-alicloud/pull/341

This PR additionally removes RBAC rule for `shoots` as admission-aws does not get/list/watch Shoots.

**Which issue(s) this PR fixes**:
See above

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing admission-aws to fail CREATE/UPDATE request to the core.gardener.cloud/v1alpha1 API is now fixed.
```
