### PR TITLE
add arm64 type for bastion instance

### DIFF
--- a/pkg/controller/bastion/options.go
+++ b/pkg/controller/bastion/options.go
@@ -228,6 +228,10 @@ func determineInstanceType(ctx context.Context, imageID string, awsClient *awscl
 		return "", fmt.Errorf("no instance types returned for architecture %s and instance types list %v", *imageArchitecture, tTypeSet.UnsortedList())
 	}
 
+	if result.InstanceTypes[0].InstanceType == nil {
+		return "", fmt.Errorf("instanceType is empty")
+	}
+
 	return *result.InstanceTypes[0].InstanceType, nil
 }
 

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -247,6 +247,7 @@ func determineBastionImage(ctx context.Context, awsClient *awsclient.Client) str
 			},
 		},
 	})
+
 	Expect(err).NotTo(HaveOccurred())
 	Expect(output.Images).To(HaveLen(1))
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-aws/issues/694

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
add 't4g.nano' and arm64 type instance supported in the bastion instance
```
