### PR TITLE
fix vpc not found classification on configvalidator

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -209,7 +209,7 @@ func (c *Client) GetNATGatewayAddressAllocations(ctx context.Context, shootNames
 func (c *Client) GetVPCAttribute(ctx context.Context, vpcID string, attribute string) (bool, error) {
 	vpcAttribute, err := c.EC2.DescribeVpcAttributeWithContext(ctx, &ec2.DescribeVpcAttributeInput{VpcId: &vpcID, Attribute: aws.String(attribute)})
 	if err != nil {
-		return false, ignoreNotFound(err)
+		return false, err
 	}
 
 	switch attribute {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-aws/issues/837

**Special notes for your reviewer**:
Thanks @Kostov6 @dimitar-kostadinov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix the categorization of the error when a user-provided VPC was not found 
```
