### PR TITLE
Publish Helm charts as OCI artifacts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,4 +1,25 @@
 gardener-extension-provider-aws:
+  templates: 
+    helmcharts:
+    - &provider-aws
+      name: provider-aws
+      dir: charts/gardener-extension-provider-aws
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-provider-aws.repository
+        attribute: image.repository
+      - ref: ocm-resource:gardener-extension-provider-aws.tag
+        attribute: image.tag
+    - &admission-aws
+      name: admission-aws
+      dir: charts/gardener-extension-admission-aws
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-admission-aws.repository
+        attribute: global.image.repository
+      - ref: ocm-resource:gardener-extension-admission-aws.tag
+        attribute: global.image.tag
+
   base_definition:
     traits:
       component_descriptor:
@@ -50,6 +71,10 @@ gardener-extension-provider-aws:
         draft_release: ~
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *provider-aws
+          - *admission-aws
     pull-request:
       traits:
         pull-request: ~
@@ -58,6 +83,10 @@ gardener-extension-provider-aws:
             - repository: europe-docker.pkg.dev/gardener-project/releases
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *provider-aws
+          - *admission-aws
     release:
       steps:
         test-integration:
@@ -90,3 +119,8 @@ gardener-extension-provider-aws:
             gardener-extension-admission-aws:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/admission-aws
               tag_as_latest: true
+          helmcharts:
+          - <<: *provider-aws
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
+          - <<: *admission-aws
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement
/platform aws

**What this PR does / why we need it**:
We should start publishing Helm charts as OCI artifacts that we can deploy them as `Extension` in the future (see https://github.com/gardener/gardener/issues/9635).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Helm charts of extension and admission controller are published as OCI artifacts now.
```
