### PR TITLE
[release-v1.44] Automated cherry pick of #763: update `aws-csi-volume-modifier` in vpa

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-vpa.yaml
@@ -49,7 +49,7 @@ spec:
         cpu: {{ .Values.vpa.resourcePolicy.livenessProbe.maxAllowed.cpu }}
         memory: {{ .Values.vpa.resourcePolicy.livenessProbe.maxAllowed.memory }}
       controlledValues: RequestsOnly
-    - containerName: aws-volume-modifier
+    - containerName: aws-csi-volume-modifier
       minAllowed:
         memory: {{ .Values.resources.volumeModifier.requests.memory }}
       maxAllowed:


### PR DESCRIPTION
/area robustness
/kind bug

Cherry pick of #763 on release-v1.44.

#763: update `aws-csi-volume-modifier` in vpa

**Release Notes:**
```bugfix operator
Fix the name of the aws-csi-volume-modifier container the in the respective VPA resource.
```