### PR TITLE
Drop support for Shoots with Kubernetes version < 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.26 | 1.26.0+     | [![Gardener v1.26 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.26%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.26%20AWS) |
 | Kubernetes 1.25 | 1.25.0+     | [![Gardener v1.25 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.25%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.25%20AWS) |
 | Kubernetes 1.24 | 1.24.0+     | [![Gardener v1.24 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.24%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.24%20AWS) |
-| Kubernetes 1.23 | 1.23.0+     | [![Gardener v1.23 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.23%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.23%20AWS) |
-| Kubernetes 1.22 | 1.22.0+     | [![Gardener v1.22 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.22%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.22%20AWS) |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/charts/internal/aws-lb-readvertiser/charts/utils-templates/templates/_versions.tpl
+++ b/charts/internal/aws-lb-readvertiser/charts/utils-templates/templates/_versions.tpl
@@ -47,11 +47,7 @@ batch/v1
 {{- end -}}
 
 {{- define "hpaversion" -}}
-{{- if semverCompare ">= 1.23-0" .Capabilities.KubeVersion.GitVersion -}}
 autoscaling/v2
-{{- else -}}
-autoscaling/v2beta1
-{{- end -}}
 {{- end -}}
 
 {{- define "webhookadmissionregistration" -}}

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
@@ -56,9 +56,6 @@ spec:
         - --authorization-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
         - --leader-elect=true
         - --secure-port={{ include "cloud-controller-manager.port" . }}
-        {{- if semverCompare "< 1.24" .Values.kubernetesVersion }}
-        - --port=0
-        {{- end }}
         - --tls-cert-file=/var/lib/cloud-controller-manager-server/tls.crt
         - --tls-private-key-file=/var/lib/cloud-controller-manager-server/tls.key
         - --tls-cipher-suites={{ .Values.tlsCipherSuites | join "," }}

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -1,6 +1,6 @@
 replicas: 1
 clusterName: shoot-foo-bar
-kubernetesVersion: 1.23.9
+kubernetesVersion: 1.26.8
 podNetwork: 192.168.0.0/16
 podAnnotations: {}
 podLabels: {}

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -44,8 +44,8 @@ spec:
   type: aws
   kubernetes:
     versions:
-    - version: 1.24.3
-    - version: 1.23.8
+    - version: 1.27.3
+    - version: 1.26.8
       expirationDate: "2022-10-31T23:59:59Z"
   machineImages:
   - name: coreos

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -16,34 +16,6 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-aws
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
-  tag: "v1.22.17"
-  targetVersion: "1.22.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-- name: cloud-controller-manager
-  sourceRepository: github.com/gardener/cloud-provider-aws
-  repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
-  tag: "v1.23.15"
-  targetVersion: "1.23.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-- name: cloud-controller-manager
-  sourceRepository: github.com/gardener/cloud-provider-aws
-  repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws
   tag: "v1.24.13"
   targetVersion: "1.24.x"
   labels:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup
/platform aws

**What this PR does / why we need it**:
Drop support for kubernetes < 1.24 for AWS extension provider

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8405

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`provider-aws` no longer supports Shoots or Seeds with Кubernetes version < 1.24.
```
