### PR TITLE
Add comment to images.yaml

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -109,7 +109,6 @@ images:
       confidentiality_requirement: 'high'
       integrity_requirement: 'high'
       availability_requirement: 'low'
-
 - name: aws-custom-route-controller
   sourceRepository: github.com/gardener/aws-custom-route-controller
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/aws-custom-route-controller
@@ -125,6 +124,9 @@ images:
       availability_requirement: 'low'
 - name: aws-load-balancer-controller
   sourceRepository: github.com/kubernetes-sigs/aws-load-balancer-controller
+  # We cannot use the upstream repository here as it is not reachable using IPv6.
+  # NOTE: Please make sure to copy new image versions when updating the version by adding them to
+  #       https://github.com/gardener/ci-infra/blob/master/config/images/images.yaml.
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/eks/aws-load-balancer-controller
   tag: "v2.6.1"
   labels:
@@ -136,7 +138,6 @@ images:
         confidentiality_requirement: 'high'
         integrity_requirement: 'high'
         availability_requirement: 'low'
-
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/aws-ebs-csi-driver
   repository: registry.k8s.io/provider-aws/aws-ebs-csi-driver
@@ -152,6 +153,9 @@ images:
       availability_requirement: 'low'
 - name: csi-volume-modifier
   sourceRepository: github.com/awslabs/volume-modifier-for-k8s
+  # We cannot use the upstream repository here as it is not reachable using IPv6.
+  # NOTE: Please make sure to copy new image versions when updating the version by adding them to
+  #       https://github.com/gardener/ci-infra/blob/master/config/images/images.yaml.
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/ebs-csi-driver/volume-modifier-for-k8s
   tag: "v0.1.3"
   labels:


### PR DESCRIPTION
Add a small comment to the `images.yaml` to explain _why_ we copy the image and point to the central file that handles the copying in an automated fashion (for future updates).

Hopefully this avoids future erroneous reverts.