### PR TITLE
Health check for aws-custom-route-controller route updates

### DIFF
--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -94,7 +94,7 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 			},
 			{
 				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
-				HealthCheck:   general.NewSeedDeploymentHealthChecker(aws.AWSCustomRouteControllerName),
+				HealthCheck:   newCustomRouteControllerHealthCheck(general.NewSeedDeploymentHealthChecker(aws.AWSCustomRouteControllerName)),
 				// no precheck needed, as the deployment is always created (with replicas=0 if not enabled, see valuesprovider.go)
 			},
 			{

--- a/pkg/controller/healthcheck/customroutecontrollerhealth.go
+++ b/pkg/controller/healthcheck/customroutecontrollerhealth.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gardener/gardener/extensions/pkg/controller/healthcheck"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type customRouteControllerHealthCheck struct {
+	shootClient     client.Client
+	logger          logr.Logger
+	deploymentCheck healthcheck.HealthCheck
+}
+
+var _ healthcheck.HealthCheck = &customRouteControllerHealthCheck{}
+
+func newCustomRouteControllerHealthCheck(deploymentCheck healthcheck.HealthCheck) *customRouteControllerHealthCheck {
+	return &customRouteControllerHealthCheck{deploymentCheck: deploymentCheck}
+}
+
+func (hc *customRouteControllerHealthCheck) Check(ctx context.Context, request types.NamespacedName) (*healthcheck.SingleCheckResult, error) {
+	result, err := hc.deploymentCheck.Check(ctx, request)
+	if err != nil || result.Status != gardencorev1beta1.ConditionTrue {
+		return result, err
+	}
+	return hc.checkEvents(ctx, request)
+}
+
+func (hc *customRouteControllerHealthCheck) checkEvents(ctx context.Context, request types.NamespacedName) (*healthcheck.SingleCheckResult, error) {
+	list := &v1.EventList{}
+	selector := fields.AndSelectors(fields.OneTermEqualSelector("involvedObject.kind", "ServiceAccount"), fields.OneTermEqualSelector("involvedObject.name", "aws-custom-route-controller"))
+	err := hc.shootClient.List(ctx, list, client.InNamespace(metav1.NamespaceSystem), client.MatchingFieldsSelector{Selector: selector})
+	if err != nil {
+		err := fmt.Errorf("failed to retrieve events for aws-custom-route-controller in namespace %q: %w", request.Namespace, err)
+		hc.logger.Error(err, "Health check failed")
+		return nil, err
+	}
+
+	var newestEvent *v1.Event
+	for i := range list.Items {
+		event := &list.Items[i]
+		if newestEvent == nil || newestEvent.LastTimestamp.Time.Before(event.LastTimestamp.Time) {
+			newestEvent = event
+		}
+	}
+	if newestEvent != nil && newestEvent.Type == v1.EventTypeWarning {
+		var codes []gardencorev1beta1.ErrorCode
+		if strings.Contains(newestEvent.Message, "RouteLimitExceeded") {
+			codes = append(codes, gardencorev1beta1.ErrorInfraQuotaExceeded)
+		} else {
+			codes = append(codes, gardencorev1beta1.ErrorRetryableInfraDependencies)
+		}
+
+		details := fmt.Sprintf("[aws-custom-route-controller] %s: %s", newestEvent.Reason, newestEvent.Message)
+		hc.logger.Error(errors.New(details), "Health check failed")
+		return &healthcheck.SingleCheckResult{
+			Status: gardencorev1beta1.ConditionFalse,
+			Detail: details,
+			Codes:  codes,
+		}, nil
+	}
+
+	return &healthcheck.SingleCheckResult{
+		Status: gardencorev1beta1.ConditionTrue,
+	}, nil
+}
+
+func (hc *customRouteControllerHealthCheck) SetLoggerSuffix(provider, extension string) {
+	hc.logger = log.Log.WithName(fmt.Sprintf("%s-healthcheck-custom-route-controller", provider))
+	hc.deploymentCheck.SetLoggerSuffix(provider, extension)
+}
+
+// DeepCopy clones the healthCheck
+func (hc *customRouteControllerHealthCheck) DeepCopy() healthcheck.HealthCheck {
+	return &customRouteControllerHealthCheck{
+		deploymentCheck: hc.deploymentCheck.DeepCopy(),
+		shootClient:     hc.shootClient,
+	}
+}
+
+// InjectSeedClient injects the seed client
+func (hc *customRouteControllerHealthCheck) InjectSeedClient(seedClient client.Client) {
+	if itf, ok := hc.deploymentCheck.(healthcheck.SeedClient); ok {
+		itf.InjectSeedClient(seedClient)
+	}
+}
+
+// InjectShootClient injects the shoot client
+func (hc *customRouteControllerHealthCheck) InjectShootClient(shootClient client.Client) {
+	if itf, ok := hc.deploymentCheck.(healthcheck.ShootClient); ok {
+		itf.InjectShootClient(shootClient)
+	}
+	hc.shootClient = shootClient
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
The aws-custom-route-controller creates events on successful or failed route updates with [PR #8](https://github.com/gardener/aws-custom-route-controller/pull/8).
These events are evaluated with a new health check and reported for the shoot condition type `ControlPlaneHealthy` on failure.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add health check for aws-custom-route-controller route updates
```
