### PR TITLE
delete ssh keypair when disabled

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -1342,6 +1342,10 @@ func (c *FlowContext) ensureKeyPair(ctx context.Context) error {
 		return err
 	}
 
+	if len(c.infraSpec.SSHPublicKey) == 0 {
+		return c.deleteKeyPair(ctx)
+	}
+
 	specFingerprint := fmt.Sprintf("%x", md5.Sum(c.infraSpec.SSHPublicKey))
 	if current != nil {
 		// check for foreign key replacement


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #958

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix a bug in which the infrastructure flow reconciler would fail to complete when the shoot's sshAccess was disabled. The reconciler now properly reconciles and deletes the ssh keypair as needed.
```
