### PR TITLE
Fix `shoot` reconciliation when `sshAccess` is disabled.

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -42,7 +42,9 @@ providerSpec:
 {{- if $machineClass.iamInstanceProfile.arn }}
     arn: {{ $machineClass.iamInstanceProfile.arn }}
 {{- end }}
+{{- if $machineClass.keyName }}
   keyName: {{ $machineClass.keyName }}
+{{- end }}
   networkInterfaces:
 {{ toYaml $machineClass.networkInterfaces | indent 2 }}
 {{- if $machineClass.tags }}

--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -364,10 +364,12 @@ EOF
 //= EC2 Key Pair
 //=====================================================================
 
+{{- if .sshPublicKey }}
 resource "aws_key_pair" "kubernetes" {
   key_name   = "{{ .clusterName }}-ssh-publickey"
   public_key = "{{ .sshPublicKey }}"
 }
+{{- end }}
 
 //=====================================================================
 //= Output variables
@@ -381,9 +383,11 @@ output "{{ .outputKeys.iamInstanceProfileNodes }}" {
   value = aws_iam_instance_profile.nodes.name
 }
 
+{{- if .sshPublicKey }}
 output "{{ .outputKeys.sshKeyName }}" {
   value = aws_key_pair.kubernetes.key_name
 }
+{{- end }}
 
 output "{{ .outputKeys.securityGroupsNodes }}" {
   value = aws_security_group.nodes.id

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -142,7 +142,6 @@ func (w *workerDelegate) generateMachineConfig() error {
 				"region":             w.worker.Spec.Region,
 				"machineType":        pool.MachineType,
 				"iamInstanceProfile": iamInstanceProfile,
-				"keyName":            infrastructureStatus.EC2.KeyName,
 				"networkInterfaces": []map[string]interface{}{
 					{
 						"subnetID":         nodesSubnet.ID,
@@ -164,6 +163,10 @@ func (w *workerDelegate) generateMachineConfig() error {
 					"cloudConfig": string(pool.UserData),
 				},
 				"blockDevices": blockDevices,
+			}
+
+			if len(infrastructureStatus.EC2.KeyName) > 0 {
+				machineClassSpec["keyName"] = infrastructureStatus.EC2.KeyName
 			}
 
 			if workerConfig.NodeTemplate != nil {

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -156,13 +156,14 @@ var _ = Describe("Machines", func() {
 				workerPoolHash1 string
 				workerPoolHash2 string
 
-				shootVersionMajorMinor string
-				shootVersion           string
-				scheme                 *runtime.Scheme
-				decoder                runtime.Decoder
-				clusterWithoutImages   *extensionscontroller.Cluster
-				cluster                *extensionscontroller.Cluster
-				w                      *extensionsv1alpha1.Worker
+				shootVersionMajorMinor       string
+				shootVersion                 string
+				scheme                       *runtime.Scheme
+				decoder                      runtime.Decoder
+				clusterWithoutImages         *extensionscontroller.Cluster
+				cluster                      *extensionscontroller.Cluster
+				infrastructureProviderStatus *api.InfrastructureStatus
+				w                            *extensionsv1alpha1.Worker
 			)
 
 			BeforeEach(func() {
@@ -295,6 +296,41 @@ var _ = Describe("Machines", func() {
 					Shoot: clusterWithoutImages.Shoot,
 				}
 
+				infrastructureProviderStatus = &api.InfrastructureStatus{
+					VPC: api.VPCStatus{
+						ID: vpcID,
+						Subnets: []api.Subnet{
+							{
+								ID:      subnetZone1,
+								Purpose: "nodes",
+								Zone:    zone1,
+							},
+							{
+								ID:      subnetZone2,
+								Purpose: "nodes",
+								Zone:    zone2,
+							},
+						},
+						SecurityGroups: []api.SecurityGroup{
+							{
+								ID:      securityGroupID,
+								Purpose: "nodes",
+							},
+						},
+					},
+					IAM: api.IAM{
+						InstanceProfiles: []api.InstanceProfile{
+							{
+								Name:    instanceProfileName,
+								Purpose: "nodes",
+							},
+						},
+					},
+					EC2: api.EC2{
+						KeyName: keyName,
+					},
+				}
+
 				w = &extensionsv1alpha1.Worker{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: namespace,
@@ -306,40 +342,7 @@ var _ = Describe("Machines", func() {
 						},
 						Region: region,
 						InfrastructureProviderStatus: &runtime.RawExtension{
-							Raw: encode(&api.InfrastructureStatus{
-								VPC: api.VPCStatus{
-									ID: vpcID,
-									Subnets: []api.Subnet{
-										{
-											ID:      subnetZone1,
-											Purpose: "nodes",
-											Zone:    zone1,
-										},
-										{
-											ID:      subnetZone2,
-											Purpose: "nodes",
-											Zone:    zone2,
-										},
-									},
-									SecurityGroups: []api.SecurityGroup{
-										{
-											ID:      securityGroupID,
-											Purpose: "nodes",
-										},
-									},
-								},
-								IAM: api.IAM{
-									InstanceProfiles: []api.InstanceProfile{
-										{
-											Name:    instanceProfileName,
-											Purpose: "nodes",
-										},
-									},
-								},
-								EC2: api.EC2{
-									KeyName: keyName,
-								},
-							}),
+							Raw: encode(infrastructureProviderStatus),
 						},
 						Pools: []extensionsv1alpha1.WorkerPool{
 							{
@@ -685,6 +688,30 @@ var _ = Describe("Machines", func() {
 					result, err := workerDelegate.GenerateMachineDeployments(ctx)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(machineDeployments))
+				})
+				It("should deploy the expected machine classes when infrastructureProviderStatus.EC2 is missing keyName", func() {
+					infrastructureProviderStatus.EC2.KeyName = ""
+					w.Spec.InfrastructureProviderStatus = &runtime.RawExtension{
+						Raw: encode(infrastructureProviderStatus),
+					}
+					workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
+
+					for _, machineClass := range machineClasses["machineClasses"].([]map[string]interface{}) {
+						delete(machineClass, "keyName")
+					}
+
+					// Test workerDelegate.DeployMachineClasses()
+					chartApplier.EXPECT().ApplyFromEmbeddedFS(
+						ctx,
+						charts.InternalChart,
+						filepath.Join("internal", "machineclass"),
+						namespace,
+						"machineclass",
+						kubernetes.Values(machineClasses),
+					)
+
+					err := workerDelegate.DeployMachineClasses(ctx)
+					Expect(err).NotTo(HaveOccurred())
 				})
 
 				Context("using workerConfig.iamInstanceProfile", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/area security
/kind bug
/platform aws

**What this PR does / why we need it**:
This PR removes `sshKeyName` from the `terraformInfraConfig` and `machineConfig` when `sshAccess` is disabled for the worker nodes. Disabling `sshAccess` stops the `keyPair` rotation and removes the current `sshPublicKey`. Currently `aws` `shoots` cannot be created with `sshAccess` disabled.

**Which issue(s) this PR fixes**:
Fixes [gardener/gardener#7481](https://github.com/gardener/gardener/issues/7481)

**Special notes for your reviewer**:
This Draft depends on the changes in [this PR](https://github.com/gardener/machine-controller-manager-provider-aws/pull/104) and will remain in draft until the PR is merged and a new release is made.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix an issue where `shoot` reconciliation would fail when `sshAccess` was disabled.
```
