### PR TITLE
SC Gardener aws-ebs-csi-driver image update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY --from=builder /go/bin/gardener-extension-provider-aws /gardener-extension-
 ENTRYPOINT ["/gardener-extension-provider-aws"]
 
 ############# gardener-extension-admission-aws
-FROM base as gardener-extension-admission-aws
+FROM base AS gardener-extension-admission-aws
 WORKDIR /
 
 COPY --from=builder /go/bin/gardener-extension-admission-aws /gardener-extension-admission-aws

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -49,7 +49,7 @@ spec:
         - --volume-attach-limit={{ .Values.driver.volumeAttachLimit }}
         {{- end }}
         {{- if .Values.driver.legacyXFS }}
-        - --legacyXFS={{ .Values.driver.legacyXFS }}
+        - --legacy-xfs={{ .Values.driver.legacyXFS }}
         {{- end }}
         - --logtostderr
         - --v=3

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -48,6 +48,9 @@ spec:
         {{- if .Values.driver.volumeAttachLimit }}
         - --volume-attach-limit={{ .Values.driver.volumeAttachLimit }}
         {{- end }}
+        {{- if .Values.driver.legacyXFS }}
+        - --legacyXFS=true
+        {{- end }}
         - --logtostderr
         - --v=3
         - --vmodule=node_*=4,mount*=4,driver=4,controller=4

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -49,7 +49,7 @@ spec:
         - --volume-attach-limit={{ .Values.driver.volumeAttachLimit }}
         {{- end }}
         {{- if .Values.driver.legacyXFS }}
-        - --legacyXFS={{ .Values.driver.volumeAttachLimit }}
+        - --legacyXFS={{ .Values.driver.legacyXFS }}
         {{- end }}
         - --logtostderr
         - --v=3

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -49,7 +49,7 @@ spec:
         - --volume-attach-limit={{ .Values.driver.volumeAttachLimit }}
         {{- end }}
         {{- if .Values.driver.legacyXFS }}
-        - --legacyXFS=true
+        - --legacyXFS={{ .Values.driver.volumeAttachLimit }}
         {{- end }}
         - --logtostderr
         - --v=3

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -8,6 +8,7 @@ vpaEnabled: false
 
 driver: {}
   # volumeAttachLimit: -1
+  # legacyXFS: true
 
 webhookConfig:
   url: https://service-name.service-namespace/volumesnapshot

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -605,7 +605,7 @@ CSI drivers usually have a different procedure for configuring this custom limit
 
 ### Other CSI options
 The newer versions of EBS CSI driver are not readily compatible with the use of XFS volumes on nodes using a kernel version <= 5.4.
