### PR TITLE
Add object selector to the shoot webhook

### DIFF
--- a/pkg/webhook/shoot/add.go
+++ b/pkg/webhook/shoot/add.go
@@ -8,6 +8,7 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/shoot"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -30,6 +31,13 @@ func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions) (*extensionswebh
 			{Obj: &corev1.ConfigMap{}},
 		},
 		Mutator: NewMutator(),
+		ObjectSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app":       "nginx-ingress",
+				"component": "controller",
+				"release":   "addons",
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Add object selector to the shoot webhook so that it is not invoked on every ConfigMap CREATE/UPDATE request in the kube-system namespace in the Shoot but only for the `addons-nginx-ingress-controller` ConfigMap.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9864

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The shoot-webhook that mutates the `addons-nginx-ingress-controller` ConfigMap does now specify object selector. The webhook will now intercept only requests for the `addons-nginx-ingress-controller` ConfigMap.
```
