### PR TITLE
Infraflow: Fix tag value for elb roles

### DIFF
--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -38,8 +38,8 @@ const (
 	TagKeyRolePrivateELB = "kubernetes.io/role/internal-elb"
 	// TagValueCluster is the tag value for the cluster tag
 	TagValueCluster = "1"
-	// TagValueUse is the tag value for the ELB tag keys
-	TagValueUse = "use"
+	// TagValueELB is the tag value for the ELB tag keys
+	TagValueELB = "1"
 
 	// IdentifierVPC is the key for the VPC id
 	IdentifierVPC = "VPC"

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -517,9 +517,9 @@ func (c *FlowContext) ensureZones(ctx context.Context) error {
 		helper := c.zoneSuffixHelpers(zone.Name)
 		tagsWorkers := c.commonTagsWithSuffix(helper.GetSuffixSubnetWorkers())
 		tagsPublic := c.commonTagsWithSuffix(helper.GetSuffixSubnetPublic())
-		tagsPublic[TagKeyRolePublicELB] = TagValueUse
+		tagsPublic[TagKeyRolePublicELB] = TagValueELB
 		tagsPrivate := c.commonTagsWithSuffix(helper.GetSuffixSubnetPrivate())
-		tagsPrivate[TagKeyRolePrivateELB] = TagValueUse
+		tagsPrivate[TagKeyRolePrivateELB] = TagValueELB
 		desired = append(desired,
 			&awsclient.Subnet{
 				Tags:             tagsWorkers,

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -1065,7 +1065,7 @@ func verifyCreation(
 				Expect(subnet.Tags).To(ConsistOf([]*ec2.Tag{
 					{
 						Key:   awssdk.String(kubernetesRoleTagPrefix + "elb"),
-						Value: awssdk.String("use"),
+						Value: awssdk.String("1"),
 					},
 					{
 						Key:   awssdk.String(kubernetesClusterTagPrefix + infra.Namespace),
@@ -1087,7 +1087,7 @@ func verifyCreation(
 				Expect(subnet.Tags).To(ConsistOf([]*ec2.Tag{
 					{
 						Key:   awssdk.String(kubernetesRoleTagPrefix + "internal-elb"),
-						Value: awssdk.String("use"),
+						Value: awssdk.String("1"),
 					},
 					{
 						Key:   awssdk.String(kubernetesClusterTagPrefix + infra.Namespace),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:
The terraform templates have been adjusted in PR #717 to set the values for tags `kubernetes.io/role/elb` and `kubernetes.io/role/internal-elb` to `1` instead to `use`. The value `1` is required by the ALB (see [here](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.5/deploy/subnet_discovery/))
 
With this fix, this change is also done for the non-terraform infrastructure controller logic.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
see https://github.com/gardener/gardener-extension-provider-aws/commit/a2988fb11daec0bd78423e22aab0345f2daf3ed1#diff-afc289f8d352f18cb669b37b6e50a550c93f0a42a2a6f143256c7aee9c778a17R167

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
