### PR TITLE
Support for Kubernetes v1.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.29 | 1.29.0+     | N/A |
 | Kubernetes 1.28 | 1.28.0+     | [![Gardener v1.28 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.28%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.28%20AWS) |
 | Kubernetes 1.27 | 1.27.0+     | [![Gardener v1.27 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.27%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.27%20AWS) |
 | Kubernetes 1.26 | 1.26.0+     | [![Gardener v1.26 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.26%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.26%20AWS) |

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -73,7 +73,21 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-aws
   repository: registry.k8s.io/provider-aws/cloud-controller-manager
   tag: "v1.28.4"
-  targetVersion: ">= 1.28"
+  targetVersion: "1.28.x"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'protected'
+      authentication_enforced: false
+      user_interaction: 'gardener-operator'
+      confidentiality_requirement: 'high'
+      integrity_requirement: 'high'
+      availability_requirement: 'low'
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes/cloud-provider-aws
+  repository: registry.k8s.io/provider-aws/cloud-controller-manager
+  tag: "v1.29.1"
+  targetVersion: ">= 1.29"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source usability
/kind enhancement
/platform aws
/exp intermediate
/topology garden seed shoot
/merge squash

**What this PR does / why we need it**:
This PR adds support for Kubernetes 1.29 to the extension.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8871

**Special notes for your reviewer**:
* I have successfully validated the functionality as follows:
  * :white_check_mark: Create new clusters with versions < 1.29
  * :white_check_mark: Create new clusters with version  = 1.29
  * :white_check_mark: Upgrade old clusters from version 1.28 to version 1.29
  * :white_check_mark: Delete clusters with versions < 1.29
  * :white_check_mark: Delete clusters with version  = 1.29

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The provider-aws extension does now support shoot clusters with Kubernetes version 1.29. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md) before upgrading to 1.29. 
```
