### PR TITLE
Remove invalid CCM feature gate from the examples

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -5,7 +5,6 @@ podNetwork: 192.168.0.0/16
 podAnnotations: {}
 podLabels: {}
 featureGates: {}
-  # RotateKubeletServerCertificate: false
 images:
   cloud-controller-manager: image-repository:image-tag
 resources:

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -262,12 +262,12 @@ An example `ControlPlaneConfig` for the AWS extension looks as follows:
 apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
 kind: ControlPlaneConfig
 cloudControllerManager:
-  featureGates:
-    RotateKubeletServerCertificate: true
+# featureGates:
+#   SomeKubernetesFeature: true
   useCustomRouteController: true
-#loadBalancerController:
-#  enabled: true
-#  ingressClassName: alb
+# loadBalancerController:
+#   enabled: true
+#   ingressClassName: alb
 storage:
   managedDefaultClass: false
 ```

--- a/example/30-controlplane.yaml
+++ b/example/30-controlplane.yaml
@@ -57,9 +57,9 @@ spec:
   providerConfig:
     apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
     kind: ControlPlaneConfig
-    cloudControllerManager:
-      featureGates:
-        RotateKubeletServerCertificate: true
+  # cloudControllerManager:
+  #   featureGates:
+  #     SomeKubernetesFeature: true
     storage:
       managedDefaultClass: false
   infrastructureProviderStatus:

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -72,7 +72,7 @@ var _ = Describe("ValuesProvider", func() {
 				Raw: encode(&apisawsv1alpha1.ControlPlaneConfig{
 					CloudControllerManager: &apisawsv1alpha1.CloudControllerManagerConfig{
 						FeatureGates: map[string]bool{
-							"RotateKubeletServerCertificate": true,
+							"SomeKubernetesFeature": true,
 						},
 						UseCustomRouteController: ptr.To(true),
 					},
@@ -84,7 +84,7 @@ var _ = Describe("ValuesProvider", func() {
 				Raw: encode(&apisawsv1alpha1.ControlPlaneConfig{
 					CloudControllerManager: &apisawsv1alpha1.CloudControllerManagerConfig{
 						FeatureGates: map[string]bool{
-							"RotateKubeletServerCertificate": true,
+							"SomeKubernetesFeature": true,
 						},
 					},
 					LoadBalancerController: &apisawsv1alpha1.LoadBalancerControllerConfig{
@@ -127,7 +127,7 @@ var _ = Describe("ValuesProvider", func() {
 						Raw: encode(&apisawsv1alpha1.ControlPlaneConfig{
 							CloudControllerManager: &apisawsv1alpha1.CloudControllerManagerConfig{
 								FeatureGates: map[string]bool{
-									"RotateKubeletServerCertificate": true,
+									"SomeKubernetesFeature": true,
 								},
 							},
 						}),
@@ -239,7 +239,7 @@ var _ = Describe("ValuesProvider", func() {
 					"checksum/configmap-" + aws.CloudProviderConfigName:           checksums[aws.CloudProviderConfigName],
 				},
 				"featureGates": map[string]bool{
-					"RotateKubeletServerCertificate": true,
+					"SomeKubernetesFeature": true,
 				},
 				"tlsCipherSuites": []string{
 					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/platform aws

**What this PR does / why we need it**:
We receive tickets because people copy the example `controlPlaneConfig` from the usage docs. 
The Shoot creation fails because there is no `RotateKubeletServerCertificate` feature gate for the cloud-controller-manager 
```
F0520 06:31:57.442953       1 main.go:84] unable to execute command: invalid argument "RotateKubeletServerCertificate=true" for "--feature-gates" flag: unrecognized feature gate: RotateKubeletServerCertificate
```

```
 % docker run registry.k8s.io/provider-aws/cloud-controller-manager:v1.29.2 --help | grep -A 26 'feature-gates '

      --feature-gates mapStringBool              A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                                                 APIResponseCompression=true|false (BETA - default=true)
                                                 APIServerIdentity=true|false (BETA - default=true)
                                                 APIServerTracing=true|false (BETA - default=true)
                                                 AdmissionWebhookMatchConditions=true|false (BETA - default=true)
                                                 AggregatedDiscoveryEndpoint=true|false (BETA - default=true)
                                                 AllAlpha=true|false (ALPHA - default=false)
                                                 AllBeta=true|false (BETA - default=false)
                                                 CloudControllerManagerWebhook=true|false (ALPHA - default=false)
                                                 CloudDualStackNodeIPs=true|false (BETA - default=true)
                                                 ComponentSLIs=true|false (BETA - default=true)
                                                 ConsistentListFromCache=true|false (ALPHA - default=false)
                                                 ContextualLogging=true|false (ALPHA - default=false)
                                                 InPlacePodVerticalScaling=true|false (ALPHA - default=false)
                                                 LoggingAlphaOptions=true|false (ALPHA - default=false)
                                                 LoggingBetaOptions=true|false (BETA - default=true)
                                                 OpenAPIEnums=true|false (BETA - default=true)
                                                 StableLoadBalancerNodeSet=true|false (BETA - default=true)
                                                 StorageVersionAPI=true|false (ALPHA - default=false)
                                                 StorageVersionHash=true|false (BETA - default=true)
                                                 StructuredAuthenticationConfiguration=true|false (ALPHA - default=false)
                                                 StructuredAuthorizationConfiguration=true|false (ALPHA - default=false)
                                                 UnauthenticatedHTTP2DOSMitigation=true|false (BETA - default=true)
                                                 ValidatingAdmissionPolicy=true|false (BETA - default=false)
                                                 WatchList=true|false (ALPHA - default=false)
                                                 ZeroLimitedNominalConcurrencyShares=true|false (BETA - default=false)
      --kube-api-burst int32                     Burst to use while talking with kubernetes apiserver. (default 30)

```

In general, we believe that there is no need to specify a real feature gate name because soon or later it will be 

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
