### PR TITLE
Block public access to S3 bucket as per standard practices

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -325,7 +325,7 @@ func (c *Client) DeleteObjectsWithPrefix(ctx context.Context, bucket, prefix str
 	return nil
 }
 
-// CreateBucketIfNotExists creates the s3 bucket with name <bucket> in <region>. If it already exist,
+// CreateBucketIfNotExists creates the s3 bucket with name <bucket> in <region>. If it already exists,
 // no error is returned.
 func (c *Client) CreateBucketIfNotExists(ctx context.Context, bucket, region string) error {
 	createBucketInput := &s3.CreateBucketInput{
@@ -359,6 +359,19 @@ func (c *Client) CreateBucketIfNotExists(ctx context.Context, bucket, region str
 					},
 				},
 			},
+		},
+	}); err != nil {
+		return err
+	}
+
+	// Block public access to the bucket
+	if _, err := c.S3.PutPublicAccessBlockWithContext(ctx, &s3.PutPublicAccessBlockInput{
+		Bucket: aws.String(bucket),
+		PublicAccessBlockConfiguration: &s3.PublicAccessBlockConfiguration{
+			BlockPublicAcls:       aws.Bool(true),
+			BlockPublicPolicy:     aws.Bool(true),
+			IgnorePublicAcls:      aws.Bool(true),
+			RestrictPublicBuckets: aws.Bool(true),
 		},
 	}); err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/area security
/area compliance
/kind task
/platform aws

**What this PR does / why we need it**:
This PR configures the newly created S3 buckets to be blocked from public access as per standard practices. This is achieved by putting a public-access-block on the created bucket, as per [AWS documentation](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-public-access-block.html).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @vlerenc 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Block public access for newly created S3 buckets.
```
