### PR TITLE
Apply PR #974 to Release branch

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/servicemonitor.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/servicemonitor.yaml
@@ -21,12 +21,12 @@ spec:
       - __name__
       action: keep
       regex: ^(rest_client_requests_total|process_max_fds|process_open_fds)$
-  honorLabels: false
-  authorization:
-    credentials:
-      name: shoot-access-prometheus-shoot
-      key: token
-  scheme: https
-  tlsConfig:
-    insecureSkipVerify: true
+    honorLabels: false
+    authorization:
+      credentials:
+        name: shoot-access-prometheus-shoot
+        key: token
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
 {{- end }}


### PR DESCRIPTION
This PR applies #974 to the release-branch for `v1.55` (required to properly transport release-notes)

/area monitoring
/kind bug

**Release note**:
```bugfix operator
Fixes a monitoring configuration issue that caused false CCM-down alerts to fire.
``` 