### PR TITLE
Update aws lb controller to v2.7.0

### DIFF
--- a/charts/internal/seed-controlplane/requirements.yaml
+++ b/charts/internal/seed-controlplane/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
   condition: aws-custom-route-controller.enabled
 - name: aws-load-balancer-controller
   repository: http://localhost:10191
-  version: 0.1.0
+  version: 0.2.0
   condition: aws-load-balancer-controller.enabled

--- a/charts/internal/shoot-crds/charts/aws-load-balancer-controller/Chart.yaml
+++ b/charts/internal/shoot-crds/charts/aws-load-balancer-controller/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for aws-load-balancer-controller CRDs.
 name: aws-load-balancer-controller
-version: 0.1.0
+version: 0.2.0

--- a/charts/internal/shoot-crds/charts/aws-load-balancer-controller/templates/crd-ingressclassparams.yaml
+++ b/charts/internal/shoot-crds/charts/aws-load-balancer-controller/templates/crd-ingressclassparams.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: ingressclassparams.elbv2.k8s.aws
 spec:
   group: elbv2.k8s.aws
@@ -36,14 +35,19 @@ spec:
           description: IngressClassParams is the Schema for the IngressClassParams API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -60,6 +64,12 @@ spec:
                   required:
                     - name
                   type: object
+                inboundCIDRs:
+                  description: InboundCIDRs specifies the CIDRs that are allowed to
+                    access the Ingresses that belong to IngressClass with this IngressClassParams.
+                  items:
+                    type: string
+                  type: array
                 ipAddressType:
                   description: IPAddressType defines the ip address type for all Ingresses
                     that belong to IngressClass with this IngressClassParams.
@@ -86,32 +96,32 @@ spec:
                     type: object
                   type: array
                 namespaceSelector:
-                  description: NamespaceSelector restrict the namespaces of Ingresses
-                    that are allowed to specify the IngressClass with this IngressClassParams.
+                  description: |-
+                    NamespaceSelector restrict the namespaces of Ingresses that are allowed to specify the IngressClass with this IngressClassParams.
                     * if absent or present but empty, it selects all namespaces.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements.
                         The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the key
-                          and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
                             description: key is the label key that the selector applies
                               to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to
-                              a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a strategic
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
                               merge patch.
                             items:
                               type: string
@@ -124,11 +134,10 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
@@ -161,10 +170,11 @@ spec:
                         items:
                           type: string
                         type: array
-                      description: Tags specifies subnets in the load balancer's VPC
-                        where each tag specified in the map key contains one of the
-                        values in the corresponding value list. Exactly one of this
-                        or `ids` must be specified.
+                      description: |-
+                        Tags specifies subnets in the load balancer's VPC where each
+                        tag specified in the map key contains one of the values in the corresponding
+                        value list.
+                        Exactly one of this or `ids` must be specified.
                       type: object
                   type: object
                 tags:

--- a/charts/internal/shoot-crds/charts/aws-load-balancer-controller/templates/crd-targetgroupbindings.yaml
+++ b/charts/internal/shoot-crds/charts/aws-load-balancer-controller/templates/crd-targetgroupbindings.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: targetgroupbindings.elbv2.k8s.aws
 spec:
   group: elbv2.k8s.aws
@@ -42,14 +41,19 @@ spec:
           description: TargetGroupBinding is the Schema for the TargetGroupBinding API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -66,28 +70,30 @@ spec:
                       items:
                         properties:
                           from:
-                            description: List of peers which should be able to access
-                              the targets in TargetGroup. At least one NetworkingPeer
-                              should be specified.
+                            description: |-
+                              List of peers which should be able to access the targets in TargetGroup.
+                              At least one NetworkingPeer should be specified.
                             items:
                               description: NetworkingPeer defines the source/destination
                                 peer for networking rules.
                               properties:
                                 ipBlock:
-                                  description: IPBlock defines an IPBlock peer. If specified,
-                                    none of the other fields can be set.
+                                  description: |-
+                                    IPBlock defines an IPBlock peer.
+                                    If specified, none of the other fields can be set.
                                   properties:
                                     cidr:
-                                      description: CIDR is the network CIDR. Both IPV4
-                                        or IPV6 CIDR are accepted.
+                                      description: |-
+                                        CIDR is the network CIDR.
+                                        Both IPV4 or IPV6 CIDR are accepted.
                                       type: string
                                   required:
                                     - cidr
                                   type: object
                                 securityGroup:
-                                  description: SecurityGroup defines a SecurityGroup
-                                    peer. If specified, none of the other fields can
-                                    be set.
+                                  description: |-
+                                    SecurityGroup defines a SecurityGroup peer.
+                                    If specified, none of the other fields can be set.
                                   properties:
                                     groupID:
                                       description: GroupID is the EC2 SecurityGroupID.
@@ -98,24 +104,24 @@ spec:
                               type: object
                             type: array
                           ports:
-                            description: List of ports which should be made accessible
-                              on the targets in TargetGroup. If ports is empty or unspecified,
-                              it defaults to all ports with TCP.
+                            description: |-
+                              List of ports which should be made accessible on the targets in TargetGroup.
+                              If ports is empty or unspecified, it defaults to all ports with TCP.
                             items:
                               properties:
                                 port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: The port which traffic must match. When
