### PR TITLE
Check for duplicate zone names in infrastructureconfig

### DIFF
--- a/pkg/apis/aws/validation/infrastructure.go
+++ b/pkg/apis/aws/validation/infrastructure.go
@@ -56,6 +56,7 @@ func validateInfrastructureConfigZones(oldInfra, infra *apisaws.InfrastructureCo
 		awsZones.Insert(awsZone.Name)
 	}
 
+	usedZones := sets.NewString()
 	for i, zone := range infra.Networks.Zones {
 		if oldInfra != nil && len(oldInfra.Networks.Zones) > i && oldInfra.Networks.Zones[i] == zone {
 			continue
@@ -64,6 +65,10 @@ func validateInfrastructureConfigZones(oldInfra, infra *apisaws.InfrastructureCo
 		if !awsZones.Has(zone.Name) {
 			allErrs = append(allErrs, field.NotSupported(fldPath.Child("zones").Index(i).Child("name"), zone.Name, awsZones.UnsortedList()))
 		}
+		if usedZones.Has(zone.Name) {
+			allErrs = append(allErrs, field.Duplicate(fldPath.Child("zones").Index(i).Child("name"), zone.Name))
+		}
+		usedZones.Insert(zone.Name)
 	}
 
 	return allErrs

--- a/pkg/apis/aws/validation/infrastructure_test.go
+++ b/pkg/apis/aws/validation/infrastructure_test.go
@@ -126,6 +126,16 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				}))))
 			})
 
+			It("should forbid because zone is duplicate", func() {
+				infrastructureConfig.Networks.Zones = append(infrastructureConfig.Networks.Zones, infrastructureConfig.Networks.Zones[0])
+				errorList := ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, shoot, cloudProfile, field.NewPath("spec"))
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeDuplicate),
+					"Field": Equal("spec.network.zones[1].name"),
+				}))))
+			})
+
 			It("should pass because zone is not specified in CloudProfile but was not changed", func() {
 				infrastructureConfig.Networks.Zones[0].Name = "not-available"
 				oldInfrastructureConfig := infrastructureConfig.DeepCopy()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
The validation of the `InfrastructureConfig` has been extended by a duplicate name check in `spec.network.zones`

**Which issue(s) this PR fixes**:
Fixes #643 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Check for duplicate zone names in infrastructureconfig
```
