### PR TITLE
Force bastion image version

### DIFF
--- a/pkg/controller/bastion/options.go
+++ b/pkg/controller/bastion/options.go
@@ -146,7 +146,7 @@ func determineImageID(shoot *gardencorev1beta1.Shoot, providerConfig *awsv1alpha
 	re := regexp.MustCompile(`^1312\.\d+\.\d+$`)
 	for _, image := range providerConfig.MachineImages {
 		for _, version := range image.Versions {
-			if !re.MatchString(version.Version) {
+			if image.Name == "gardenlinux" && !re.MatchString(version.Version) {
 				continue
 			}
 			for _, region := range version.Regions {

--- a/pkg/controller/bastion/options_test.go
+++ b/pkg/controller/bastion/options_test.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bastion
+
+import (
+	apisaws "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Bastion Options", func() {
+	var region = "test-region"
+	var image = "test-image"
+	var ami = "test-ami"
+	var cloudProfileConfig *apisaws.CloudProfileConfig
+	var shoot *v1beta1.Shoot
+
+	BeforeEach(func() {
+		cloudProfileConfig = &apisaws.CloudProfileConfig{
+			MachineImages: []apisaws.MachineImages{
+				{
+					Name: image,
+					Versions: []apisaws.MachineImageVersion{
+						{
+							Regions: []apisaws.RegionAMIMapping{
+								{
+									Name: region,
+									AMI:  ami,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		shoot = &v1beta1.Shoot{
+			Spec: v1beta1.ShootSpec{
+				Region: region,
+			},
+		}
+	})
+
+	Context("determineImageID", func() {
+		var supportedVersion = "1312.2.0"
+		var unsupportedVersion = "1443.1.0"
+
+		It("should find imageID", func() {
+			cloudProfileConfig.MachineImages[0].Versions[0].Version = supportedVersion
+			foundAmi, err := determineImageID(shoot, cloudProfileConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(foundAmi).To(Equal(ami))
+		})
+
+		It("should fail for unsupported image version", func() {
+			cloudProfileConfig.MachineImages[0].Versions[0].Version = unsupportedVersion
+			_, err := determineImageID(shoot, cloudProfileConfig)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/pkg/controller/bastion/options_test.go
+++ b/pkg/controller/bastion/options_test.go
@@ -14,7 +14,7 @@ import (
 
 var _ = Describe("Bastion Options", func() {
 	var region = "test-region"
-	var image = "test-image"
+	var image = "gardenlinux"
 	var ami = "test-ami"
 	var cloudProfileConfig *apisaws.CloudProfileConfig
 	var shoot *v1beta1.Shoot
@@ -45,20 +45,28 @@ var _ = Describe("Bastion Options", func() {
 	})
 
 	Context("determineImageID", func() {
-		var supportedVersion = "1312.2.0"
-		var unsupportedVersion = "1443.1.0"
+		var supportedGardenLinuxVersion = "1312.2.0"
+		var unsupportedGardenLinuxVersion = "1443.1.0"
 
 		It("should find imageID", func() {
-			cloudProfileConfig.MachineImages[0].Versions[0].Version = supportedVersion
+			cloudProfileConfig.MachineImages[0].Versions[0].Version = supportedGardenLinuxVersion
 			foundAmi, err := determineImageID(shoot, cloudProfileConfig)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(foundAmi).To(Equal(ami))
 		})
 
 		It("should fail for unsupported image version", func() {
-			cloudProfileConfig.MachineImages[0].Versions[0].Version = unsupportedVersion
+			cloudProfileConfig.MachineImages[0].Versions[0].Version = unsupportedGardenLinuxVersion
 			_, err := determineImageID(shoot, cloudProfileConfig)
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("unsupported image version should pass for none gardenlinux images", func() {
+			cloudProfileConfig.MachineImages[0].Versions[0].Version = unsupportedGardenLinuxVersion
+			cloudProfileConfig.MachineImages[0].Name = "ubuntu"
+			foundAmi, err := determineImageID(shoot, cloudProfileConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(foundAmi).To(Equal(ami))
 		})
 	})
 })

--- a/pkg/controller/bastion/options_test.go
+++ b/pkg/controller/bastion/options_test.go
@@ -5,10 +5,11 @@
 package bastion
 
 import (
-	apisaws "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	apisaws "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
 )
 
 var _ = Describe("Bastion Options", func() {

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -54,8 +54,8 @@ const (
 	vpcCIDR             = "10.250.0.0/16"
 	subnetCIDR          = "10.250.0.0/18"
 	publicUtilitySuffix = "public-utility-z0"
-	bastionImageVersion = "20.04.20210223"
-	bastionAMI          = "ubuntu/images/hvm-ssd/ubuntu-jammy*"
+	imageVersion        = "1312.2.0" // not the real version - only used in the cloudProfile
+	imageName           = "ubuntu/images/hvm-ssd/ubuntu-jammy*"
 )
 
 var (
@@ -176,7 +176,7 @@ var _ = BeforeSuite(func() {
 	awsClient, err = awsclient.NewClient(*accessKeyID, *secretAccessKey, *region)
 	Expect(err).NotTo(HaveOccurred())
 
-	imageAMI := getImageAMI(ctx, bastionAMI, awsClient)
+	imageAMI := getImageAMI(ctx, imageName, awsClient)
 	amiID := determineBastionImage(ctx, imageAMI, awsClient)
 	extensionscluster, corecluster = newCluster(namespaceName, amiID)
 })
@@ -402,7 +402,7 @@ func newCluster(name string, amiID string) (*extensionsv1alpha1.Cluster, *contro
 					Name: "ubuntu",
 					Versions: []awsv1alpha1.MachineImageVersion{
 						{
-							Version: bastionImageVersion,
+							Version: imageVersion,
 							Regions: []awsv1alpha1.RegionAMIMapping{
 								{
 									Name: *region,

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -54,7 +54,7 @@ const (
 	vpcCIDR             = "10.250.0.0/16"
 	subnetCIDR          = "10.250.0.0/18"
 	publicUtilitySuffix = "public-utility-z0"
-	imageVersion        = "1312.2.0" // not the real version - only used in the cloudProfile
+	imageVersion        = "20.04.20210223" // not the real version - only used in the cloudProfile
 	imageName           = "ubuntu/images/hvm-ssd/ubuntu-jammy*"
 )
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind regression
/platform aws

**What this PR does / why we need it**:
Temporarily forces bastion image to have version 1312.x.x

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Temporarily forces bastion image to have version 1312.x.x
```
