### PR TITLE
No caching of secrets

### DIFF
--- a/cmd/gardener-extension-provider-aws/app/app.go
+++ b/cmd/gardener-extension-provider-aws/app/app.go
@@ -32,10 +32,12 @@ import (
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	autoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/component-base/version/verflag"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -184,7 +186,11 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 					return fmt.Errorf("error ensuring the machine CRDs: %w", err)
 				}
 			}
-			mgr, err := manager.New(restOpts.Completed().Config, mgrOpts.Completed().Options())
+			mopts := mgrOpts.Completed().Options()
+			mopts.ClientDisableCacheFor = []client.Object{
+				&corev1.Secret{},
+			}
+			mgr, err := manager.New(restOpts.Completed().Config, mopts)
 			if err != nil {
 				return fmt.Errorf("could not instantiate manager: %w", err)
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area cost
/kind enhancement
/platform aws

**What this PR does / why we need it**:
By default, the controller-runtime caches all objects of kinds which are accessed.
On very large seeds caching secrets can consume GBs of memory.
Therefore it is better to disable caching of secret objects.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I made a small benchmark on an empty seed with 230 secrets (150 big secrets added to make differences more visibile).

Memory usage with caching of secrets:
```bash
$ k -n extension-provider-aws-zj2jw top po
NAME                                               CPU(cores)   MEMORY(bytes)
gardener-extension-provider-aws-6cb999694d-fnfhz   5m           202Mi
gardener-extension-provider-aws-6cb999694d-nk6ln   1m           173Mi
```
During startup, the memory went even shortly up to 500Mi and high CPU usage was also seen.

After disabling caching secrets:
```bash
$ k -n extension-provider-aws-zj2jw top po
NAME                                               CPU(cores)   MEMORY(bytes)
gardener-extension-provider-aws-5bf5ddf647-rdjpr   2m           27Mi
gardener-extension-provider-aws-5bf5ddf647-txkd4   5m           35Mi
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
No caching of secrets
```
