### PR TITLE
Add object selector to controlplane webhook with version constraint

### DIFF
--- a/cmd/gardener-extension-provider-aws/app/app.go
+++ b/cmd/gardener-extension-provider-aws/app/app.go
@@ -120,8 +120,9 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			Namespace: os.Getenv("WEBHOOK_CONFIG_NAMESPACE"),
 		}
 
+		gardenerVersion    = new(string)
 		controllerSwitches = awscmd.ControllerSwitchOptions()
-		webhookSwitches    = awscmd.WebhookSwitchOptions()
+		webhookSwitches    = awscmd.WebhookSwitchOptions(gardenerVersion)
 		webhookOptions     = webhookcmd.NewAddToManagerOptions(
 			aws.Name,
 			genericactuator.ShootWebhooksResourceName,
@@ -224,6 +225,8 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			}
 
 			log.Info("Adding controllers to manager")
+			*gardenerVersion = generalOpts.Completed().GardenerVersion
+
 			configFileOpts.Completed().ApplyETCDStorage(&awscontrolplaneexposure.DefaultAddOptions.ETCDStorage)
 			configFileOpts.Completed().ApplyHealthCheckConfig(&healthcheck.DefaultAddOptions.HealthCheckConfig)
 			healthCheckCtrlOpts.Completed().Apply(&healthcheck.DefaultAddOptions.Controller)

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -64,9 +64,9 @@ func ControllerSwitchOptions() *controllercmd.SwitchOptions {
 }
 
 // WebhookSwitchOptions are the webhookcmd.SwitchOptions for the provider webhooks.
-func WebhookSwitchOptions() *webhookcmd.SwitchOptions {
+func WebhookSwitchOptions(gardenerVersion *string) *webhookcmd.SwitchOptions {
 	return webhookcmd.NewSwitchOptions(
-		webhookcmd.Switch(extensioncontrolplanewebhook.WebhookName, controlplanewebhook.AddToManager),
+		webhookcmd.Switch(extensioncontrolplanewebhook.WebhookName, controlplanewebhook.AddToManager(gardenerVersion)),
 		webhookcmd.Switch(extensioncontrolplanewebhook.ExposureWebhookName, controlplaneexposurewebhook.AddToManager),
 		webhookcmd.Switch(extensionshootwebhook.WebhookName, shootwebhook.AddToManager),
 		webhookcmd.Switch(extensionscloudproviderwebhook.WebhookName, cloudproviderwebhook.AddToManager),

--- a/pkg/webhook/controlplane/add.go
+++ b/pkg/webhook/controlplane/add.go
@@ -5,13 +5,19 @@
 package controlplane
 
 import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
 	oscutils "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/utils"
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -20,22 +26,43 @@ import (
 )
 
 var (
-	logger = log.Log.WithName("aws-controlplane-webhook")
+	logger                           = log.Log.WithName("aws-controlplane-webhook")
+	versionConstraintGreaterEqual198 *semver.Constraints
 )
 
+func init() {
+	var err error
+	// TODO(LucaBernstein): Clean up the gardener version check after October/2024.
+	versionConstraintGreaterEqual198, err = semver.NewConstraint(">= 1.98")
+	utilruntime.Must(err)
+}
+
 // AddToManager creates a webhook and adds it to the manager.
-func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
-	logger.Info("Adding webhook to manager")
-	fciCodec := oscutils.NewFileContentInlineCodec()
-	return controlplane.New(mgr, controlplane.Args{
-		Kind:     controlplane.KindShoot,
-		Provider: aws.Type,
-		Types: []extensionswebhook.Type{
-			{Obj: &appsv1.Deployment{}},
-			{Obj: &vpaautoscalingv1.VerticalPodAutoscaler{}},
-			{Obj: &extensionsv1alpha1.OperatingSystemConfig{}},
-		},
-		Mutator: genericmutator.NewMutator(mgr, NewEnsurer(logger, mgr.GetClient()), oscutils.NewUnitSerializer(),
-			kubelet.NewConfigCodec(fciCodec), fciCodec, logger),
-	})
+func AddToManager(gardenerVersion *string) func(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	return func(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+		var objectSelector *metav1.LabelSelector
+		if gardenerVersion != nil && len(*gardenerVersion) > 0 {
+			version, err := semver.NewVersion(*gardenerVersion)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse gardener version: %v", err)
+			}
+			if versionConstraintGreaterEqual198.Check(version) {
+				objectSelector = &metav1.LabelSelector{MatchLabels: map[string]string{v1beta1constants.LabelExtensionProviderMutatedByControlplaneWebhook: "true"}}
+			}
+		}
+		logger.Info("Adding webhook to manager")
+		fciCodec := oscutils.NewFileContentInlineCodec()
+		return controlplane.New(mgr, controlplane.Args{
+			Kind:     controlplane.KindShoot,
+			Provider: aws.Type,
+			Types: []extensionswebhook.Type{
+				{Obj: &appsv1.Deployment{}},
+				{Obj: &vpaautoscalingv1.VerticalPodAutoscaler{}},
+				{Obj: &extensionsv1alpha1.OperatingSystemConfig{}},
+			},
+			ObjectSelector: objectSelector,
+			Mutator: genericmutator.NewMutator(mgr, NewEnsurer(logger, mgr.GetClient()), oscutils.NewUnitSerializer(),
+				kubelet.NewConfigCodec(fciCodec), fciCodec, logger),
+		})
+	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Part of issue https://github.com/gardener/gardener/issues/9864, followup for g/g PR #9981. Use `ObjectSelector` in controlplane webhook to limit mutator calls for unrelated resource changes.

**Which issue(s) this PR fixes**:
Part of #9864

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Starting with gardenlet >= v1.98.0, use controlplane webhook object selector to limit mutator calls.
```
