### PR TITLE
Remove leftover from prior cleanup

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -102,17 +101,6 @@ func (s *shoot) validateShoot(_ context.Context, shoot *core.Shoot) error {
 		if errList := awsvalidation.ValidateControlPlaneConfig(controlPlaneConfig, shoot.Spec.Kubernetes.Version, fldPath.Child("controlPlaneConfig")); len(errList) != 0 {
 			return errList.ToAggregate()
 		}
-	}
-
-	// WorkerConfig and Shoot workers
-	shootV1beta1 := &gardencorev1beta1.Shoot{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
-			Kind:       "Shoot",
-		},
-	}
-	if err := s.scheme.Convert(shoot, shootV1beta1, nil); err != nil {
-		return err
 	}
 
 	fldPath = fldPath.Child("workers")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform aws

**What this PR does / why we need it**:
Cleanup leftover validation, code has been introduced in https://github.com/gardener/gardener-extension-provider-aws/commit/c2d8b3292fd27cae25c2fa3b10abf191c3d11939#diff-341af93ea91d0a1cfcaedd3f19b8bbcefda579a084daef873d7b4938d965d947R128-R138 and partly removed in https://github.com/gardener/gardener-extension-provider-aws/commit/ded95f74ea82855ed4265458f849ba99bc6da926#diff-341af93ea91d0a1cfcaedd3f19b8bbcefda579a084daef873d7b4938d965d947L130-L134

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
