### PR TITLE
[release-v1.57] Automated cherry pick of #1039: fix controlplane migration case for the infrastructure resources

### DIFF
--- a/pkg/controller/infrastructure/actuator_migrate.go
+++ b/pkg/controller/infrastructure/actuator_migrate.go
@@ -18,9 +18,6 @@ import (
 
 // Migrate deletes only the ConfigMaps and Secrets of the Terraformer.
 func (a *actuator) Migrate(ctx context.Context, log logr.Logger, infrastructure *extensionsv1alpha1.Infrastructure, _ *extensionscontroller.Cluster) error {
-	if infrastructure.Status.State != nil {
-		return nil // nothing to do if already using new flow without Terraformer
-	}
 	tf, err := newTerraformer(log, a.restConfig, aws.TerraformerPurposeInfra, infrastructure, a.disableProjectedTokenMount)
 	if err != nil {
 		return err


### PR DESCRIPTION
/kind bug
/area control-plane-migration

Cherry pick of #1039 on release-v1.57.

#1039: fix controlplane migration case for the infrastructure resources

**Release Notes:**
```other operator
Fix an issue where terraformer artifacts would not be deleted during the control-plane-migration `migrate` phase.
```