### PR TITLE
Add wait-for-csi-node annotation to csi-driver-node Pods

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -19,6 +19,8 @@ spec:
         app: csi
         role: disk-driver
         node.gardener.cloud/critical-component: "true"
+      annotations:
+        node.gardener.cloud/wait-for-csi-node-aws: {{ include "csi-driver-node.provisioner" . }}
     spec:
       hostNetwork: true
       priorityClassName: system-node-critical


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind enhancement
/platform aws

**What this PR does / why we need it**:

This PR adds the `wait-for-csi-node` annotation to `csi-driver-node` introduced in gardener/gardener#7621

**Which issue(s) this PR fixes**:
Parts of gardener/gardener#7117

**Special notes for your reviewer**:
gardener/gardener#7621 is merged

**Release note**:

```feature operator
`csi-driver-node` is annotated with the `wait-for-csi-node` annotation. Gardener uses this to only schedule workload pods to a `Node` once the driver has been successfully registered with the `CSINode` object.
```
