### PR TITLE
Upgrade machine-controller-manager from v0.48.1 to v0.48.2

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -114,7 +114,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.48.1"
+  tag: "v0.48.2"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
cherry-picking #727

``` bugfix user github.com/gardener/machine-controller-manager #804 @himanshu-kun
An edge case where all the machineSets were scaled down to zero has been dealt with.
```