### PR TITLE
[release-v1.40] Automated cherry pick of #660: If machine image architecture is nil consider its architecture amd64

### DIFF
--- a/pkg/apis/aws/helper/helper.go
+++ b/pkg/apis/aws/helper/helper.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 
 	api "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"k8s.io/utils/pointer"
 )
 
@@ -86,6 +88,9 @@ func FindSubnetForPurposeAndZone(subnets []api.Subnet, purpose, zone string) (*a
 // found then an error will be returned.
 func FindMachineImage(machineImages []api.MachineImage, name, version string, arch *string) (*api.MachineImage, error) {
 	for _, machineImage := range machineImages {
+		if machineImage.Architecture == nil {
+			machineImage.Architecture = pointer.String(v1beta1constants.ArchitectureAMD64)
+		}
 		if machineImage.Name == name && machineImage.Version == version && pointer.StringEqual(arch, machineImage.Architecture) {
 			return &machineImage, nil
 		}

--- a/pkg/apis/aws/helper/helper_test.go
+++ b/pkg/apis/aws/helper/helper_test.go
@@ -84,6 +84,7 @@ var _ = Describe("Helper", func() {
 		Entry("entry not found (no name)", []api.MachineImage{{Name: "bar", Version: "1.2.3"}}, "foo", "1.2.ś", pointer.String("foo"), nil, true),
 		Entry("entry not found (no version)", []api.MachineImage{{Name: "bar", Version: "1.2.3"}}, "foo", "1.2.3", pointer.String("foo"), nil, true),
 		Entry("entry not found (no architecture)", []api.MachineImage{{Name: "bar", Version: "1.2.3", Architecture: pointer.String("bar")}}, "foo", "1.2.3", pointer.String("foo"), nil, true),
+		Entry("entry exists if architecture is nil", []api.MachineImage{{Name: "bar", Version: "1.2.3"}}, "bar", "1.2.3", pointer.String("amd64"), &api.MachineImage{Name: "bar", Version: "1.2.3", Architecture: pointer.String("amd64")}, false),
 		Entry("entry exists", []api.MachineImage{{Name: "bar", Version: "1.2.3", Architecture: pointer.String("foo")}}, "bar", "1.2.3", pointer.String("foo"), &api.MachineImage{Name: "bar", Version: "1.2.3", Architecture: pointer.String("foo")}, false),
 	)
 


### PR DESCRIPTION
/area control-plane
/kind bug

Cherry pick of #660 on release-v1.40.

#660: If machine image architecture is nil consider its architecture amd64

**Release Notes:**
```other operator
NONE
```