### PR TITLE
Fix the annotation value for `snapshot.storage.kubernetes.io/is-default-class`

### DIFF
--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -21,7 +21,7 @@ metadata:
   name: default
   {{- if .Values.managedDefaultClass }}
   annotations:
-    snapshot.storage.kubernetes.io/is-default-class: “true”
+    snapshot.storage.kubernetes.io/is-default-class: "true"
   {{- end }}
 driver: ebs.csi.aws.com
 deletionPolicy: Delete


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind bug
/platform aws

**What this PR does / why we need it**:
Currently the defaulting logic for VolumeSnapshotClass for a VolumeSnapshot does not work because the annotation value is “true” and not "true" (note the wrong quotes).

**Steps to reproduce**:
1. Create a PVC:
```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: ebs-claim
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 4Gi
---
apiVersion: v1
kind: Pod
metadata:
  name: app
spec:
  containers:
  - name: app
    image: centos
    command: ["/bin/sh"]
    args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
    volumeMounts:
    - name: persistent-storage
      mountPath: /data
  volumes:
  - name: persistent-storage
    persistentVolumeClaim:
      claimName: ebs-claim
```

2. Create a VolumeSnapshot without a class:

```yaml
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  name: ebs-volume-snapshot
spec:
  source:
    persistentVolumeClaimName: ebs-claim
```

3. Make sure that no default VolumeSnapshotClass is applied to the VolumeSnapshot:
```yaml
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  creationTimestamp: "2023-03-20T14:23:14Z"
  generation: 1
  name: ebs-volume-snapshot
  namespace: default
  resourceVersion: "8457999"
  uid: 187a56de-06c8-402b-8bfc-604d1c73d478
spec:
  source:
    persistentVolumeClaimName: ebs-claim
status:
  error:
    message: Failed to set default snapshot class with error cannot find default
      snapshot class
    time: "2023-03-20T14:23:14Z"
```

**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
With the fix from this PR a VolumeSnapshotClass is successfully assigned to a VolumeSnapshot created without a class.

The following script can the used to check if a Shoot in a Gardener landscape already defines a default VolumeSnapshotClass - ref https://gist.github.com/ialidzhikov/a8927c75e71edfcbbbda2f333b9c3e74

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The default VolumeSnapshotClass managed by `provider-aws` does now properly define this VolumeSnapshotClass as default one. Previously there was a typo in the annotation value for `snapshot.storage.kubernetes.io/is-default-class`, hence the VolumeSnapshotClass was never considered as default one by the external-snapshotter and the VolumeSnapshotClass defaulting was never working as expected.
If you already deploy your own default VolumeSnapshotClass, then consider disabling provider-aws's default VolumeSnapshotClass (using the `storage.managedDefaultClass` field in the controlPlaneConfig) as having more than 1 default VolumeSnapshotClass will prevent external-snapshotter to default the `spec.volumeSnapshotClassName` of a VolumeSnapshot.
```
