### PR TITLE
Remove obsolete test for load balancer which is known to be IPv4 only

### DIFF
--- a/test/integration/dnsrecord/dnsrecord_test.go
+++ b/test/integration/dnsrecord/dnsrecord_test.go
@@ -53,9 +53,8 @@ import (
 )
 
 var (
-	accessKeyID      = flag.String("access-key-id", "", "AWS access key id")
-	secretAccessKey  = flag.String("secret-access-key", "", "AWS secret access key")
-	ipv4Loadbalancer = flag.String("known-ipv4-loadbalancer", "", "known existing IPv4 loadbalancer on elb.eu-west-1.amazonaws.com")
+	accessKeyID     = flag.String("access-key-id", "", "AWS access key id")
+	secretAccessKey = flag.String("secret-access-key", "", "AWS secret access key")
 )
 
 func validateFlags() {
@@ -293,16 +292,6 @@ var _ = Describe("DNSRecord tests", func() {
 			dns := newDNSRecord(testName, zoneName, nil, extensionsv1alpha1.DNSRecordTypeCNAME, []string{"foo.elb.eu-west-1.amazonaws.com"}, nil)
 			dns.Annotations = map[string]string{awsapi.AnnotationKeyIPStack: string(awsclient.IPStackIPDualStack)}
 			runTest(dns, awsclient.IPStackIPDualStack, nil, nil, nil, nil)
-		})
-
-		It("should successfully create and delete a dnsrecord of type CNAME as an alias target for a known IPv4 loadbalancer", func() {
-			if len(pointer.StringDeref(ipv4Loadbalancer, "")) == 0 {
-				Skip("--known-ipv4-loadbalancer not set")
-			}
-
-			Expect(strings.HasSuffix(*ipv4Loadbalancer, "elb.eu-west-1.amazonaws.com"))
-			dns := newDNSRecord(testName, zoneName, nil, extensionsv1alpha1.DNSRecordTypeCNAME, []string{*ipv4Loadbalancer}, nil)
-			runTest(dns, awsclient.IPStackIPv4, nil, nil, nil, nil)
 		})
 
 		It("should successfully create and delete a dnsrecord of type TXT", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup
/platform aws

**What this PR does / why we need it**:
The integration test case using a load balancer known to be IPv4 only is obsolete, as action is now relying on an annotation and not on the IP addresses of the load balancer itself.
There are separate test cases for all annotation values. This test, which was optional anyway, can be removed.
Followup of #847 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
