### PR TITLE
[release-v1.44] Vendor gardener/gardener@v1.71.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.173
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/gardener/etcd-druid v0.15.3
-	github.com/gardener/gardener v1.71.0
+	github.com/gardener/gardener v1.71.5
 	github.com/gardener/gardener-extension-networking-calico v1.27.1
 	github.com/gardener/gardener-extension-networking-cilium v1.18.0
 	github.com/gardener/machine-controller-manager v0.48.1

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gardener/etcd-druid v0.15.3 h1:IMsJTaUaSOXusfgOOF5GX5eJ0o1CI/9XtKzgxwWJ0Eo=
 github.com/gardener/etcd-druid v0.15.3/go.mod h1:VTxoQXmaE2RSP+LQS5qWUDoXzmdK6xlKLUdFhaGu6KM=
-github.com/gardener/gardener v1.71.0 h1:W0Yuc+QpLD/eyFLr9Xweuh92Jt5kFRIGRMF+wKmhvdw=
-github.com/gardener/gardener v1.71.0/go.mod h1:l6FaKO0wqF2qaUe4Zh05/CYGMNDAOuoqRGfHUnbjQ74=
+github.com/gardener/gardener v1.71.5 h1:trw2IXgRGjknBMELqeU7T7jWjAFJT5zaAbSMqPaUkTY=
+github.com/gardener/gardener v1.71.5/go.mod h1:l6FaKO0wqF2qaUe4Zh05/CYGMNDAOuoqRGfHUnbjQ74=
 github.com/gardener/gardener-extension-networking-calico v1.27.1 h1:q/lsdqbwV+qlwNPxlqFxGeqKMDwPk+dPhUGXjxObzGE=
 github.com/gardener/gardener-extension-networking-calico v1.27.1/go.mod h1:MURFRmYPHiXSfmJ82S3nXH3qGcszeYQwhMVKn/J5XoU=
 github.com/gardener/gardener-extension-networking-cilium v1.18.0 h1:LNBMqVAkltHBDkP+C5Vq/dFgve/YOG8MIvTJJuWWCtU=

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/helper.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/helper.go
@@ -668,7 +668,7 @@ func IsAPIServerExposureManaged(obj metav1.Object) bool {
 }
 
 // FindPrimaryDNSProvider finds the primary provider among the given `providers`.
-// It returns the first provider in case no primary provider is available or the first one if multiple candidates are found.
+// It returns the first provider if multiple candidates are found.
 func FindPrimaryDNSProvider(providers []gardencorev1beta1.DNSProvider) *gardencorev1beta1.DNSProvider {
 	for _, provider := range providers {
 		if provider.Primary != nil && *provider.Primary {

--- a/vendor/github.com/gardener/gardener/pkg/controllerutils/miscellaneous.go
+++ b/vendor/github.com/gardener/gardener/pkg/controllerutils/miscellaneous.go
@@ -29,7 +29,7 @@ import (
 )
 
 // DefaultReconciliationTimeout is the default timeout for the context of reconciliation functions.
-const DefaultReconciliationTimeout = 1 * time.Minute
+const DefaultReconciliationTimeout = 3 * time.Minute
 
 const separator = ","
 

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/managedseed.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/managedseed.go
@@ -43,7 +43,7 @@ func GetManagedSeedWithReader(ctx context.Context, r client.Reader, shootNamespa
 	return &managedSeedList.Items[0], nil
 }
 
-// GetManagedSeedByName tries to reads a ManagedSeed in the garden namespace. If it's not found then `nil` is returned.
+// GetManagedSeedByName tries to read a ManagedSeed in the garden namespace. If it's not found then `nil` is returned.
 func GetManagedSeedByName(ctx context.Context, client client.Client, name string) (*seedmanagementv1alpha1.ManagedSeed, error) {
 	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
 	if err := client.Get(ctx, Key(constants.GardenNamespace, name), managedSeed); err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -137,7 +137,7 @@ github.com/fsnotify/fsnotify
 # github.com/gardener/etcd-druid v0.15.3
 ## explicit; go 1.19
 github.com/gardener/etcd-druid/api/v1alpha1
-# github.com/gardener/gardener v1.71.0
+# github.com/gardener/gardener v1.71.5
 ## explicit; go 1.20
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/platform aws

**What this PR does / why we need it**:
This PR vendors github.com/gardener/gardener@v1.75.0 in order to adopt cherry-pick of https://github.com/gardener/gardener/pull/8059.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8058

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following dependency is updated to adopt a fix for https://github.com/gardener/gardener/issues/8058:
- github.com/gardener/gardener: v1.71.0 -> v1.71.5
```
