### PR TITLE
Fix/Update infra-test

### DIFF
--- a/test/integration/dnsrecord/dnsrecord_test.go
+++ b/test/integration/dnsrecord/dnsrecord_test.go
@@ -230,9 +230,6 @@ var runTest = func(dns *extensionsv1alpha1.DNSRecord, stack awsclient.IPStack, n
 	By("verifying that the AWS DNS recordset exists and matches dnsrecord")
 	verifyDNSRecordSet(ctx, awsClient, dns, stack)
 
-	By("verifying that the meta AWS DNS recordset does not exist")
-	verifyMetaDNSRecordSetDeleted(ctx, awsClient, dns)
-
 	if len(newValues) > 0 {
 		if beforeUpdate != nil {
 			beforeUpdate()
@@ -299,9 +296,8 @@ var _ = Describe("DNSRecord tests", func() {
 				stack,
 				[]string{"3.3.3.3", "1.1.1.1"},
 				func() {
-					By("creating AWS DNS recordset and its meta recordset")
+					By("creating AWS DNS recordset")
 					Expect(awsClient.CreateOrUpdateDNSRecordSet(ctx, zoneID, dns.Spec.Name, route53.RRTypeA, []string{"8.8.8.8"}, 120, stack)).To(Succeed())
-					Expect(awsClient.CreateOrUpdateDNSRecordSet(ctx, zoneID, "comment-"+dns.Spec.Name, route53.RRTypeTxt, []string{"foo"}, 600, stack)).To(Succeed())
 				},
 				func() {
 					By("updating AWS DNS recordset")
@@ -473,12 +469,6 @@ func verifyDNSRecordSet(ctx context.Context, awsClient *awsclient.Client, dns *e
 
 func verifyDNSRecordSetDeleted(ctx context.Context, awsClient *awsclient.Client, dns *extensionsv1alpha1.DNSRecord) {
 	rrss, err := awsClient.GetDNSRecordSets(ctx, *dns.Status.Zone, dns.Spec.Name, getRecordType(dns))
-	Expect(err).NotTo(HaveOccurred())
-	Expect(rrss).To(BeNil())
-}
-
-func verifyMetaDNSRecordSetDeleted(ctx context.Context, awsClient *awsclient.Client, dns *extensionsv1alpha1.DNSRecord) {
-	rrss, err := awsClient.GetDNSRecordSets(ctx, *dns.Status.Zone, "comment-"+dns.Spec.Name, route53.RRTypeTxt)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(rrss).To(BeNil())
 }

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -1215,14 +1215,14 @@ func verifyCreation(
 	describeNatGatewaysOutput, err := awsClient.EC2.DescribeNatGatewaysWithContext(ctx, &ec2.DescribeNatGatewaysInput{Filter: vpcIDFilter})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(describeNatGatewaysOutput.NatGateways).To(HaveLen(1))
-	Expect(describeNatGatewaysOutput.NatGateways[0].NatGatewayAddresses).To(ConsistOf([]*ec2.NatGatewayAddress{
-		{
-			AllocationId:       describeAddressesOutput.Addresses[0].AllocationId,
-			NetworkInterfaceId: describeAddressesOutput.Addresses[0].NetworkInterfaceId,
-			PrivateIp:          describeAddressesOutput.Addresses[0].PrivateIpAddress,
-			PublicIp:           describeAddressesOutput.Addresses[0].PublicIp,
-		},
-	}))
+	Expect(describeNatGatewaysOutput.NatGateways[0].NatGatewayAddresses).To(HaveLen(1))
+
+	natGatewayAddress := describeNatGatewaysOutput.NatGateways[0].NatGatewayAddresses[0]
+	Expect(natGatewayAddress).To(HaveField("AllocationId", Equal(describeAddressesOutput.Addresses[0].AllocationId)))
+	Expect(natGatewayAddress).To(HaveField("NetworkInterfaceId", Equal(describeAddressesOutput.Addresses[0].NetworkInterfaceId)))
+	Expect(natGatewayAddress).To(HaveField("PrivateIp", Equal(describeAddressesOutput.Addresses[0].PrivateIpAddress)))
+	Expect(natGatewayAddress).To(HaveField("PublicIp", Equal(describeAddressesOutput.Addresses[0].PublicIp)))
+
 	Expect(describeNatGatewaysOutput.NatGateways[0].SubnetId).To(PointTo(Equal(publicSubnetID)))
 	Expect(describeNatGatewaysOutput.NatGateways[0].Tags).To(ConsistOf([]*ec2.Tag{
 		{

--- a/test/integration/vpc.go
+++ b/test/integration/vpc.go
@@ -50,6 +50,16 @@ func CreateVPC(ctx context.Context, log logr.Logger, awsClient *awsclient.Client
 		return "", "", err
 	}
 
+	_, err = awsClient.EC2.ModifyVpcAttribute(&ec2.ModifyVpcAttributeInput{
+		EnableDnsSupport: &ec2.AttributeBooleanValue{
+			Value: awssdk.Bool(true),
+		},
+		VpcId: vpcID,
+	})
+	if err != nil {
+		return "", "", err
+	}
+
 	if enableDnsHostnames {
 		_, err = awsClient.EC2.ModifyVpcAttribute(&ec2.ModifyVpcAttributeInput{
 			EnableDnsHostnames: &ec2.AttributeBooleanValue{
@@ -60,16 +70,6 @@ func CreateVPC(ctx context.Context, log logr.Logger, awsClient *awsclient.Client
 		if err != nil {
 			return "", "", err
 		}
-	}
-
-	_, err = awsClient.EC2.ModifyVpcAttribute(&ec2.ModifyVpcAttributeInput{
-		EnableDnsSupport: &ec2.AttributeBooleanValue{
-			Value: awssdk.Bool(true),
-		},
-		VpcId: vpcID,
-	})
-	if err != nil {
-		return "", "", err
 	}
 
 	createIgwOutput, err := awsClient.EC2.CreateInternetGateway(&ec2.CreateInternetGatewayInput{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup
/platform aws

**What this PR does / why we need it**:
Fixes some issues with the integration-tests after the recent update to our dependencies:
- rm mentions of MetaDNSRecordSet from tests as well
- do not check for exact structural equality in natGatewayAddress, rather only check the fields we are interested in.
- ensure that the order of operations for DNS-related VPC options matches the one required as per documentation.