-                                    NodePort endpoints(instance TargetType) is used,
-                                    this must be a numerical port. When Port endpoints(ip
-                                    TargetType) is used, this can be either numerical
-                                    or named port on pods. if port is unspecified, it
-                                    defaults to all ports.
+                                  description: |-
+                                    The port which traffic must match.
+                                    When NodePort endpoints(instance TargetType) is used, this must be a numerical port.
+                                    When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.
+                                    if port is unspecified, it defaults to all ports.
                                   x-kubernetes-int-or-string: true
                                 protocol:
-                                  description: The protocol which traffic must match.
+                                  description: |-
+                                    The protocol which traffic must match.
                                     If protocol is unspecified, it defaults to TCP.
                                   enum:
                                     - TCP
@@ -201,14 +207,19 @@ spec:
           description: TargetGroupBinding is the Schema for the TargetGroupBinding API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -234,28 +245,30 @@ spec:
                           of traffic that is allowed to access TargetGroup's targets.
                         properties:
                           from:
-                            description: List of peers which should be able to access
-                              the targets in TargetGroup. At least one NetworkingPeer
-                              should be specified.
+                            description: |-
+                              List of peers which should be able to access the targets in TargetGroup.
+                              At least one NetworkingPeer should be specified.
                             items:
                               description: NetworkingPeer defines the source/destination
                                 peer for networking rules.
                               properties:
                                 ipBlock:
-                                  description: IPBlock defines an IPBlock peer. If specified,
-                                    none of the other fields can be set.
+                                  description: |-
+                                    IPBlock defines an IPBlock peer.
+                                    If specified, none of the other fields can be set.
                                   properties:
                                     cidr:
-                                      description: CIDR is the network CIDR. Both IPV4
-                                        or IPV6 CIDR are accepted.
+                                      description: |-
+                                        CIDR is the network CIDR.
+                                        Both IPV4 or IPV6 CIDR are accepted.
                                       type: string
                                   required:
                                     - cidr
                                   type: object
                                 securityGroup:
-                                  description: SecurityGroup defines a SecurityGroup
-                                    peer. If specified, none of the other fields can
-                                    be set.
+                                  description: |-
+                                    SecurityGroup defines a SecurityGroup peer.
+                                    If specified, none of the other fields can be set.
                                   properties:
                                     groupID:
                                       description: GroupID is the EC2 SecurityGroupID.
@@ -266,9 +279,9 @@ spec:
                               type: object
                             type: array
                           ports:
-                            description: List of ports which should be made accessible
-                              on the targets in TargetGroup. If ports is empty or unspecified,
-                              it defaults to all ports with TCP.
+                            description: |-
+                              List of ports which should be made accessible on the targets in TargetGroup.
+                              If ports is empty or unspecified, it defaults to all ports with TCP.
                             items:
                               description: NetworkingPort defines the port and protocol
                                 for networking rules.
@@ -277,15 +290,15 @@ spec:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  description: The port which traffic must match. When
-                                    NodePort endpoints(instance TargetType) is used,
-                                    this must be a numerical port. When Port endpoints(ip
-                                    TargetType) is used, this can be either numerical
-                                    or named port on pods. if port is unspecified, it
-                                    defaults to all ports.
+                                  description: |-
+                                    The port which traffic must match.
+                                    When NodePort endpoints(instance TargetType) is used, this must be a numerical port.
+                                    When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.
+                                    if port is unspecified, it defaults to all ports.
                                   x-kubernetes-int-or-string: true
                                 protocol:
-                                  description: The protocol which traffic must match.
+                                  description: |-
+                                    The protocol which traffic must match.
                                     If protocol is unspecified, it defaults to TCP.
                                   enum:
                                     - TCP
@@ -307,24 +320,24 @@ spec:
                       description: matchExpressions is a list of label selector requirements.
                         The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the key
-                          and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
                             description: key is the label key that the selector applies
                               to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to
-                              a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a strategic
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
                               merge patch.
                             items:
                               type: string
@@ -337,11 +350,10 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic

--- a/charts/internal/shoot-crds/requirements.yaml
+++ b/charts/internal/shoot-crds/requirements.yaml
@@ -5,5 +5,5 @@ dependencies:
   condition: volumesnapshots.enabled
 - name: aws-load-balancer-controller
   repository: http://localhost:10191
-  version: 0.1.0
+  version: 0.2.0
   condition: aws-load-balancer-controller.enabled

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -129,7 +129,7 @@ images:
   # NOTE: Please make sure to copy new image versions when updating the version by adding them to
   #       https://github.com/gardener/ci-infra/blob/master/config/images/images.yaml.
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/eks/aws-load-balancer-controller
-  tag: "v2.6.1"
+  tag: "v2.7.0"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This upgrade is necessary to enable utilization of the new annotation "alb.ingress.kubernetes.io/mutual-authentication," facilitating automated configuration of mutual authentication with the Ingress resource.

**Which issue(s) this PR fixes**:
Fixes #884 

**Special notes for your reviewer**:
Depends on https://github.com/gardener/ci-infra/pull/1266

**Release note**:
```
updated image aws-load-balancer-controller -> `v2.7.0`
```
