### PR TITLE
switch from public ecr to artifact registry for ipv6 support

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -125,7 +125,7 @@ images:
       availability_requirement: 'low'
 - name: aws-load-balancer-controller
   sourceRepository: github.com/kubernetes-sigs/aws-load-balancer-controller
-  repository: public.ecr.aws/eks/aws-load-balancer-controller
+  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/eks/aws-load-balancer-controller
   tag: "v2.6.1"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
@@ -152,7 +152,7 @@ images:
       availability_requirement: 'low'
 - name: csi-volume-modifier
   sourceRepository: github.com/awslabs/volume-modifier-for-k8s
-  repository: public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s
+  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/ebs-csi-driver/volume-modifier-for-k8s
   tag: "v0.1.3"
   labels:
     - name: 'gardener.cloud/cve-categorisation'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Switch from public ecr to artifact registry to expose images also via IPv6. The PR depends on https://github.com/gardener/ci-infra/pull/982/files.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Switch from public ecr to artifact registry for IPv6 support.
```
