### PR TITLE
Introduce `InfrastructureConfigFromCluster` and use it instead of API call

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -362,11 +362,8 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx gcon
 		}
 
 		if k8sGreaterEqual127 {
-			infra := &extensionsv1alpha1.Infrastructure{}
-			if err := e.client.Get(ctx, client.ObjectKey{
-				Namespace: cluster.ObjectMeta.Name,
-				Name:      cluster.Shoot.Name,
-			}, infra); err != nil {
+			infra, err := helper.InfrastructureFromCluster(cluster)
+			if err != nil {
 				return nil, err
 			}
 			infraConfig, err := helper.InfrastructureConfigFromInfrastructure(infra)
@@ -590,14 +587,10 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.Garde
 		return nil
 	}
 
-	infra := &extensionsv1alpha1.Infrastructure{}
-	if err := e.client.Get(ctx, client.ObjectKey{
-		Namespace: cluster.ObjectMeta.Name,
-		Name:      cluster.Shoot.Name,
-	}, infra); err != nil {
+	infra, err := helper.InfrastructureFromCluster(cluster)
+	if err != nil {
 		return err
 	}
-
 	infraConfig, err := helper.InfrastructureConfigFromInfrastructure(infra)
 	if err != nil {
 		return err

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -54,34 +54,9 @@ var _ = Describe("Ensurer", func() {
 		ctx  = context.TODO()
 
 		dummyContext   = gcontext.NewGardenContext(nil, nil)
-		eContextK8s126 = gcontext.NewInternalGardenContext(
-			&extensionscontroller.Cluster{
-				Shoot: &gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.26.1",
-						},
-					},
-				},
-			},
-		)
-		eContextK8s127 = gcontext.NewInternalGardenContext(
-			&extensionscontroller.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "shoot--project--foo",
-				},
-				Shoot: &gardencorev1beta1.Shoot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "foo",
-					},
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.27.1",
-						},
-					},
-				},
-			},
-		)
+		eContextK8s126 gcontext.GardenContext
+		eContextK8s127 gcontext.GardenContext
+
 		eContextK8s131 = gcontext.NewInternalGardenContext(
 			&extensionscontroller.Cluster{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
This PR introduces `InfrastructureConfigFromCluster` that extracts the infrastructureConfig from a cluster resource and uses it in `pkg/webhook/controlplane/ensurer.go` instead of an API call.

**Which issue(s) this PR fixes**:
This fixes a issue where cluster force deletion may fail

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing Shoot force deletion to fail because the control plane webhook failing to get the Infrastructure object from the Seed cluster is now fixed. The control plane webhook now reads the infrastructureConfig from the Shoot spec in the Cluster resource. Previously, it was fetching the Infrastructure object from the Seed cluster and was reading the infrastructureConfig from there.
```
