### PR TITLE
Modify the AWS Load Balancer Controller deployment to use an AWS credentials file for authentication.

### DIFF
--- a/charts/internal/seed-controlplane/charts/aws-load-balancer-controller/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/aws-load-balancer-controller/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
                     path: token
                 name: shoot-access-aws-load-balancer-controller
                 optional: false
+      - name: cloudprovider
+        secret:
+          secretName: cloudprovider
       # end provider-aws-specific
       {{- with .Values.extraVolumes }}
       {{ toYaml . | nindent 6 }}
@@ -169,16 +172,8 @@ spec:
         # end provider-aws-specific
         env:
         # start provider-aws-specific
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: cloudprovider
-              key: accessKeyID
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: cloudprovider
-              key: secretAccessKey
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /srv/cloudprovider/credentialsFile
         # end provider-aws-specific
         {{- if .Values.env }}
         {{- range $key, $value := .Values.env }}
@@ -201,6 +196,8 @@ spec:
         - name: kubeconfig
           mountPath: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig
           readOnly: true
+        - name: cloudprovider
+          mountPath: /srv/cloudprovider
         # end provider-aws-specific
         {{- with .Values.extraVolumeMounts }}
         {{ toYaml . | nindent 8 }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area compliance
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR modifies the `aws-load-balancer-controller` deployment to use an AWS credentials file for authentication.
These changes are in sync with Kubernetes' STIG. See rule [242415](https://www.stigviewer.com/stig/kubernetes/2022-09-13/finding/V-242415) for more details.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `aws-load-balancer-controller` deployment now uses an AWS credentials file for authentication.
```
