### PR TITLE
[dnsrecords] create AAAA alias targets for load balancers with IPv6 addresses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.173
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/gardener/etcd-druid v0.22.0
+	github.com/gardener/external-dns-management v0.17.1
 	github.com/gardener/gardener v1.87.0
 	github.com/gardener/machine-controller-manager v0.50.0
 	github.com/go-logr/logr v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gardener/etcd-druid v0.22.0 h1:DVe+Zjrb93r9vI1uUiCTMHBffIUoMAKhNzFZNC6hsQ8=
 github.com/gardener/etcd-druid v0.22.0/go.mod h1:FROhfVKyWBo4krlPe3R6FIhJRmOmijEWBdEeUP0CJjE=
+github.com/gardener/external-dns-management v0.17.1 h1:fvdl36E6PJVcyRm4AJt6w+4bqAqft22sxiNkg1em7TY=
+github.com/gardener/external-dns-management v0.17.1/go.mod h1:mTOCgst9Rda9MNmJtYiel+JFvbo7EUUBwOfCjN6zyRc=
 github.com/gardener/gardener v1.87.0 h1:aCZuGdQ5HS9u3xuVJsj2EpOJlcDtNqoNvzHaHTZgjtM=
 github.com/gardener/gardener v1.87.0/go.mod h1:MNqPkSxLD2w+HeIP56JnZbZtaqPnDb4hSRl3JWEZTWU=
 github.com/gardener/hvpa-controller/api v0.5.0 h1:f4F3O7YUrenwh4S3TgPREPiB287JjjUiUL18OqPLyAA=

--- a/pkg/apis/aws/const.go
+++ b/pkg/apis/aws/const.go
@@ -22,4 +22,6 @@ const (
 	SeedLabelKeyUseFlow = AnnotationKeyUseFlow
 	// SeedLabelUseFlowValueNew is the value to restrict flow reconciliation to new shoot clusters
 	SeedLabelUseFlowValueNew = "new"
+	// AnnotationKeyIPStack is the annotation key to set the IP stack for a DNSRecord.
+	AnnotationKeyIPStack = "dns.gardener.cloud/ip-stack"
 )

--- a/pkg/aws/client/mock/mocks.go
+++ b/pkg/aws/client/mock/mocks.go
@@ -196,17 +196,17 @@ func (mr *MockInterfaceMockRecorder) CreateNATGateway(arg0, arg1 interface{}) *g
 }
 
 // CreateOrUpdateDNSRecordSet mocks base method.