-A workaround was added that enables the use of a "legacy XFS" mode that introduces a backwards compatible volume formating for the older kernels. You can enable this option for your shoot by using by annotating it with `aws.provider.extensions.gardener.cloud/legacy-xfs=true`.
+A workaround was added that enables the use of a "legacy XFS" mode that introduces a backwards compatible volume formating for the older kernels. You can enable this option for your shoot by annotating it with `aws.provider.extensions.gardener.cloud/legacy-xfs=true`.
 
 ## Kubernetes Versions per Worker Pool
 

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -603,6 +603,10 @@ The Kubernetes scheduler allows configurable limit for the number of volumes tha
 
 CSI drivers usually have a different procedure for configuring this custom limit. By default, the EBS CSI driver parses the machine type name and then decides the volume limit. However, this is only a rough approximation and not good enough in most cases. Specifying the volume attach limit via command line flag (`--volume-attach-limit`) is currently the alternative until a more sophisticated solution presents itself (dynamically discovering the maximum number of attachable volume per EC2 machine type, see also https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/347). The AWS extension allows the `--volume-attach-limit` flag of the EBS CSI driver to be configurable via `aws.provider.extensions.gardener.cloud/volume-attach-limit` annotation on the `Shoot` resource. If the annotation is added to an existing `Shoot`, then reconciliation needs to be triggered manually (see [Immediate reconciliation](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_operations.md#immediate-reconciliation)), as in general adding annotation to resource is not a change that leads to `.metadata.generation` increase in general.
 
+### Other CSI options
+The newer versions of EBS CSI driver are not readily compatible with the use of XFS volumes on nodes using a kernel version <= 5.4.
+A workaround was added that enables the use of a "legacy XFS" mode that introduces a backwards compatible volume formating for the older kernels. You can enable this option for your shoot by using by annotating it with `aws.provider.extensions.gardener.cloud/legacy-xfs=true`.
+
 ## Kubernetes Versions per Worker Pool
 
 This extension supports `gardener/gardener`'s `WorkerPoolKubernetesVersion` feature gate, i.e., having [worker pools with overridden Kubernetes versions](https://github.com/gardener/gardener/blob/8a9c88866ec5fce59b5acf57d4227eeeb73669d7/example/90-shoot.yaml#L69-L70) since `gardener-extension-provider-aws@v1.34`.

--- a/pkg/aws/types.go
+++ b/pkg/aws/types.go
@@ -12,13 +12,13 @@ const (
 	// Name is the name of the AWS provider.
 	Name = "provider-aws"
 
-	// VolumeAttachLimit is the key for an annotation on a Shoot object whose value
-	// represents the maximum number of volumes attachable for all nodes.
+	// VolumeAttachLimit is the key for an annotation on a Shoot object whose value represents the maximum number of
+	// volumes attachable for all nodes.
 	VolumeAttachLimit = "aws.provider.extensions.gardener.cloud/volume-attach-limit"
 
-	// LegacyXFS is the key for an annotation on a Shoot object whose value
-	// represents whether or not LegacyXFS mode should be enabled
-	legacyXFS = "aws.provider.extensions.gardener.cloud/legacyXFS"
+	// LegacyXFS is the key for an annotation on a Shoot object whose value represents whether LegacyXFS mode should be
+	// enabled.
+	LegacyXFS = "aws.provider.extensions.gardener.cloud/legacyXFS"
 
 	// CloudControllerManagerImageName is the name of the cloud-controller-manager image.
 	CloudControllerManagerImageName = "cloud-controller-manager"

--- a/pkg/aws/types.go
+++ b/pkg/aws/types.go
@@ -16,6 +16,10 @@ const (
 	// represents the maximum number of volumes attachable for all nodes.
 	VolumeAttachLimit = "aws.provider.extensions.gardener.cloud/volume-attach-limit"
 
+	// LegacyXFS is the key for an annotation on a Shoot object whose value
+	// represents whether or not LegacyXFS mode should be enabled
+	legacyXFS = "aws.provider.extensions.gardener.cloud/legacyXFS"
+
 	// CloudControllerManagerImageName is the name of the cloud-controller-manager image.
 	CloudControllerManagerImageName = "cloud-controller-manager"
 	// AWSCustomRouteControllerImageName is the name of the aws-custom-route-controller image.

--- a/pkg/aws/types.go
+++ b/pkg/aws/types.go
@@ -18,7 +18,7 @@ const (
 
 	// LegacyXFS is the key for an annotation on a Shoot object whose value represents whether LegacyXFS mode should be
 	// enabled.
-	LegacyXFS = "aws.provider.extensions.gardener.cloud/legacyXFS"
+	LegacyXFS = "aws.provider.extensions.gardener.cloud/legacy-xfs"
 
 	// CloudControllerManagerImageName is the name of the cloud-controller-manager image.
 	CloudControllerManagerImageName = "cloud-controller-manager"

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -820,17 +820,15 @@ func getControlPlaneShootChartValues(
 		},
 	}
 
+	driver := map[string]interface{}{}
 	if value, ok := cluster.Shoot.Annotations[aws.VolumeAttachLimit]; ok {
-		csiDriverNodeValues["driver"] = map[string]interface{}{
-			"volumeAttachLimit": value,
-		}
+		driver["volumeAttachLimit"] = value
 	}
 
-	if value, ok := cluster.Shoot.Annotations[aws.legacyXFS]; ok {
-		csiDriverNodeValues["driver"] = map[string]interface{}{
-			"legacyXFS": value,
-		}
+	if value, ok := cluster.Shoot.Annotations[aws.LegacyXFS]; ok {
+		driver["legacyXFS"] = value
 	}
+	csiDriverNodeValues["driver"] = driver
 
 	albValues, err := getALBChartValues(cpConfig, cp, cluster, secretsReader, nil, false, nil)
 	if err != nil {

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -826,6 +826,12 @@ func getControlPlaneShootChartValues(
 		}
 	}
 
+	if value, ok := cluster.Shoot.Annotations[aws.legacyXFS]; ok {
+		csiDriverNodeValues["driver"] = map[string]interface{}{
+			"legacyXFS": value,
+		}
+	}
+
 	albValues, err := getALBChartValues(cpConfig, cp, cluster, secretsReader, nil, false, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/area control-plane
/area delivery
/kind bug
/platform aws

**What this PR does / why we need it**:
SC Gardener landscapes require the aws csi-driver to run in legacyXFS mode. To do this the parameter needs to be configurable inside of the values.yaml file as well as added to the daemonset if aforementioned parameter is set to `True`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Test manually. Paused the corresponding managed resource object, edited the csi-driver pod and its image for one of our cluster to use the `1.35.0` version. Then, edited the pod spec to include the extra legacyXFS patameter. The pod is running fine with no issues in legacyXFS mode.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following images are updated:
registry.k8s.io/provider-aws/aws-ebs-csi-driver: v1.29.0 -> v1.35.0
```
