### PR TITLE
Align the aws_internet_gateway timeout to terraformer's timeout

### DIFF
--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -46,6 +46,11 @@ resource "aws_default_security_group" "default" {
 resource "aws_internet_gateway" "igw" {
   vpc_id = {{ .vpc.id }}
 
+  timeouts {
+    create = "10m"
+    delete = "10m"
+  }
+
 {{ commonTags .clusterName | indent 2 }}
 }
 {{- end}}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Currently the terraformer's `deadlinePod` timeout is 15mins:
https://github.com/gardener/gardener-extension-provider-aws/blob/5f0d082c2fc02ae5fe9a22d7f02af84d05dce111/pkg/controller/infrastructure/actuator.go#L62-L68

On the other hand, the aws_internet_gateway's `create` and `delete` timeouts are 20mins:
https://github.com/hashicorp/terraform-provider-aws/blob/8af0bd79119df3f3f8e642b931b0281bef29bb39/internal/service/ec2/vpc_internet_gateway.go#L29-L33

Hence, for example for a `terraform destroy` the terraformer Pod will be deleted by the provider extension before the aws_internet_gateway delete timeout is exceeded and it reports why the aws_internet_gateway cannot be deleted.

```
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 11m40s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 11m50s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 12m0s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 12m10s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 12m20s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 12m30s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 12m40s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 12m50s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 13m0s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 13m10s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 13m20s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 13m30s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 13m40s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 13m50s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 14m0s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 14m10s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 14m20s elapsed]
aws_internet_gateway.igw: Still destroying... [id=igw-1234, 14m30s elapsed]
{"level":"info","ts":"2023-06-02T13:25:55.244Z","msg":"interrupt received"}

Interrupt received.
Please wait for Terraform to exit or data loss may occur.
Gracefully shutting down...

Stopping operation...

Error: deleting EC2 Subnet (subnet-1234): DependencyViolation: The subnet 'subnet-1234' has dependencies and cannot be deleted.
	status code: 400, request id: 1234


Error: deleting EC2 Internet Gateway (igw-1234): error detaching EC2 Internet Gateway (igw-1234) from VPC (vpc-1234): DependencyViolation: Network vpc-1234 has some mapped public address(es). Please unmap those public address(es) before detaching the gateway.
	status code: 400, request id: 123


Error: execution halted


Error: execution halted
```

Hence, the error cannot be propagated properly to the Shoot status.
The Shoot status displays a generic error such as:
```
  lastErrors:
    - description: "task \"Waiting until shoot infrastructure has been deleted\" failed: Failed to delete Infrastructure shoot--foo--bar/bar: Error deleting Infrastructure: 1 error occurred:\n\t* task \"Destroying Shoot infrastructure\" failed: Terraform execution for command 'destroy' could not be completed\n\n"
      taskID: Waiting until shoot infrastructure has been deleted
      lastUpdateTime: '2023-06-02T14:31:10Z'
```

With this PR the following proper error is being displayed:
```
  lastErrors:
  - codes:
    - ERR_INFRA_DEPENDENCIES
    description: "task \"Waiting until shoot infrastructure has been deleted\" failed:
      Failed to delete Infrastructure shoot--foo--bar/bar: Error
      deleting Infrastructure: 1 error occurred:\n\t* task \"Destroying Shoot infrastructure\"
      failed: Terraform execution for command 'destroy' could not be completed:\n\n*
      deleting EC2 Internet Gateway (igw-1234): error detaching EC2 Internet
      Gateway (igw-1234) from VPC (vpc-1234): DependencyViolation:
      Network vpc-1234 has some mapped public address(es). Please unmap
      those public address(es) before detaching the gateway.\n\tstatus code: 400,
      request id: <omitted>\n* deleting EC2 Subnet (subnet-1234): DependencyViolation:
      The subnet 'subnet-1234' has dependencies and cannot be deleted.\n\tstatus
      code: 400, request id: <omitted>\n\n"
    lastUpdateTime: "2023-06-05T09:18:33Z"
    taskID: Waiting until shoot infrastructure has been deleted
```

**Which issue(s) this PR fixes**:
See above.
Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/94

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
provider-aws does now define proper `create` and `delete` timeouts for `aws_internet_gateway`. Now, these timeouts are aligned with the terraformer's timeout. Previously the timeouts were not aligned and provider-aws was not able to properly report the `aws_internet_gateway` related error.
```
