### PR TITLE
Fix leader election of admission controller

### DIFF
--- a/cmd/gardener-extension-admission-aws/app/app.go
+++ b/cmd/gardener-extension-admission-aws/app/app.go
@@ -113,7 +113,7 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 				managerOptions.LeaderElectionConfig = sourceClusterConfig
 			}
 
-			mgr, err := manager.New(restOpts.Completed().Config, mgrOpts.Completed().Options())
+			mgr, err := manager.New(restOpts.Completed().Config, managerOptions)
 			if err != nil {
 				return fmt.Errorf("could not instantiate manager: %w", err)
 			}

--- a/cmd/gardener-extension-admission-aws/app/app.go
+++ b/cmd/gardener-extension-admission-aws/app/app.go
@@ -26,11 +26,13 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -111,6 +113,13 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 					return err
 				}
 				managerOptions.LeaderElectionConfig = sourceClusterConfig
+			} else {
+				// Restrict the cache for secrets to the configured namespace to avoid the need for cluster-wide list/watch permissions.
+				managerOptions.Cache = cache.Options{
+					ByObject: map[client.Object]cache.ByObject{
+						&corev1.Secret{}: {Namespaces: map[string]cache.Config{webhookOptions.Server.Completed().Namespace: {}}},
+					},
+				}
 			}
 
 			mgr, err := manager.New(restOpts.Completed().Config, managerOptions)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug
/platform aws

**What this PR does / why we need it**:
This PR rectifies the leader election for the admission controller (introduced with #844).

**Special notes for your reviewer**:
⚠️ Must be part of `v1.52` release.

/cc @MartinWeindel

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
