### PR TITLE
Publish separate admission Helm charts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -10,9 +10,18 @@ gardener-extension-provider-aws:
         attribute: image.repository
       - ref: ocm-resource:gardener-extension-provider-aws.tag
         attribute: image.tag
-    - &admission-aws
-      name: admission-aws
-      dir: charts/gardener-extension-admission-aws
+    - &admission-aws-application
+      name: admission-aws-application
+      dir: charts/gardener-extension-admission-aws/charts/application
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-admission-aws.repository
+        attribute: global.image.repository
+      - ref: ocm-resource:gardener-extension-admission-aws.tag
+        attribute: global.image.tag
+    - &admission-aws-runtime
+      name: admission-aws-runtime
+      dir: charts/gardener-extension-admission-aws/charts/runtime
       registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
       mappings:
       - ref: ocm-resource:gardener-extension-admission-aws.repository
@@ -74,7 +83,8 @@ gardener-extension-provider-aws:
         publish:
           helmcharts:
           - *provider-aws
-          - *admission-aws
+          - *admission-aws-application
+          - *admission-aws-runtime
     pull-request:
       traits:
         pull-request: ~
@@ -86,7 +96,8 @@ gardener-extension-provider-aws:
         publish:
           helmcharts:
           - *provider-aws
-          - *admission-aws
+          - *admission-aws-application
+          - *admission-aws-runtime
     release:
       steps:
         test-integration:
@@ -122,5 +133,7 @@ gardener-extension-provider-aws:
           helmcharts:
           - <<: *provider-aws
             registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
-          - <<: *admission-aws
+          - <<: *admission-aws-application
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
+          - <<: *admission-aws-runtime
             registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Admission Helm charts have to be published as separate charts for application and runtime that they can be used in `operator.gardener.cloud/v1alpha1.Extension` resource.

**Which issue(s) this PR fixes**:
Follow up to #1012

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
