### PR TITLE
Inserts `Architecture`  from worker to machineclass

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -27,6 +27,7 @@ metadata:
     {{- end }}
 {{- if $machineClass.nodeTemplate }}
 nodeTemplate:
+  architecture: {{$machineClass.nodeTemplate.architecture}}
   capacity:
 {{ toYaml $machineClass.nodeTemplate.capacity | indent 4 }}
   instanceType: {{ $machineClass.nodeTemplate.instanceType }}

--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -27,7 +27,7 @@ metadata:
     {{- end }}
 {{- if $machineClass.nodeTemplate }}
 nodeTemplate:
-  architecture: {{$machineClass.nodeTemplate.architecture}}
+  architecture: {{ $machineClass.nodeTemplate.architecture }}
   capacity:
 {{ toYaml $machineClass.nodeTemplate.capacity | indent 4 }}
   instanceType: {{ $machineClass.nodeTemplate.instanceType }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -6,6 +6,7 @@ machineClasses:
   region: eu-west-1
   machineType: m4.xlarge
   nodeTemplate:
+    architecture: amd64
     capacity:
       cpu: 4
       gpu: 0

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -191,6 +191,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 					InstanceType: pool.MachineType,
 					Region:       w.worker.Spec.Region,
 					Zone:         zone,
+					Architecture: &arch,
 				}
 			} else if pool.NodeTemplate != nil {
 				machineClassSpec["nodeTemplate"] = machinev1alpha1.NodeTemplate{
@@ -198,6 +199,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 					InstanceType: pool.MachineType,
 					Region:       w.worker.Spec.Region,
 					Zone:         zone,
+					Architecture: &arch,
 				}
 			}
 

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -289,7 +289,7 @@ var _ = Describe("Machines", func() {
 										{
 											Name:         region,
 											AMI:          machineImageAMI,
-											Architecture: pointer.String(archARM),
+											Architecture: ptr.To(archARM),
 										},
 									},
 								},

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -85,8 +85,9 @@ var _ = Describe("Machines", func() {
 				securityGroupID       string
 				keyName               string
 
-				archAMD string
-				archARM string
+				archAMD  string
+				archARM  string
+				archFAKE string
 
 				volumeType       string
 				volumeSize       int
@@ -126,9 +127,11 @@ var _ = Describe("Machines", func() {
 
 				labels map[string]string
 
-				nodeCapacity      corev1.ResourceList
-				nodeTemplateZone1 machinev1alpha1.NodeTemplate
-				nodeTemplateZone2 machinev1alpha1.NodeTemplate
+				nodeCapacity           corev1.ResourceList
+				nodeTemplatePool1Zone1 machinev1alpha1.NodeTemplate
+				nodeTemplatePool2Zone1 machinev1alpha1.NodeTemplate
+				nodeTemplatePool1Zone2 machinev1alpha1.NodeTemplate
+				nodeTemplatePool2Zone2 machinev1alpha1.NodeTemplate
 
 				machineConfiguration *machinev1alpha1.MachineConfiguration
 
@@ -166,6 +169,7 @@ var _ = Describe("Machines", func() {
 
 				archAMD = "amd64"
 				archARM = "arm64"
+				archFAKE = "fake"
 
 				volumeType = "normal"
 				volumeSize = 20
@@ -210,18 +214,34 @@ var _ = Describe("Machines", func() {
 					"gpu":    resource.MustParse("1"),
 					"memory": resource.MustParse("128Gi"),
 				}
-				nodeTemplateZone1 = machinev1alpha1.NodeTemplate{
+				nodeTemplatePool1Zone1 = machinev1alpha1.NodeTemplate{
 					Capacity:     nodeCapacity,
 					InstanceType: machineType,
 					Region:       region,
 					Zone:         zone1,
+					Architecture: &archAMD,
 				}
-
-				nodeTemplateZone2 = machinev1alpha1.NodeTemplate{
+				nodeTemplatePool1Zone2 = machinev1alpha1.NodeTemplate{
 					Capacity:     nodeCapacity,
 					InstanceType: machineType,
 					Region:       region,
 					Zone:         zone2,
+					Architecture: &archAMD,
+				}
+
+				nodeTemplatePool2Zone1 = machinev1alpha1.NodeTemplate{
+					Capacity:     nodeCapacity,
+					InstanceType: machineType,
+					Region:       region,
+					Zone:         zone1,
+					Architecture: &archARM,
+				}
+				nodeTemplatePool2Zone2 = machinev1alpha1.NodeTemplate{
+					Capacity:     nodeCapacity,
+					InstanceType: machineType,
+					Region:       region,
+					Zone:         zone2,
+					Architecture: &archARM,
 				}
 
 				machineConfiguration = &machinev1alpha1.MachineConfiguration{}
@@ -255,6 +275,21 @@ var _ = Describe("Machines", func() {
 											Name:         region,
 											AMI:          machineImageAMI,
 											Architecture: ptr.To(archAMD),
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: machineImageName,
+							Versions: []apiv1alpha1.MachineImageVersion{
+								{
+									Version: machineImageVersion,
+									Regions: []apiv1alpha1.RegionAMIMapping{
+										{
+											Name:         region,
+											AMI:          machineImageAMI,
+											Architecture: pointer.String(archARM),
 										},
 									},
 								},
@@ -394,6 +429,7 @@ var _ = Describe("Machines", func() {
 							{
 								Name:           namePool2,
 								Minimum:        minPool2,
+								Architecture:   ptr.To(archARM),
 								Maximum:        maxPool2,
 								MaxSurge:       maxSurgePool2,
 								MaxUnavailable: maxUnavailablePool2,
@@ -573,10 +609,10 @@ var _ = Describe("Machines", func() {
 					addNameAndSecretToMachineClass(machineClassPool2Zone1, machineClassWithHashPool2Zone1, w.Spec.SecretRef)
 					addNameAndSecretToMachineClass(machineClassPool2Zone2, machineClassWithHashPool2Zone2, w.Spec.SecretRef)
 
-					addNodeTemplateToMachineClass(machineClassPool1Zone1, nodeTemplateZone1)
-					addNodeTemplateToMachineClass(machineClassPool1Zone2, nodeTemplateZone2)
-					addNodeTemplateToMachineClass(machineClassPool2Zone1, nodeTemplateZone1)
-					addNodeTemplateToMachineClass(machineClassPool2Zone2, nodeTemplateZone2)
+					addNodeTemplateToMachineClass(machineClassPool1Zone1, nodeTemplatePool1Zone1)
+					addNodeTemplateToMachineClass(machineClassPool1Zone2, nodeTemplatePool1Zone2)
+					addNodeTemplateToMachineClass(machineClassPool2Zone1, nodeTemplatePool2Zone1)
+					addNodeTemplateToMachineClass(machineClassPool2Zone2, nodeTemplatePool2Zone2)
 
 					machineClasses = map[string]interface{}{"machineClasses": []map[string]interface{}{
 						machineClassPool1Zone1,
@@ -674,6 +710,12 @@ var _ = Describe("Machines", func() {
 								Version:      machineImageVersion,
 								AMI:          machineImageAMI,
 								Architecture: ptr.To(archAMD),
+							},
+							{
+								Name:         machineImageName,
+								Version:      machineImageVersion,
+								AMI:          machineImageAMI,
+								Architecture: ptr.To(archARM),
 							},
 						},
 					}
@@ -864,7 +906,7 @@ var _ = Describe("Machines", func() {
 			})
 
 			It("should fail because the ami for this architecture cannot be found", func() {
-				w.Spec.Pools[0].Architecture = ptr.To(archARM)
+				w.Spec.Pools[0].Architecture = ptr.To(archFAKE)
 
 				workerDelegate, _ = NewWorkerDelegate(c, decoder, scheme, chartApplier, "", w, cluster)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR  takes the `architecture` field from worker and then inserts it in the machine class
**Which issue(s) this PR fixes**:
Fixes Part of  #https://github.com/gardener/autoscaler/issues/122

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Inserts `architecture` from worker to the machine class
```
