### PR TITLE
Add new mutator tests to clarify expected behavior.

### DIFF
--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -255,6 +255,17 @@ var _ = Describe("Shoot mutator", func() {
 				}))
 			})
 
+			It("should disable overlay for a new shoot non empty network config", func() {
+				shoot.Spec.Networking.ProviderConfig = &runtime.RawExtension{
+					Raw: []byte(`{"foo":{"enabled":true}}`),
+				}
+				err := shootMutator.Mutate(ctx, shoot, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot.Spec.Networking.ProviderConfig).To(Equal(&runtime.RawExtension{
+					Raw: []byte(`{"foo":{"enabled":true},"overlay":{"enabled":false}}`),
+				}))
+			})
+
 			It("should take overlay field value from old shoot when unspecified in new shoot", func() {
 				oldShoot.Spec.Networking.ProviderConfig = &runtime.RawExtension{
 					Raw: []byte(`{"overlay":{"enabled":true}}`),
@@ -265,6 +276,13 @@ var _ = Describe("Shoot mutator", func() {
 					Raw: []byte(`{"overlay":{"enabled":true}}`),
 				}))
 			})
+
+			It("should not add the overlay field when unspecified in new and old shoot", func() {
+				err := shootMutator.Mutate(ctx, shoot, oldShoot)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot.Spec.Networking.ProviderConfig).To(BeNil())
+			})
+
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind test
/platform aws

**What this PR does / why we need it**:
Add tow more test:
* Check that arbitrary network config is not lost.
* Check that existing shoots with no overlay config don't get one.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Add new unit tests.
```
