### PR TITLE
[release-v1.40] Automated cherry pick of #657: Do not fail a request for a Shoot from the core.gardener.cloud/v1alpha1 API

### DIFF
--- a/charts/gardener-extension-admission-aws/charts/application/templates/mutatingwebhook-mutator.yaml
+++ b/charts/gardener-extension-admission-aws/charts/application/templates/mutatingwebhook-mutator.yaml
@@ -8,7 +8,6 @@ webhooks:
   - apiGroups:
     - "core.gardener.cloud"
     apiVersions:
-    - v1alpha1
     - v1beta1
     operations:
     - CREATE
@@ -16,6 +15,7 @@ webhooks:
     resources:
     - shoots
   failurePolicy: Fail
+  matchPolicy: Equivalent
   objectSelector:
     {{- if .Values.global.webhookConfig.useObjectSelector }}
     matchLabels:

--- a/charts/gardener-extension-admission-aws/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-aws/charts/application/templates/rbac.yaml
@@ -10,7 +10,6 @@ rules:
   - core.gardener.cloud
   resources:
   - cloudprofiles
-  - shoots
   verbs:
   - get
   - list

--- a/example/50-mutatingwebhookconfiguration.yaml
+++ b/example/50-mutatingwebhookconfiguration.yaml
@@ -8,7 +8,6 @@ webhooks:
   - apiGroups:
     - "core.gardener.cloud"
     apiVersions:
-    - v1alpha1
     - v1beta1
     operations:
     - CREATE
@@ -16,6 +15,7 @@ webhooks:
     resources:
     - shoots
   failurePolicy: Fail
+  matchPolicy: Equivalent
   # Please make sure you are running `gardener@v1.42` or later before enabling this object selector.
   objectSelector:
     matchLabels:


### PR DESCRIPTION
/area/quality
/kind/bug
/kind/regression

Cherry pick of #657 on release-v1.40.

#657: Do not fail a request for a Shoot from the core.gardener.cloud/v1alpha1 API

**Release Notes:**
```bugfix operator
An issue causing admission-aws to fail CREATE/UPDATE requests for Shoots from the `core.gardener.cloud/v1alpha1` API is now fixed.
```