### PR TITLE
Allow to expand node CIDR

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -186,6 +186,10 @@ func (s *shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 		return err
 	}
 
+	if errList := awsvalidation.ValidateNetworkingUpdate(oldShoot.Spec.Networking, shoot.Spec.Networking, infraConfig, field.NewPath("spec", "networking")); len(errList) != 0 {
+		return errList.ToAggregate()
+	}
+
 	if errList := awsvalidation.ValidateWorkersUpdate(oldShoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers, fldPath.Child("workers")); len(errList) != 0 {
 		return errList.ToAggregate()
 	}

--- a/pkg/aws/client/mock/mocks.go
+++ b/pkg/aws/client/mock/mocks.go
@@ -223,6 +223,21 @@ func (mr *MockInterfaceMockRecorder) GetNATGatewayAddressAllocations(arg0, arg1 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNATGatewayAddressAllocations", reflect.TypeOf((*MockInterface)(nil).GetNATGatewayAddressAllocations), arg0, arg1)
 }
 
+// GetVPC mocks base method.
+func (m *MockInterface) GetVPC(arg0 context.Context, arg1 string) (*client.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPC", arg0, arg1)
+	ret0, _ := ret[0].(*client.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPC indicates an expected call of GetVPC.
+func (mr *MockInterfaceMockRecorder) GetVPC(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPC", reflect.TypeOf((*MockInterface)(nil).GetVPC), arg0, arg1)
+}
+
 // GetVPCAttribute mocks base method.
 func (m *MockInterface) GetVPCAttribute(arg0 context.Context, arg1, arg2 string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -39,6 +39,7 @@ type Interface interface {
 	GetDHCPOptions(ctx context.Context, vpcID string) (map[string]string, error)
 	GetElasticIPsAssociationIDForAllocationIDs(ctx context.Context, allocationIDs []string) (map[string]*string, error)
 	GetNATGatewayAddressAllocations(ctx context.Context, shootNamespace string) (sets.String, error)
+	GetVPC(ctx context.Context, id string) (*VPC, error)
 
 	// S3 wrappers
 	DeleteObjectsWithPrefix(ctx context.Context, bucket, prefix string) error
@@ -71,4 +72,15 @@ type FactoryFunc func(accessKeyID, secretAccessKey, region string) (Interface, e
 // NewClient creates a new instance of Interface for the given AWS credentials and region.
 func (f FactoryFunc) NewClient(accessKeyID, secretAccessKey, region string) (Interface, error) {
 	return f(accessKeyID, secretAccessKey, region)
+}
+
+// VPC contains the relevant fields of a EC2 VPC resource.
+type VPC struct {
+	VpcId              string
+	CidrBlock          string
+	EnableDnsSupport   bool
+	EnableDnsHostnames bool
+	DhcpOptionsId      *string
+	InstanceTenancy    *string
+	State              *string
 }

--- a/pkg/controller/infrastructure/configvalidator_test.go
+++ b/pkg/controller/infrastructure/configvalidator_test.go
@@ -97,7 +97,7 @@ var _ = Describe("ConfigValidator", func() {
 				},
 			},
 		}
-		shootJSON, err := json.Marshal(shoot)
+		shootJSON, _ := json.Marshal(shoot)
 		cluster = &extensionsv1alpha1.Cluster{
 			Spec: extensionsv1alpha1.ClusterSpec{
 				CloudProfile: runtime.RawExtension{Raw: []byte("{}")},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:

This PR: 
- [x] adds an admission check to check that the nodes CIDR block can only be expanded when a gardener-managed VPC is used.
- [x] configvalidator check during runtime to check if the nodes CIDR is within the VPC range in "bring-your-own-VPC" scenarios.


**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/gardener/issues/4834

**Special notes for your reviewer**:

Generally for https://github.com/gardener/gardener/issues/4834 the extension is already having sufficient checks to ensure that the `vpc > nodes > worker subnets`. This PR only enhances this checks for runtime. In addition, the nodes CIDR is mutable in BYO-VPC cases to allow users to correct mistakes.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
