### PR TITLE
Create IPv6 ServiceCIDR and write IPv6 ranges to `Infra.Status.Networking`

### DIFF
--- a/pkg/apis/aws/validation/infrastructure.go
+++ b/pkg/apis/aws/validation/infrastructure.go
@@ -148,7 +148,7 @@ func ValidateInfrastructureConfig(infra *apisaws.InfrastructureConfig, ipFamilie
 
 	if (infra.Networks.VPC.ID == nil && infra.Networks.VPC.CIDR == nil) || (infra.Networks.VPC.ID != nil && infra.Networks.VPC.CIDR != nil) {
 		allErrs = append(allErrs, field.Invalid(networksPath.Child("vpc"), infra.Networks.VPC, "must specify either a vpc id or a cidr"))
-	} else if infra.Networks.VPC.CIDR != nil && infra.Networks.VPC.ID == nil {
+	} else if infra.Networks.VPC.CIDR != nil && infra.Networks.VPC.ID == nil && !slices.Contains(ipFamilies, core.IPFamilyIPv6) {
 		cidrPath := networksPath.Child("vpc", "cidr")
 		vpcCIDR := cidrvalidation.NewCIDR(*infra.Networks.VPC.CIDR, cidrPath)
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(cidrPath, *infra.Networks.VPC.CIDR)...)

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -1535,7 +1535,9 @@ func (c *Client) GetIPv6CIDRReservations(ctx context.Context, subnet *Subnet) ([
 	}
 	var cidrs []string
 	for _, cidrReservation := range output.SubnetIpv6CidrReservations {
-		cidrs = append(cidrs, *cidrReservation.Cidr)
+		if cidrReservation != nil && cidrReservation.Cidr != nil {
+			cidrs = append(cidrs, *cidrReservation.Cidr)
+		}
 	}
 	return cidrs, nil
 }

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -1508,6 +1508,38 @@ func (c *Client) CreateSubnet(ctx context.Context, subnet *Subnet) (*Subnet, err
 	return fromSubnet(output.Subnet), nil
 }
 
+// CreateCIDRReservation creates a EC2 subnet cidr reservation resource.
+func (c *Client) CreateCIDRReservation(ctx context.Context, subnet *Subnet, cidr string, reservationType string) (string, error) {
+	input := &ec2.CreateSubnetCidrReservationInput{
+		SubnetId:        &subnet.SubnetId,
+		Cidr:            aws.String(cidr),
+		ReservationType: aws.String(reservationType),
+	}
+
+	output, err := c.EC2.CreateSubnetCidrReservationWithContext(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	return *output.SubnetCidrReservation.Cidr, nil
+}
+
+// CreateCIDRReservation gets EC2 subnet cidr reservations.
+func (c *Client) GetIPv6CIDRReservations(ctx context.Context, subnet *Subnet) ([]string, error) {
+	input := &ec2.GetSubnetCidrReservationsInput{
+		SubnetId: &subnet.SubnetId,
+	}
+
+	output, err := c.EC2.GetSubnetCidrReservationsWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	var cidrs []string
+	for _, cidrReservation := range output.SubnetIpv6CidrReservations {
+		cidrs = append(cidrs, *cidrReservation.Cidr)
+	}
+	return cidrs, nil
+}
+
 // GetSubnets gets subnets for the given identifiers.
 // Non-existing identifiers are ignored silently.
 func (c *Client) GetSubnets(ctx context.Context, ids []string) ([]*Subnet, error) {

--- a/pkg/aws/client/mock/mocks.go
+++ b/pkg/aws/client/mock/mocks.go
@@ -112,6 +112,21 @@ func (mr *MockInterfaceMockRecorder) CreateBucketIfNotExists(arg0, arg1, arg2 an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBucketIfNotExists", reflect.TypeOf((*MockInterface)(nil).CreateBucketIfNotExists), arg0, arg1, arg2)
 }
 
+// CreateCIDRReservation mocks base method.
+func (m *MockInterface) CreateCIDRReservation(arg0 context.Context, arg1 *client.Subnet, arg2, arg3 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateCIDRReservation", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateCIDRReservation indicates an expected call of CreateCIDRReservation.
+func (mr *MockInterfaceMockRecorder) CreateCIDRReservation(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCIDRReservation", reflect.TypeOf((*MockInterface)(nil).CreateCIDRReservation), arg0, arg1, arg2, arg3)
+}
+
 // CreateEC2Tags mocks base method.
 func (m *MockInterface) CreateEC2Tags(arg0 context.Context, arg1 []string, arg2 client.Tags) error {
 	m.ctrl.T.Helper()
@@ -1057,6 +1072,21 @@ func (m *MockInterface) GetIAMRolePolicy(arg0 context.Context, arg1, arg2 string
 func (mr *MockInterfaceMockRecorder) GetIAMRolePolicy(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIAMRolePolicy", reflect.TypeOf((*MockInterface)(nil).GetIAMRolePolicy), arg0, arg1, arg2)
+}
+
+// GetIPv6CIDRReservations mocks base method.
+func (m *MockInterface) GetIPv6CIDRReservations(arg0 context.Context, arg1 *client.Subnet) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIPv6CIDRReservations", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIPv6CIDRReservations indicates an expected call of GetIPv6CIDRReservations.
+func (mr *MockInterfaceMockRecorder) GetIPv6CIDRReservations(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPv6CIDRReservations", reflect.TypeOf((*MockInterface)(nil).GetIPv6CIDRReservations), arg0, arg1)
 }
 
 // GetIPv6Cidr mocks base method.

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -120,6 +120,10 @@ type Interface interface {
 	UpdateSubnetAttributes(ctx context.Context, desired, current *Subnet) (modified bool, err error)
 	DeleteSubnet(ctx context.Context, id string) error
 
+	// Subnet CIDR Reservation
+	CreateCIDRReservation(ctx context.Context, subnet *Subnet, cidr string, reservationType string) (string, error)
+	GetIPv6CIDRReservations(ctx context.Context, subnet *Subnet) ([]string, error)
+
 	// Route table associations
 	CreateRouteTableAssociation(ctx context.Context, routeTableId, subnetId string) (associationId *string, err error)
 	DeleteRouteTableAssociation(ctx context.Context, associationId string) error

--- a/pkg/controller/infrastructure/flow_reconciler.go
+++ b/pkg/controller/infrastructure/flow_reconciler.go
@@ -207,7 +207,7 @@ func (f *FlowReconciler) migrateFromTerraform(ctx context.Context, infra *extens
 		return nil, err
 	}
 
-	if err := infraflow.PatchProviderStatusAndState(ctx, f.client, infra, infrastructureStatus, &runtime.RawExtension{Object: state}, nil); err != nil {
+	if err := infraflow.PatchProviderStatusAndState(ctx, f.client, infra, infrastructureStatus, &runtime.RawExtension{Object: state}, nil, nil); err != nil {
 		return nil, fmt.Errorf("updating status state failed: %w", err)
 	}
 

--- a/pkg/controller/infrastructure/flow_reconciler.go
+++ b/pkg/controller/infrastructure/flow_reconciler.go
@@ -207,7 +207,7 @@ func (f *FlowReconciler) migrateFromTerraform(ctx context.Context, infra *extens
 		return nil, err
 	}
 
-	if err := infraflow.PatchProviderStatusAndState(ctx, f.client, infra, infrastructureStatus, &runtime.RawExtension{Object: state}, nil, nil); err != nil {
+	if err := infraflow.PatchProviderStatusAndState(ctx, f.client, infra, infrastructureStatus, &runtime.RawExtension{Object: state}, nil, nil, nil); err != nil {
 		return nil, fmt.Errorf("updating status state failed: %w", err)
 	}
 

--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -197,6 +197,7 @@ func PatchProviderStatusAndState(
 				Pods:     []string{*vpcIPv6CidrBlock},
 				Services: []string{*serviceCIDR},
 			}
+			infra.Status.EgressCIDRs = append(infra.Status.EgressCIDRs, *vpcIPv6CidrBlock)
 		}
 	}
 

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -47,7 +47,8 @@ func (c *FlowContext) Reconcile(ctx context.Context) error {
 	status := c.computeInfrastructureStatus()
 	state := c.computeInfrastructureState()
 	egressCIDRs := c.getEgressCIDRs()
-	return PatchProviderStatusAndState(ctx, c.runtimeClient, c.infra, status, state, egressCIDRs)
+	vpcIPv6CidrBlock := c.state.Get(IdentifierVpcIPv6CidrBlock)
+	return PatchProviderStatusAndState(ctx, c.runtimeClient, c.infra, status, state, egressCIDRs, vpcIPv6CidrBlock)
 }
 
 func (c *FlowContext) buildReconcileGraph() *flow.Graph {

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -952,6 +952,7 @@ func (c *FlowContext) ensureSubnetCidrReservation(ctx context.Context) error {
 			}
 
 			if slices.Contains(currentCidrs, cidr) {
+				c.state.Set(IdentifierServiceCIDR, cidr)
 				return nil
 			}
 		}

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -842,7 +842,6 @@ func (c *FlowContext) addZoneReconcileTasks(g *flow.Graph, zone *aws.Zone, depen
 	_ = c.AddTask(g, "ensure VPC endpoints route table associations "+zone.Name,
 		c.ensureVPCEndpointsRoutingTableAssociations(zone.Name),
 		Timeout(defaultTimeout), Dependencies(dependencies...), Dependencies(ensureRoutingTable))
-
 }
 
 func (c *FlowContext) addZoneDeletionTasks(g *flow.Graph, zoneName string) flow.TaskIDer {

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"net"
 	"reflect"
+	"slices"
 	"strings"
 	"text/template"
 	"time"
@@ -48,7 +49,8 @@ func (c *FlowContext) Reconcile(ctx context.Context) error {
 	state := c.computeInfrastructureState()
 	egressCIDRs := c.getEgressCIDRs()
 	vpcIPv6CidrBlock := c.state.Get(IdentifierVpcIPv6CidrBlock)
-	return PatchProviderStatusAndState(ctx, c.runtimeClient, c.infra, status, state, egressCIDRs, vpcIPv6CidrBlock)
+	serviceCidr := c.state.Get(IdentifierServiceCIDR)
+	return PatchProviderStatusAndState(ctx, c.runtimeClient, c.infra, status, state, egressCIDRs, vpcIPv6CidrBlock, serviceCidr)
 }
 
 func (c *FlowContext) buildReconcileGraph() *flow.Graph {
@@ -94,6 +96,10 @@ func (c *FlowContext) buildReconcileGraph() *flow.Graph {
 	ensureZones := c.AddTask(g, "ensure zones resources",
 		c.ensureZones,
 		Timeout(defaultLongTimeout), Dependencies(ensureVpc, ensureNodesSecurityGroup, ensureVpcIPv6CidrBloc, ensureMainRouteTable))
+
+	_ = c.AddTask(g, "ensure subnet cidr reservation",
+		c.ensureSubnetCidrReservation,
+		Timeout(defaultLongTimeout), Dependencies(ensureZones))
 
 	_ = c.AddTask(g, "ensure egress CIDRs",
 		c.ensureEgressCIDRs,
@@ -836,6 +842,7 @@ func (c *FlowContext) addZoneReconcileTasks(g *flow.Graph, zone *aws.Zone, depen
 	_ = c.AddTask(g, "ensure VPC endpoints route table associations "+zone.Name,
 		c.ensureVPCEndpointsRoutingTableAssociations(zone.Name),
 		Timeout(defaultTimeout), Dependencies(dependencies...), Dependencies(ensureRoutingTable))
+
 }
 
 func (c *FlowContext) addZoneDeletionTasks(g *flow.Graph, zoneName string) flow.TaskIDer {
@@ -915,6 +922,64 @@ func (c *FlowContext) ensureSubnet(subnetKey string, desired, current *awsclient
 		}
 		return nil
 	}
+}
+
+func (c *FlowContext) ensureSubnetCidrReservation(ctx context.Context) error {
+	if !isIPv6(c.ipFamilies) {
+		return nil
+	}
+
+	subnets, err := c.collectExistingSubnets(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, subnet := range subnets {
+		_, key, err := c.getSubnetKey(subnet)
+		if err != nil {
+			return err
+		}
+
+		if key == IdentifierZoneSubnetWorkers {
+			cidr, err := cidrSubnet(subnet.Ipv6CidrBlocks[0], 108, 1)
+			if err != nil {
+				return err
+			}
+
+			currentCidrs, err := c.client.GetIPv6CIDRReservations(ctx, subnet)
+			if err != nil {
+				return err
+			}
+
+			if slices.Contains(currentCidrs, cidr) {
+				return nil
+			}
+		}
+	}
+
+	// we didn't find a CIDR reservation on a subnet
+	// create a new one at the first nodes subnet we find
+	for _, subnet := range subnets {
+		_, key, err := c.getSubnetKey(subnet)
+		if err != nil {
+			return err
+		}
+
+		if key == IdentifierZoneSubnetWorkers {
+			cidr, err := cidrSubnet(subnet.Ipv6CidrBlocks[0], 108, 1)
+			if err != nil {
+				return err
+			}
+
+			cidr, err = c.client.CreateCIDRReservation(ctx, subnet, cidr, "explicit")
+			if err != nil {
+				return err
+			}
+			c.state.Set(IdentifierServiceCIDR, cidr)
+			return nil
+		}
+	}
+	return nil
 }
 
 func (c *FlowContext) ensureElasticIP(zone *aws.Zone) flow.TaskFn {

--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -389,6 +389,14 @@ resource "aws_vpc_endpoint_route_table_association" "vpc_gwep_{{ $ep }}_z{{ $ind
 
 {{end}}
 
+{{- if .isIPv6 }}
+resource "aws_ec2_subnet_cidr_reservation" "service-range" {
+  cidr_block       = "${cidrsubnet(cidrsubnet({{ .vpc.ipv6CidrBlock }}, 8, 0),44,1)}"
+  reservation_type = "explicit"
+  subnet_id        = aws_subnet.nodes_z0.id
+}
+{{end}}
+
 //=====================================================================
 //= IAM instance profiles
 //=====================================================================

--- a/pkg/controller/infrastructure/tf_reconciler.go
+++ b/pkg/controller/infrastructure/tf_reconciler.go
@@ -135,7 +135,7 @@ func (t *TerraformReconciler) reconcile(ctx context.Context, infra *extensionsv1
 		return err
 	}
 
-	return infraflow.PatchProviderStatusAndState(ctx, t.client, infra, status, &runtime.RawExtension{Raw: stateBytes}, egressCIDRs)
+	return infraflow.PatchProviderStatusAndState(ctx, t.client, infra, status, &runtime.RawExtension{Raw: stateBytes}, egressCIDRs, nil)
 }
 
 // Delete deletes the infrastructure using Terraformer.

--- a/pkg/controller/infrastructure/tf_reconciler.go
+++ b/pkg/controller/infrastructure/tf_reconciler.go
@@ -135,7 +135,7 @@ func (t *TerraformReconciler) reconcile(ctx context.Context, infra *extensionsv1
 		return err
 	}
 
-	return infraflow.PatchProviderStatusAndState(ctx, t.client, infra, status, &runtime.RawExtension{Raw: stateBytes}, egressCIDRs, nil)
+	return infraflow.PatchProviderStatusAndState(ctx, t.client, infra, status, &runtime.RawExtension{Raw: stateBytes}, egressCIDRs, nil, nil)
 }
 
 // Delete deletes the infrastructure using Terraformer.
@@ -374,7 +374,7 @@ func generateTerraformInfraConfig(ctx context.Context, infrastructure *extension
 			existingEgressOnlyInternetGatewayID := eogw.EgressOnlyInternetGatewayId
 			egressOnlyInternetGatewayID = strconv.Quote(existingEgressOnlyInternetGatewayID)
 		}
-		// if dual stack is enabled or ipFamily is IPv6, then we wait for until the target VPC has a ipv6 CIDR assigned.
+		// if dual stack is enabled or ipFamily is IPv6, then we wait until the target VPC has a ipv6 CIDR assigned.
 		if enableDualStack || isIPv6 {
 			existingIPv6CidrBlock, err := awsClient.WaitForIPv6Cidr(ctx, existingVpcID)
 			if err != nil {

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -1228,6 +1228,10 @@ func verifyCreation(
 			Expect(eoigs[0].Tags).To(ConsistOf(defaultTags))
 			infrastructureIdentifier.egressOnlyInternetGatewayID = eoigs[0].EgressOnlyInternetGatewayId
 		}
+
+		Expect(infra.Status.Networking.Nodes).To(HaveLen(1))
+		Expect(infra.Status.Networking.Pods).To(HaveLen(1))
+		Expect(infra.Status.Networking.Services).To(HaveLen(1))
 	}
 
 	// route tables + routes

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -1209,7 +1209,7 @@ func verifyCreation(
 			}
 		}
 	}
-	Expect(infra.Status.EgressCIDRs).To(ConsistOf(egressCIDRs))
+	Expect(infra.Status.EgressCIDRs).To(ContainElements(egressCIDRs))
 
 	if isIPv6(ipfamilies) {
 		// egress only internet gateway


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Create an IPv6 CIDR reservation for the first nodes subnet that we find, use it as Service CIDR and write it to `Infra.Status.Networking`.
The CIDR of the VPC will be used as Node range and Pod range and written to `Infra.Status.Networking`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Create IPv6 ServiceCIDR and write IPv6 ranges to Infra.Status.Networking
```
