### PR TITLE
add getImageAMI for sustainable test

### DIFF
--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -182,7 +182,7 @@ var _ = BeforeSuite(func() {
 	awsClient, err = awsclient.NewClient(*accessKeyID, *secretAccessKey, *region)
 	Expect(err).NotTo(HaveOccurred())
 
-	imageAMI := getImageIAM(ctx, bastionAMI, awsClient)
+	imageAMI := getImageAMI(ctx, bastionAMI, awsClient)
 	amiID := determineBastionImage(ctx, imageAMI, awsClient)
 	extensionscluster, corecluster = newCluster(namespaceName, amiID)
 })
@@ -254,7 +254,7 @@ func determineBastionImage(ctx context.Context, name string, awsClient *awsclien
 	return *output.Images[0].ImageId
 }
 
-func getImageIAM(ctx context.Context, name string, awsClient *awsclient.Client) string {
+func getImageAMI(ctx context.Context, name string, awsClient *awsclient.Client) string {
 	filters := []*ec2.Filter{
 		{
 			Name: awssdk.String("name"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/platform aws

**What this PR does / why we need it**:
add a "sustainable" way to get available image AMIs for the test 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-aws/issues/713

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
add a sustainable way to get available image AMIs for the test
```
/invite @kon-angelo 