### PR TITLE
Skip network mutation when shoot specs are equal

### DIFF
--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -17,6 +17,7 @@ package mutator
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	calicov1alpha1 "github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/v1alpha1"
 	awsv1alpha1 "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
@@ -69,6 +70,11 @@ func (s *shoot) Mutate(ctx context.Context, new, old client.Object) error {
 	}
 
 	if oldShoot != nil && isShootInMigrationOrRestorePhase(shoot) {
+		return nil
+	}
+
+	// Skip if specs are matching
+	if oldShoot != nil && reflect.DeepEqual(shoot.Spec, oldShoot.Spec) {
 		return nil
 	}
 

--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -108,6 +108,16 @@ var _ = Describe("Shoot mutator", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(shoot).To(DeepEqual(shootExpected))
 			})
+
+			It("should return nil when shoot specs have not changed", func() {
+				shootWithAnnotations := shoot.DeepCopy()
+				shootWithAnnotations.Annotations = map[string]string{"foo": "bar"}
+				shootExpected := shootWithAnnotations.DeepCopy()
+
+				err := shootMutator.Mutate(ctx, shootWithAnnotations, shoot)
+				Expect(err).To(BeNil())
+				Expect(shootWithAnnotations).To(DeepEqual(shootExpected))
+			})
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:
Skip network mutation when shoot specs are equal. This may prevent deletion in some cases because the deletion confirmation annotation can not be added. See https://github.com/gardener/gardener/pull/7134 for such a case

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Skip network mutation when shoot specs are equal.
```
