### PR TITLE
Fix error handling

### DIFF
--- a/pkg/controller/infrastructure/terraform.go
+++ b/pkg/controller/infrastructure/terraform.go
@@ -66,7 +66,7 @@ func generateTerraformerEnvVars(secretRef corev1.SecretReference) []corev1.EnvVa
 // CleanupTerraformerResources deletes terraformer artifacts (config, state, secrets).
 func CleanupTerraformerResources(ctx context.Context, tf terraformer.Terraformer) error {
 	if err := tf.EnsureCleanedUp(ctx); err != nil {
-		return nil
+		return err
 	}
 	if err := tf.CleanupConfiguration(ctx); err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
Return error instead of nil in function `CleanupTerraformerResources`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other bugfix
Fix error handling in terraformer cleanup resources function
```
