### PR TITLE
[release-v1.50] Automated cherry pick of #825: [ci:component:github.com/gardener/machine-controller-manager-provider-aws:v0.19.1->v0.19.2]

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -99,7 +99,7 @@ images:
 - name: machine-controller-manager-provider-aws
   sourceRepository: github.com/gardener/machine-controller-manager-provider-aws
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-aws
-  tag: "v0.19.1"
+  tag: "v0.19.2"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/kind bug

Cherry pick of #825 on release-v1.50.

#825: [ci:component:github.com/gardener/machine-controller-manager-provider-aws:v0.19.1->v0.19.2]

**Release Notes:**
```other operator github.com/gardener/machine-controller-manager #866 @gardener-robot-ci-2
The default `machine-safety-orphan-vms-period` has been reduced from 30m to 15m.
```
```bugfix operator github.com/gardener/machine-controller-manager #866 @gardener-robot-ci-2
Removes `node.machine.sapcloud.io/not-managed-by-mcm` annotation from nodes managed by the MCM.
```