### PR TITLE
[release-v1.57] Automated cherry pick of #1038: Fix issues with the AWS flow after last update

### DIFF
--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -36,6 +36,7 @@ import (
 	cloudproviderwebhook "github.com/gardener/gardener-extension-provider-aws/pkg/webhook/cloudprovider"
 	controlplanewebhook "github.com/gardener/gardener-extension-provider-aws/pkg/webhook/controlplane"
 	controlplaneexposurewebhook "github.com/gardener/gardener-extension-provider-aws/pkg/webhook/controlplaneexposure"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/webhook/infrastructure"
 	shootwebhook "github.com/gardener/gardener-extension-provider-aws/pkg/webhook/shoot"
 )
 
@@ -70,6 +71,7 @@ func WebhookSwitchOptions(gardenerVersion *string) *webhookcmd.SwitchOptions {
 		webhookcmd.Switch(extensioncontrolplanewebhook.ExposureWebhookName, controlplaneexposurewebhook.AddToManager),
 		webhookcmd.Switch(extensionshootwebhook.WebhookName, shootwebhook.AddToManager),
 		webhookcmd.Switch(extensionscloudproviderwebhook.WebhookName, cloudproviderwebhook.AddToManager),
+		webhookcmd.Switch(infrastructure.WebhookName, infrastructure.AddToManager),
 	)
 }
 

--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -218,7 +218,7 @@ func (c *FlowContext) computeInfrastructureStatus() *awsv1alpha1.InfrastructureS
 	if vpcID != "" {
 		var subnets []awsv1alpha1.Subnet
 		prefix := ChildIdZones + shared.Separator
-		for k, v := range c.state.AsMap() {
+		for k, v := range c.state.ExportAsFlatMap() {
 			if !shared.IsValidValue(v) {
 				continue
 			}

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -971,6 +971,11 @@ func verifyCreation(
 					},
 				))
 				infrastructureIdentifier.subnetIDs = append(infrastructureIdentifier.subnetIDs, subnet.SubnetId)
+				Expect(infraStatus.VPC.Subnets).To(ContainElement(Equal(awsv1alpha1.Subnet{
+					Purpose: awsv1alpha1.PurposeNodes,
+					ID:      ptr.Deref(subnet.SubnetId, ""),
+					Zone:    availabilityZone,
+				})))
 			}
 			if reflect.DeepEqual(tag.Key, awssdk.String("Name")) && reflect.DeepEqual(tag.Value, awssdk.String(infra.Namespace+publicUtilitySuffix)) {
 				foundExpectedSubnets++


### PR DESCRIPTION
/area control-plane
/kind bug

Cherry pick of #1038 on release-v1.57.

#1038: Fix issues with the AWS flow after last update

**Release Notes:**
```other operator
Correctly register infrastructure webhook with the controllerruntime manager
```
```other operator
Fix an issue where the infrastructure state was not properly transformed to the provider status. 
```