### PR TITLE
update timeout for release pipeline

### DIFF
--- a/.ci/test-integration.sh
+++ b/.ci/test-integration.sh
@@ -12,6 +12,6 @@ mkdir -p /tm
     --tm-kubeconfig-path=/tm/kubeconfig \
     --no-execution-group \
     --testrun-prefix tm-extension-aws- \
-    --timeout=1800 \
+    --timeout=3600 \
     --testruns-chart-path=.ci/testruns/default \
     --set revision="$(git rev-parse HEAD)"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind regression
/platform aws

**What this PR does / why we need it**:

Same as https://github.com/gardener/gardener-extension-provider-aws/pull/778/commits/36ad694fae256aad8938ca84aad3fb8b57bcc2b6 -> increate the timeout for the release pipeline to accomodate the newer tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
