### PR TITLE
Drop code related to `APIServerSNI` feature gate

### DIFF
--- a/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/pkg/webhook/controlplaneexposure/ensurer.go
@@ -18,14 +18,10 @@ import (
 	"context"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/go-logr/logr"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/config"
@@ -43,38 +39,6 @@ type ensurer struct {
 	genericmutator.NoopEnsurer
 	etcdStorage *config.ETCDStorage
 	logger      logr.Logger
-}
-
-// EnsureKubeAPIServerService ensures that the kube-apiserver service conforms to the provider requirements.
-func (e *ensurer) EnsureKubeAPIServerService(_ context.Context, _ gcontext.GardenContext, newObj, _ *corev1.Service) error {
-	if v1beta1helper.IsAPIServerExposureManaged(newObj) {
-		return nil
-	}
-
-	if newObj.Annotations == nil {
-		newObj.Annotations = make(map[string]string)
-	}
-	newObj.Annotations["service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"] = "3600"
-	newObj.Annotations["service.beta.kubernetes.io/aws-load-balancer-backend-protocol"] = "ssl"
-	newObj.Annotations["service.beta.kubernetes.io/aws-load-balancer-ssl-ports"] = "443"
-	newObj.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout"] = "5"
-	newObj.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval"] = "30"
-	newObj.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold"] = "2"
-	newObj.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold"] = "2"
-	newObj.Annotations["service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy"] = "ELBSecurityPolicy-TLS-1-2-2017-01"
-	return nil
-}
-
-// EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
-func (e *ensurer) EnsureKubeAPIServerDeployment(_ context.Context, _ gcontext.GardenContext, newObj, _ *appsv1.Deployment) error {
-	if v1beta1helper.IsAPIServerExposureManaged(newObj) {
-		return nil
-	}
-
-	if c := extensionswebhook.ContainerWithName(newObj.Spec.Template.Spec.Containers, "kube-apiserver"); c != nil {
-		c.Command = extensionswebhook.EnsureStringWithPrefix(c.Command, "--endpoint-reconciler-type=", "none")
-	}
-	return nil
 }
 
 // EnsureETCD ensures that the etcd conform to the provider requirements.

--- a/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -19,15 +19,11 @@ import (
 	"testing"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
-	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -53,132 +49,6 @@ var _ = Describe("Ensurer", func() {
 
 		dummyContext = gcontext.NewGardenContext(nil, nil)
 	)
-
-	Describe("#EnsureKubeAPIServerService", func() {
-		var (
-			svc     *corev1.Service
-			ensurer genericmutator.Ensurer
-		)
-
-		BeforeEach(func() {
-			svc = &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver"},
-			}
-			ensurer = NewEnsurer(etcdStorage, logger)
-		})
-
-		It("should not modify kube-apiserver service if SNI is enabled", func() {
-			svc.Labels = map[string]string{"core.gardener.cloud/apiserver-exposure": "gardener-managed"}
-			svcCopy := svc.DeepCopy()
-
-			err := ensurer.EnsureKubeAPIServerService(ctx, dummyContext, svc, nil)
-			Expect(err).To(Not(HaveOccurred()))
-
-			Expect(svc).To(Equal(svcCopy))
-		})
-
-		It("should add annotations to kube-apiserver service", func() {
-			err := ensurer.EnsureKubeAPIServerService(ctx, dummyContext, svc, nil)
-			Expect(err).To(Not(HaveOccurred()))
-
-			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout", "3600"))
-			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-backend-protocol", "ssl"))
-			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-ssl-ports", "443"))
-			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout", "5"))
-			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval", "30"))
-			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold", "2"))
-			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold", "2"))
-			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy", "ELBSecurityPolicy-TLS-1-2-2017-01"))
-		})
-	})
-
-	Describe("#EnsureKubeAPIServerDeployment", func() {
-		It("should not modify kube-apiserver deployment if SNI is enabled", func() {
-			var (
-				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   v1beta1constants.DeploymentNameKubeAPIServer,
-						Labels: map[string]string{"core.gardener.cloud/apiserver-exposure": "gardener-managed"},
-					},
-					Spec: appsv1.DeploymentSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name: "kube-apiserver",
-									},
-								},
-							},
-						},
-					},
-				}
-				depCopy = dep.DeepCopy()
-			)
-
-			// Create ensurer
-			ensurer := NewEnsurer(etcdStorage, logger)
-
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, dummyContext, dep, nil)
-			Expect(err).To(Not(HaveOccurred()))
-
-			Expect(dep).To(Equal(depCopy))
-		})
-
-		It("should add missing elements to kube-apiserver deployment", func() {
-			var (
-				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer},
-					Spec: appsv1.DeploymentSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name: "kube-apiserver",
-									},
-								},
-							},
-						},
-					},
-				}
-			)
-
-			// Create ensurer
-			ensurer := NewEnsurer(etcdStorage, logger)
-
-			// Call EnsureKubeAPIServerDeployment method and check the result
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, dummyContext, dep, nil)
-			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep)
-		})
-
-		It("should modify existing elements of kube-apiserver deployment", func() {
-			var (
-				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer},
-					Spec: appsv1.DeploymentSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name:    "kube-apiserver",
-										Command: []string{"--endpoint-reconciler-type=?"},
-									},
-								},
-							},
-						},
-					},
-				}
-			)
-
-			// Create ensurer
-			ensurer := NewEnsurer(etcdStorage, logger)
-
-			// Call EnsureKubeAPIServerDeployment method and check the result
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, dummyContext, dep, nil)
-			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep)
-		})
-	})
 
 	Describe("#EnsureETCD", func() {
 		It("should add or modify elements to etcd-main statefulset", func() {
@@ -255,13 +125,6 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
-	// Check that the kube-apiserver container still exists and contains all needed command line args
-	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-apiserver")
-	Expect(c).To(Not(BeNil()))
-	Expect(c.Command).To(ContainElement("--endpoint-reconciler-type=none"))
-}
-
 func checkETCDMain(etcd *druidv1alpha1.Etcd) {
 	Expect(*etcd.Spec.StorageClass).To(Equal("gardener.cloud-fast"))
 	Expect(*etcd.Spec.StorageCapacity).To(Equal(resource.MustParse("80Gi")))
@@ -269,5 +132,4 @@ func checkETCDMain(etcd *druidv1alpha1.Etcd) {
 
 func checkETCDEvents(etcd *druidv1alpha1.Etcd) {
 	Expect(*etcd.Spec.StorageClass).To(Equal(""))
-
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
This PR removes all code related to the removed `APIServerSNI` feature gate of `gardenlet` since it is no longer relevant now (it wasn't relevant for a long time already since the feature gate was locked to "enabled").

**Special notes for your reviewer**:
Related to https://github.com/gardener/gardener/pull/8062

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
All code related to the removed `APIServerSNI` feature gate of `gardenlet` has been removed from this extension.
```