### PR TITLE
Fix issues with the AWS flow after last update

### DIFF
--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -36,6 +36,7 @@ import (
 	cloudproviderwebhook "github.com/gardener/gardener-extension-provider-aws/pkg/webhook/cloudprovider"
 	controlplanewebhook "github.com/gardener/gardener-extension-provider-aws/pkg/webhook/controlplane"
 	controlplaneexposurewebhook "github.com/gardener/gardener-extension-provider-aws/pkg/webhook/controlplaneexposure"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/webhook/infrastructure"
 	shootwebhook "github.com/gardener/gardener-extension-provider-aws/pkg/webhook/shoot"
 )
 
@@ -70,6 +71,7 @@ func WebhookSwitchOptions(gardenerVersion *string) *webhookcmd.SwitchOptions {
 		webhookcmd.Switch(extensioncontrolplanewebhook.ExposureWebhookName, controlplaneexposurewebhook.AddToManager),
 		webhookcmd.Switch(extensionshootwebhook.WebhookName, shootwebhook.AddToManager),
 		webhookcmd.Switch(extensionscloudproviderwebhook.WebhookName, cloudproviderwebhook.AddToManager),
+		webhookcmd.Switch(infrastructure.WebhookName, infrastructure.AddToManager),
 	)
 }
 

--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -218,7 +218,7 @@ func (c *FlowContext) computeInfrastructureStatus() *awsv1alpha1.InfrastructureS
 	if vpcID != "" {
 		var subnets []awsv1alpha1.Subnet
 		prefix := ChildIdZones + shared.Separator
-		for k, v := range c.state.AsMap() {
+		for k, v := range c.state.ExportAsFlatMap() {
 			if !shared.IsValidValue(v) {
 				continue
 			}

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -971,6 +971,11 @@ func verifyCreation(
 					},
 				))
 				infrastructureIdentifier.subnetIDs = append(infrastructureIdentifier.subnetIDs, subnet.SubnetId)
+				Expect(infraStatus.VPC.Subnets).To(ContainElement(Equal(awsv1alpha1.Subnet{
+					Purpose: awsv1alpha1.PurposeNodes,
+					ID:      ptr.Deref(subnet.SubnetId, ""),
+					Zone:    availabilityZone,
+				})))
 			}
 			if reflect.DeepEqual(tag.Key, awssdk.String("Name")) && reflect.DeepEqual(tag.Value, awssdk.String(infra.Namespace+publicUtilitySuffix)) {
 				foundExpectedSubnets++


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Correctly register infrastructure webhook with the controllerruntime manager
```
```other operator
Fix an issue where the infrastructure state was not properly transformed to the provider status. 
```
