### PR TITLE
Feature backup to s3 compatible

### DIFF
--- a/example/30-backupbucket.yaml
+++ b/example/30-backupbucket.yaml
@@ -8,6 +8,9 @@ type: Opaque
 data:
 # accessKeyID: base64(access-key-id)
 # secretAccessKey: base64(secret-access-key)
+# endpoint: base64(custom endpoint for S3 compatible object storage)
+# s3ForcePathStyle: base64(force path style for storing objects, necessary for S3 compatible storage)
+# trustedCaCert: base64(trusted ca certificate in pem format. Necessary custom CAs)
 ---
 apiVersion: extensions.gardener.cloud/v1alpha1
 kind: BackupBucket

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -44,6 +44,7 @@ type Interface interface {
 	// S3 wrappers
 	DeleteObjectsWithPrefix(ctx context.Context, bucket, prefix string) error
 	CreateBucketIfNotExists(ctx context.Context, bucket, region string) error
+	S3CompatCreateBucketIfNotExists(ctx context.Context, bucket, region string) error
 	DeleteBucketIfExists(ctx context.Context, bucket string) error
 
 	// Route53 wrappers

--- a/pkg/aws/types.go
+++ b/pkg/aws/types.go
@@ -67,6 +67,14 @@ const (
 	SharedCredentialsFile = "credentialsFile"
 	// Region is a constant for the key in a backup secret that holds the AWS region.
 	Region = "region"
+	// Endpoint is a custom endpoint to use for example for S3 compatible storage
+	Endpoint = "endpoint"
+	// Boolean for enabling path-style addressing for S3 compatible storage
+	S3ForcePathStyle = "s3ForcePathStyle"
+	// InsecureSkipVerify controls whether a client verifies the server's certificate chain and host name
+	InsecureSkipVerify = "insecureSkipVerify"
+	// RootCA to be added to the list of root certificate authorities that clients use when verifying server certificates
+	TrustedCaCert = "trustedCaCert"
 	// DNSAccessKeyID is a constant for the key in a DNS secret that holds the AWS access key id.
 	DNSAccessKeyID = "AWS_ACCESS_KEY_ID"
 	// DNSSecretAccessKey is a constant for the key in a DNS secret that holds the AWS secret access key.
@@ -136,7 +144,11 @@ var (
 
 // Credentials stores AWS credentials.
 type Credentials struct {
-	AccessKeyID     []byte
-	SecretAccessKey []byte
-	Region          []byte
+	AccessKeyID        []byte
+	SecretAccessKey    []byte
+	Region             []byte
+	Endpoint           []byte
+	S3ForcePathStyle   bool
+	InsecureSkipVerify bool
+	TrustedCaCert      []byte
 }


### PR DESCRIPTION
**How to categorize this PR?**
/area backup
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Adds funktionality to backup to S3 compatible object storage.

**Special notes for your reviewer**:
The following additional parameters can be used within the secret referenced by a `backupbucket` for for storing backups on a S3 compatible object storage like e.g. Minio:

- endpoint
  This parameter specifies the custom S3 endpoint to backup

- s3ForcePathStyle
  Forces the path style for storing objects, necessary for S3 compatible storage.

- trustedCaCert
  A trusted CA certificate in PEM format

- insecureSkipVerify
  Boolean switch for skipping TLS verification.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```
- category: feature
- target_group: operator

Adding feature to store Shoot-backups in S3 compatible object storage.
```
