### PR TITLE
Do not delete `csi-snapshot-validation` ClusterRole and ClusterRoleBinding from the wrong cluster (Seed cluster) when deleting Shoot

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -170,8 +170,6 @@ var (
 					// csi-snapshot-validation-webhook
 					{Type: &appsv1.Deployment{}, Name: aws.CSISnapshotValidationName},
 					{Type: &corev1.Service{}, Name: aws.CSISnapshotValidationName},
-					{Type: &rbacv1.ClusterRole{}, Name: aws.UsernamePrefix + aws.CSISnapshotValidationName},
-					{Type: &rbacv1.ClusterRoleBinding{}, Name: aws.UsernamePrefix + aws.CSISnapshotValidationName},
 				},
 			},
 		},
@@ -232,6 +230,8 @@ var (
 					{Type: &rbacv1.RoleBinding{}, Name: aws.UsernamePrefix + aws.CSIResizerName},
 					// csi-snapshot-validation-webhook
 					{Type: &admissionregistrationv1.ValidatingWebhookConfiguration{}, Name: aws.CSISnapshotValidationName},
+					{Type: &rbacv1.ClusterRole{}, Name: aws.UsernamePrefix + aws.CSISnapshotValidationName},
+					{Type: &rbacv1.ClusterRoleBinding{}, Name: aws.UsernamePrefix + aws.CSISnapshotValidationName},
 				},
 			},
 		},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/kind regression
/platform aws

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-provider-aws/pull/666 introduces the following issue:
We noticed that Seeds' SystemComponents condition are constantly flapping with error:
```
Required ClusterRole "extensions.gardener.cloud:provider-aws:csi-snapshot-validation" in namespace "" is missing
```

The above mentioned PR introduces adds the `extensions.gardener.cloud:provider-aws:csi-snapshot-validation` ClusterRole and ClusterRoleBinding to the Shoot cluster. But it also adds https://github.com/gardener/gardener-extension-provider-aws/blob/e12c20f1ff0c56cbaaf8526fbc8cfae64262c6de/pkg/controller/controlplane/valuesprovider.go#L173-L174 to the `controlPlaneChart`. On Shoot deletion, the ControlPlane actuator deletes the resources from the `controlPlaneChart` https://github.com/gardener/gardener-extension-provider-aws/blob/5ec19cbf3af7458da47571be81f1c499eadaae00/vendor/github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator/actuator.go#L495-L501. Hence, on every Shoot deletion, provider-aws deletes these `extensions.gardener.cloud:provider-aws:csi-snapshot-validation` ClusterRole and ClusterRoleBinding from the Seed cluster (wrong cluster).
`extensions.gardener.cloud:provider-aws:csi-snapshot-validation` ClusterRole and ClusterRoleBinding are actually managed by MR (hence, we don't need to delete them explicitly). Deleting the ControlPlane will delete the `extension-controlplane-shoot` MR, which will delete the RBAC.

**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing provider-aws to wrongly delete the `extensions.gardener.cloud:provider-aws:csi-snapshot-validation` ClusterRole and ClusterRoleBinding from the Seed cluster on every Shoot deletion is now fixed.
```
