### PR TITLE
Add support to dual-stack ingress with bring-your-own VPC.

### DIFF
--- a/docs/usage/dual-stack-ingress.md
+++ b/docs/usage/dual-stack-ingress.md
@@ -52,6 +52,8 @@ spec:
 ...
 ```
 
+When `infrastructureConfig.networks.vpc.id` is set to the ID of an existing VPC, please make sure that your VPC has an [Amazon-provided IPv6 CIDR block added](https://docs.aws.amazon.com/vpc/latest/userguide/modify-vpcs.html#vpc-associate-ipv6-cidr).
+
 After adapting the shoot specification and reconciling the cluster, dual-stack load balancers can be created using
 kubernetes services objects.
 

--- a/pkg/aws/client/mock/mocks.go
+++ b/pkg/aws/client/mock/mocks.go
@@ -964,6 +964,21 @@ func (mr *MockInterfaceMockRecorder) GetIAMRolePolicy(arg0, arg1, arg2 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIAMRolePolicy", reflect.TypeOf((*MockInterface)(nil).GetIAMRolePolicy), arg0, arg1, arg2)
 }
 
+// GetIPv6Cidr mocks base method.
+func (m *MockInterface) GetIPv6Cidr(arg0 context.Context, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIPv6Cidr", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIPv6Cidr indicates an expected call of GetIPv6Cidr.
+func (mr *MockInterfaceMockRecorder) GetIPv6Cidr(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPv6Cidr", reflect.TypeOf((*MockInterface)(nil).GetIPv6Cidr), arg0, arg1)
+}
+
 // GetInternetGateway mocks base method.
 func (m *MockInterface) GetInternetGateway(arg0 context.Context, arg1 string) (*client.InternetGateway, error) {
 	m.ctrl.T.Helper()

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -64,6 +64,7 @@ type Interface interface {
 	FindVpcDhcpOptionsByTags(ctx context.Context, tags Tags) ([]*DhcpOptions, error)
 	DeleteVpcDhcpOptions(ctx context.Context, id string) error
 	CreateVpc(ctx context.Context, vpc *VPC) (*VPC, error)
+	GetIPv6Cidr(ctx context.Context, vpcID string) (string, error)
 	WaitForIPv6Cidr(ctx context.Context, vpcID string) (string, error)
 	AddVpcDhcpOptionAssociation(vpcId string, dhcpOptionsId *string) error
 	UpdateVpcAttribute(ctx context.Context, vpcId, attributeName string, value bool) error

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -440,7 +440,7 @@ func generateTerraformInfraConfig(ctx context.Context, infrastructure *extension
 			"dhcpDomainName":    dhcpDomainName,
 			"internetGatewayID": internetGatewayID,
 			"gatewayEndpoints":  infrastructureConfig.Networks.VPC.GatewayEndpoints,
-			"ipv6CidrBlock":  ipv6CidrBlock,
+			"ipv6CidrBlock":     ipv6CidrBlock,
 		},
 		"clusterName": infrastructure.Namespace,
 		"zones":       zones,

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -366,6 +366,7 @@ func generateTerraformInfraConfig(ctx context.Context, infrastructure *extension
 		vpcID             = "aws_vpc.vpc.id"
 		vpcCIDR           = ""
 		internetGatewayID = "aws_internet_gateway.igw.id"
+		ipv6CidrBlock     = "aws_vpc.vpc.ipv6_cidr_block"
 
 		ignoreTagKeys        []string
 		ignoreTagKeyPrefixes []string
@@ -385,6 +386,11 @@ func generateTerraformInfraConfig(ctx context.Context, infrastructure *extension
 		}
 		vpcID = strconv.Quote(existingVpcID)
 		internetGatewayID = strconv.Quote(existingInternetGatewayID)
+		existingIPv6CidrBlock, err := awsClient.WaitForIPv6Cidr(ctx, existingVpcID)
+		if err != nil {
+			return nil, err
+		}
+		ipv6CidrBlock = strconv.Quote(existingIPv6CidrBlock)
 
 	case infrastructureConfig.Networks.VPC.CIDR != nil:
 		vpcCIDR = *infrastructureConfig.Networks.VPC.CIDR
@@ -434,6 +440,7 @@ func generateTerraformInfraConfig(ctx context.Context, infrastructure *extension
 			"dhcpDomainName":    dhcpDomainName,
 			"internetGatewayID": internetGatewayID,
 			"gatewayEndpoints":  infrastructureConfig.Networks.VPC.GatewayEndpoints,
+			"ipv6CidrBlock":  ipv6CidrBlock,
 		},
 		"clusterName": infrastructure.Namespace,
 		"zones":       zones,

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -65,7 +65,7 @@ func (c *FlowContext) buildReconcileGraph() *flow.Graph {
 
 	ensureVpcIPv6CidrBloc := c.AddTask(g, "ensure IPv6 CIDR Block",
 		c.ensureVpcIPv6CidrBlock,
-		DoIf(createVPC), Timeout(defaultTimeout), Dependencies(ensureVpc))
+		Timeout(defaultTimeout), Dependencies(ensureVpc))
 
 	ensureDefaultSecurityGroup := c.AddTask(g, "ensure default security group",
 		c.ensureDefaultSecurityGroup,
@@ -261,6 +261,9 @@ func (c *FlowContext) validateVpc(ctx context.Context, item *awsclient.VPC) erro
 			return fmt.Errorf("missing DhcpConfiguration '%s'='%s' (actual: %s)",
 				k, strings.Join(v, ","), strings.Join(options.DhcpConfigurations[k], ","))
 		}
+	}
+	if c.config.DualStack != nil && c.config.DualStack.Enabled && item.IPv6CidrBlock == "" {
+		return fmt.Errorf("VPC has no ipv6 CIDR")
 	}
 	return nil
 }

--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -87,7 +87,7 @@ resource "aws_route" "public" {
   }
 }
 
-{{ if and .dualStack.enabled .create.vpc }}
+{{ if .dualStack.enabled }}
 resource "aws_route" "public-ipv6" {
   route_table_id         = aws_route_table.routetable_main.id
   destination_ipv6_cidr_block = "::/0"
@@ -153,8 +153,8 @@ resource "aws_subnet" "nodes_z{{ $index }}" {
   vpc_id            = {{ $.vpc.id }}
   cidr_block        = "{{ $zone.worker }}"
   availability_zone = "{{ $zone.name }}"
-{{- if and $.dualStack.enabled $.create.vpc}}
-  ipv6_cidr_block = "${cidrsubnet(aws_vpc.vpc.ipv6_cidr_block, 8, (({{ $index }} * 3)))}"
+{{- if $.dualStack.enabled }}
+  ipv6_cidr_block = "${cidrsubnet({{ $.vpc.ipv6CidrBlock }}, 8, (({{ $index }} * 3)))}"
   assign_ipv6_address_on_creation = false
 {{- end }}
   timeouts {
@@ -173,8 +173,8 @@ resource "aws_subnet" "private_utility_z{{ $index }}" {
   vpc_id            = {{ $.vpc.id }}
   cidr_block        = "{{ $zone.internal }}"
   availability_zone = "{{ $zone.name }}"
-{{- if and $.dualStack.enabled $.create.vpc}}
-  ipv6_cidr_block = "${cidrsubnet(aws_vpc.vpc.ipv6_cidr_block, 8, (1 + ({{ $index }} * 3)))}"
+{{- if $.dualStack.enabled }}
+  ipv6_cidr_block = "${cidrsubnet({{ $.vpc.ipv6CidrBlock }}, 8, (1 + ({{ $index }} * 3)))}"
   assign_ipv6_address_on_creation = false
 {{- end }}
   timeouts {
@@ -211,8 +211,8 @@ resource "aws_subnet" "public_utility_z{{ $index }}" {
   vpc_id            = {{ $.vpc.id }}
   cidr_block        = "{{ $zone.public }}"
   availability_zone = "{{ $zone.name }}"
-{{- if and $.dualStack.enabled $.create.vpc}}
-  ipv6_cidr_block = "${cidrsubnet(aws_vpc.vpc.ipv6_cidr_block, 8, (2 + ({{ $index }} * 3)))}"
+{{- if $.dualStack.enabled }}
+  ipv6_cidr_block = "${cidrsubnet({{ $.vpc.ipv6CidrBlock }}, 8, (2 + ({{ $index }} * 3)))}"
   assign_ipv6_address_on_creation = false
   {{- end }}
   timeouts {

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -321,7 +321,7 @@ type infrastructure struct {
 }
 
 func setupInfrastructure(ctx context.Context, log logr.Logger, awsClient *awsclient.Client, shootName string) *infrastructure {
-	vpcID, igwID, err := integration.CreateVPC(ctx, log, awsClient, vpcCIDR, true)
+	vpcID, igwID, err := integration.CreateVPC(ctx, log, awsClient, vpcCIDR, true, false)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(vpcID).NotTo(BeEmpty())
 	Expect(igwID).NotTo(BeEmpty())

--- a/test/integration/vpc.go
+++ b/test/integration/vpc.go
@@ -29,10 +29,11 @@ import (
 
 // CreateVPC creates a new VPC and waits for it to become available. It returns
 // the VPC ID, the Internet Gateway ID or an error in case something unexpected happens.
-func CreateVPC(ctx context.Context, log logr.Logger, awsClient *awsclient.Client, vpcCIDR string, enableDnsHostnames bool) (string, string, error) {
+func CreateVPC(ctx context.Context, log logr.Logger, awsClient *awsclient.Client, vpcCIDR string, enableDnsHostnames, dualstack bool) (string, string, error) {
 	createVpcOutput, err := awsClient.EC2.CreateVpc(&ec2.CreateVpcInput{
-		TagSpecifications: awsclient.Tags{"Name": "aws-infrastructure-it-create-vpc"}.ToTagSpecifications(ec2.ResourceTypeVpc),
-		CidrBlock:         awssdk.String(vpcCIDR),
+		TagSpecifications:           awsclient.Tags{"Name": "aws-infrastructure-it-create-vpc"}.ToTagSpecifications(ec2.ResourceTypeVpc),
+		CidrBlock:                   awssdk.String(vpcCIDR),
+		AmazonProvidedIpv6CidrBlock: awssdk.Bool(dualstack),
 	})
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR add support to dual-stack ingress with bring-your-own VPC. Users must assign Amazon managed CIDR range to their VPC. 

**Which issue(s) this PR fixes**:
Fixes # part of https://github.com/gardener/gardener-extension-provider-aws/issues/833

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
dual-stack ingress with bring-your-own VPC is supported.
```
