### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# see https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  allow:
+  - dependency-name: "github.com/gardener/gardener"
+    dependency-type: "direct"
+  - dependency-type: "indirect"
+- package-ecosystem: "docker"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
**How to categorize this PR?**
/area quality
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Adds `dependabot.yml` configuring the Dependabot. As of now, this is configured to provide weekly update-PRs (if available) for Gardener and the image(s) referenced in this repository's Dockerfile.

I am not sure if this plays nice with our update-PR-checks though. Maybe we should directly move to renovate instead.
