### PR TITLE
Upgrade machine-controller-manager-provider-aws on release-branch

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -100,7 +100,7 @@ images:
 - name: machine-controller-manager-provider-aws
   sourceRepository: github.com/gardener/machine-controller-manager-provider-aws
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-aws
-  tag: "v0.20.0"
+  tag: "v0.20.1"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
from v0.20.0 to v0.20.1

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
**Release Notes**:
```bugfix operator github.com/gardener/machine-controller-manager #928 @rishabh-11
Fixed a bug where the `Unitialised` error code was blocking machine deletion
```
