### PR TITLE
Fix S3 bucket policy for different AWS partitions (region groups)

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -377,6 +377,14 @@ func (c *Client) CreateBucketIfNotExists(ctx context.Context, bucket, region str
 		return err
 	}
 
+	// Handle bucket policy IAM ARN for different partitions (AWS region groups)
+	arnPartition := "aws"
+	if strings.HasPrefix(region, "cn-") {
+		arnPartition = "aws-cn" // China regions
+	} else if strings.HasPrefix(region, "us-gov-") {
+		arnPartition = "aws-us-gov" // AWS GovCloud (US) regions
+	}
+
 	// Set bucket policy to deny non-HTTPS requests
 	bucketPolicy := map[string]interface{}{
 		"Version": "2012-10-17",
@@ -386,8 +394,8 @@ func (c *Client) CreateBucketIfNotExists(ctx context.Context, bucket, region str
 				"Principal": "*",
 				"Action":    "s3:*",
 				"Resource": []string{
-					fmt.Sprintf("arn:aws:s3:::%s", bucket),
-					fmt.Sprintf("arn:aws:s3:::%s/*", bucket),
+					fmt.Sprintf("arn:%s:s3:::%s", arnPartition, bucket),
+					fmt.Sprintf("arn:%s:s3:::%s/*", arnPartition, bucket),
 				},
 				"Condition": map[string]interface{}{
 					"Bool": map[string]string{

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -378,6 +378,8 @@ func (c *Client) CreateBucketIfNotExists(ctx context.Context, bucket, region str
 	}
 
 	// Handle bucket policy IAM ARN for different partitions (AWS region groups)
+	// Different available partitions in AWS are defined at
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html
 	arnPartition := "aws"
 	if strings.HasPrefix(region, "cn-") {
 		arnPartition = "aws-cn" // China regions


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind bug
/platform aws

**What this PR does / why we need it**:
Adds handling for S3 bucket policy for different [AWS partitions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) (region groups) such as [China regions](https://aws.amazon.com/blogs/enterprise-strategy/getting-started-with-aws-services-in-aws-china-beijing-region-and-aws-china-ningxia-region/) and [AWS GovCloud (US) regions](https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-arns.html).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Handle S3 bucket policy IAM ARN for China and GovCloud (US) regions.
```
