### PR TITLE
Bump github.com/gardener/external-dns-management from 0.18.4 to 0.18.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.51.21
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/gardener/etcd-druid v0.22.0
-	github.com/gardener/external-dns-management v0.18.4
+	github.com/gardener/external-dns-management v0.18.5
 	github.com/gardener/gardener v1.91.1
 	github.com/gardener/machine-controller-manager v0.52.0
 	github.com/go-logr/logr v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/gardener/cert-management v0.13.0 h1:KIT9wWFmbo2+YwnN3EhUqGX2tOkvB8aTF
 github.com/gardener/cert-management v0.13.0/go.mod h1:0nTNVZoKA+v7uumOQ0xZPNjqSOfYxF93PFCEN26A+mw=
 github.com/gardener/etcd-druid v0.22.0 h1:DVe+Zjrb93r9vI1uUiCTMHBffIUoMAKhNzFZNC6hsQ8=
 github.com/gardener/etcd-druid v0.22.0/go.mod h1:FROhfVKyWBo4krlPe3R6FIhJRmOmijEWBdEeUP0CJjE=
-github.com/gardener/external-dns-management v0.18.4 h1:v8TA3XgkU2THdyJfqeJKr/60bPe5znce15X5lz3pjAU=
-github.com/gardener/external-dns-management v0.18.4/go.mod h1:7aFu4BUkFEM1Il8GbWhHczA2UiGwNI4vjcTaTMthwwE=
+github.com/gardener/external-dns-management v0.18.5 h1:lqKVuuPTPzw5zhYtHtdETSVyxIiLRsmj1LzMqxAwPYo=
+github.com/gardener/external-dns-management v0.18.5/go.mod h1:6WO+q0vfcxlGjAIeXG9hNr6ve6NHNw1E9Ey8mnGax8Q=
 github.com/gardener/gardener v1.91.1 h1:c+RlotxhZkSOnlzo9MhoINlI0m7YJDp7+EwLYPXoAls=
 github.com/gardener/gardener v1.91.1/go.mod h1:3h8gSsr05ABuLGnGLB4bEYRn8ot42APkIa2E3f+nGc0=
 github.com/gardener/hvpa-controller/api v0.15.0 h1:igsalL5Z6kFMn1+Kv1Eq0cRjYW+4oBA1aEY/yDO2QtI=


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:
Bump github.com/gardener/external-dns-management from 0.18.4 to 0.18.5.

This includes the fix from PR gardener/external-dns-management#365 which excludes "us-gov" domains from ALIAS DNS record creation. As the package `github.com/gardener/external-dns-management/pkg/controller/provider/aws/data` is reused in the Route53 client, the "us-gov" alias fix applies automatically with this PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Bump github.com/gardener/external-dns-management from 0.18.4 to 0.18.5.
```

```bugfix operator
DNSRecord controller will not create ALIAS DNS records for AWS "us-gov" zones anymore.
```