### PR TITLE
Fix dnsrecord flag usage

### DIFF
--- a/.test-defs/infrastructure-test.yaml
+++ b/.test-defs/infrastructure-test.yaml
@@ -4,12 +4,12 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Integration test for infrastructure creation and deletion
-  activeDeadlineSeconds: 3600
+  activeDeadlineSeconds: 8000
 
   command: [bash, -c]
   args:
   - >-
-    go test -timeout=55m ./test/integration/infrastructure
+    go test -timeout=120m ./test/integration/infrastructure
     --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
     --kubeconfig=$TM_KUBECONFIG_PATH/testmachinery.config
     --access-key-id=$ACCESS_KEY_ID

--- a/test/integration/dnsrecord/dnsrecord_test.go
+++ b/test/integration/dnsrecord/dnsrecord_test.go
@@ -296,13 +296,13 @@ var _ = Describe("DNSRecord tests", func() {
 		})
 
 		It("should successfully create and delete a dnsrecord of type CNAME as an alias target for a known IPv4 loadbalancer", func() {
-			if ipv4Loadbalancer == nil {
+			if len(pointer.StringDeref(ipv4Loadbalancer, "")) == 0 {
 				Skip("--known-ipv4-loadbalancer not set")
-			} else {
-				Expect(strings.HasSuffix(*ipv4Loadbalancer, "elb.eu-west-1.amazonaws.com"))
-				dns := newDNSRecord(testName, zoneName, nil, extensionsv1alpha1.DNSRecordTypeCNAME, []string{*ipv4Loadbalancer}, nil)
-				runTest(dns, awsclient.IPStackIPv4, nil, nil, nil, nil)
 			}
+
+			Expect(strings.HasSuffix(*ipv4Loadbalancer, "elb.eu-west-1.amazonaws.com"))
+			dns := newDNSRecord(testName, zoneName, nil, extensionsv1alpha1.DNSRecordTypeCNAME, []string{*ipv4Loadbalancer}, nil)
+			runTest(dns, awsclient.IPStackIPv4, nil, nil, nil, nil)
 		})
 
 		It("should successfully create and delete a dnsrecord of type TXT", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
