### PR TITLE
set correct Ipv6CidrBlocks value for all subnets

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -611,9 +611,9 @@ func (c *FlowContext) ensureZones(ctx context.Context) error {
 
 		for i := 0; i < 3; i++ {
 			if len(subnetCIDRs) == 3 && subnetCIDRs[i] != "" {
-				desired[i].Ipv6CidrBlocks = []string{subnetCIDRs[i]}
+				desired[i+3*index].Ipv6CidrBlocks = []string{subnetCIDRs[i]}
 			} else {
-				desired[i].Ipv6CidrBlocks = nil
+				desired[i+3*index].Ipv6CidrBlocks = nil
 			}
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform aws

**What this PR does / why we need it**:
Set correct Ipv6CidrBlocks value for all subnets.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