-func (m *MockInterface) CreateOrUpdateDNSRecordSet(arg0 context.Context, arg1, arg2, arg3 string, arg4 []string, arg5 int64) error {
+func (m *MockInterface) CreateOrUpdateDNSRecordSet(arg0 context.Context, arg1, arg2, arg3 string, arg4 []string, arg5 int64, arg6 client.IPStack) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdateDNSRecordSet", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "CreateOrUpdateDNSRecordSet", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateOrUpdateDNSRecordSet indicates an expected call of CreateOrUpdateDNSRecordSet.
-func (mr *MockInterfaceMockRecorder) CreateOrUpdateDNSRecordSet(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) CreateOrUpdateDNSRecordSet(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateDNSRecordSet", reflect.TypeOf((*MockInterface)(nil).CreateOrUpdateDNSRecordSet), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateDNSRecordSet", reflect.TypeOf((*MockInterface)(nil).CreateOrUpdateDNSRecordSet), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // CreateRoute mocks base method.
@@ -357,17 +357,17 @@ func (mr *MockInterfaceMockRecorder) DeleteBucketIfExists(arg0, arg1 interface{}
 }
 
 // DeleteDNSRecordSet mocks base method.
-func (m *MockInterface) DeleteDNSRecordSet(arg0 context.Context, arg1, arg2, arg3 string, arg4 []string, arg5 int64) error {
+func (m *MockInterface) DeleteDNSRecordSet(arg0 context.Context, arg1, arg2, arg3 string, arg4 []string, arg5 int64, arg6 client.IPStack) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteDNSRecordSet", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "DeleteDNSRecordSet", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteDNSRecordSet indicates an expected call of DeleteDNSRecordSet.
-func (mr *MockInterfaceMockRecorder) DeleteDNSRecordSet(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) DeleteDNSRecordSet(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDNSRecordSet", reflect.TypeOf((*MockInterface)(nil).DeleteDNSRecordSet), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDNSRecordSet", reflect.TypeOf((*MockInterface)(nil).DeleteDNSRecordSet), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // DeleteEC2Tags mocks base method.

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -32,6 +32,18 @@ const (
 	errCodeBucketNotEmpty = "BucketNotEmpty"
 )
 
+// IPStack is an enumeration of IP stacks
+type IPStack string
+
+const (
+	// IPStackIPv4 is the default IPv4 stack
+	IPStackIPv4 IPStack = "ipv4"
+	// IPStackIPDualStack is the IPv4/IPv6 dual-stack
+	IPStackIPDualStack IPStack = "dual-stack"
+	// IPStackIPv6 is the IPv6 stack
+	IPStackIPv6 IPStack = "ipv6"
+)
+
 // Interface is an interface which must be implemented by AWS clients.
 type Interface interface {
 	GetAccountID(ctx context.Context) (string, error)
@@ -48,8 +60,8 @@ type Interface interface {
 
 	// Route53 wrappers
 	GetDNSHostedZones(ctx context.Context) (map[string]string, error)
-	CreateOrUpdateDNSRecordSet(ctx context.Context, zoneId, name, recordType string, values []string, ttl int64) error
-	DeleteDNSRecordSet(ctx context.Context, zoneId, name, recordType string, values []string, ttl int64) error
+	CreateOrUpdateDNSRecordSet(ctx context.Context, zoneId, name, recordType string, values []string, ttl int64, stack IPStack) error
+	DeleteDNSRecordSet(ctx context.Context, zoneId, name, recordType string, values []string, ttl int64, stack IPStack) error
 
 	// The following functions are only temporary needed due to https://github.com/gardener/gardener/issues/129.
 	ListKubernetesELBs(ctx context.Context, vpcID, clusterName string) ([]string, error)

--- a/pkg/controller/dnsrecord/actuator_test.go
+++ b/pkg/controller/dnsrecord/actuator_test.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
+	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
 	mockawsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client/mock"
 	. "github.com/gardener/gardener-extension-provider-aws/pkg/controller/dnsrecord"
 )
@@ -144,8 +145,8 @@ var _ = Describe("Actuator", func() {
 
 		It("should reconcile the DNSRecord", func() {
 			awsClient.EXPECT().GetDNSHostedZones(ctx).Return(zones, nil)
-			awsClient.EXPECT().CreateOrUpdateDNSRecordSet(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120)).Return(nil)
-			awsClient.EXPECT().DeleteDNSRecordSet(ctx, zone, "comment-"+domainName, "TXT", nil, int64(0)).Return(nil)
+			awsClient.EXPECT().CreateOrUpdateDNSRecordSet(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120), awsclient.IPStackIPv4).Return(nil)
+			awsClient.EXPECT().DeleteDNSRecordSet(ctx, zone, "comment-"+domainName, "TXT", nil, int64(0), awsclient.IPStackIPv4).Return(nil)
 			sw.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.DNSRecord{}), gomock.Any()).DoAndReturn(
 				func(_ context.Context, obj *extensionsv1alpha1.DNSRecord, _ client.Patch, opts ...client.PatchOption) error {
 					Expect(obj.Status).To(Equal(extensionsv1alpha1.DNSRecordStatus{
@@ -162,7 +163,7 @@ var _ = Describe("Actuator", func() {
 		It("should fail if creating the DNS record set failed", func() {
 			dns.Spec.Zone = pointer.String(zone)
 
-			awsClient.EXPECT().CreateOrUpdateDNSRecordSet(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120)).
+			awsClient.EXPECT().CreateOrUpdateDNSRecordSet(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120), awsclient.IPStackIPv4).
 				Return(errors.New("test"))
 
 			err := a.Reconcile(ctx, logger, dns, nil)
@@ -174,7 +175,7 @@ var _ = Describe("Actuator", func() {
 		It("should fail with ERR_CONFIGURATION_PROBLEM if there is no such hosted zone", func() {
 			dns.Spec.Zone = pointer.String(zone)
 
-			awsClient.EXPECT().CreateOrUpdateDNSRecordSet(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120)).
+			awsClient.EXPECT().CreateOrUpdateDNSRecordSet(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120), awsclient.IPStackIPv4).
 				Return(awserr.New(route53.ErrCodeNoSuchHostedZone, "", nil))
 
 			err := a.Reconcile(ctx, logger, dns, nil)
@@ -187,7 +188,7 @@ var _ = Describe("Actuator", func() {
 		It("should fail with ERR_CONFIGURATION_PROBLEM if the domain name is not permitted in the zone", func() {
 			dns.Spec.Zone = pointer.String(zone)
 
-			awsClient.EXPECT().CreateOrUpdateDNSRecordSet(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120)).
+			awsClient.EXPECT().CreateOrUpdateDNSRecordSet(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120), awsclient.IPStackIPv4).
 				Return(awserr.New(route53.ErrCodeInvalidChangeBatch, "RRSet with DNS name api.aws.foobar.shoot.example.com. is not permitted in zone foo.com.", nil))
 
 			err := a.Reconcile(ctx, logger, dns, nil)
@@ -209,7 +210,7 @@ var _ = Describe("Actuator", func() {
 				},
 			)
 			awsClientFactory.EXPECT().NewClient(accessKeyID, secretAccessKey, aws.DefaultDNSRegion).Return(awsClient, nil)
-			awsClient.EXPECT().DeleteDNSRecordSet(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120)).Return(nil)
+			awsClient.EXPECT().DeleteDNSRecordSet(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120), awsclient.IPStackIPv4).Return(nil)
 
 			err := a.Delete(ctx, logger, dns, nil)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
On creating a `DNSRecord` for a AWS load balancer, the requested `CNAME`  record was always mapped to an `A` alias target recordset only. 
With this PR, creation of  `A` and/or `AAAA` recordsets can be controlled with the annotation `dns.gardener.cloud/ip-stack`. Possible values for the annotation are `ipv4`, `ipv6`, and `dual-stack`. In this way, e.g. dual-stack load balancers for the apiserver can be supported.

Additionally, the list of canonical hosted zone IDs was updated with some newer AWS zones.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[dnsrecords] AAAA alias targets for load balancers with IPv6 addresses with annotation `dns.gardener.cloud/ip-stack=dual-stack`
```
