### PR TITLE
Update golang version in tm-tests

### DIFF
--- a/.test-defs/bastion-test.yaml
+++ b/.test-defs/bastion-test.yaml
@@ -16,4 +16,4 @@ spec:
     --secret-access-key=$SECRET_ACCESS_KEY
     --region=$REGION
 
-  image: golang:1.22.1
+  image: golang:1.22.2

--- a/.test-defs/dnsrecord-test.yaml
+++ b/.test-defs/dnsrecord-test.yaml
@@ -15,4 +15,4 @@ spec:
     --access-key-id=$DNS_ACCESS_KEY_ID
     --secret-access-key=$DNS_SECRET_ACCESS_KEY
 
-  image: golang:1.22.1
+  image: golang:1.22.2

--- a/.test-defs/infrastructure-test.yaml
+++ b/.test-defs/infrastructure-test.yaml
@@ -16,4 +16,4 @@ spec:
     --secret-access-key=$SECRET_ACCESS_KEY
     --region=$REGION
 
-  image: golang:1.22.1
+  image: golang:1.22.2

--- a/.test-defs/provider-aws.yaml
+++ b/.test-defs/provider-aws.yaml
@@ -18,4 +18,4 @@ spec:
     --network-worker-cidr=$NETWORK_WORKER_CIDR
     --zone=$ZONE
 
-  image: golang:1.22.1
+  image: golang:1.22.2


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the golang version in the TM-images to the required version.
