### PR TITLE
support nat64 and dns64

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -1460,6 +1460,7 @@ func (c *Client) describeRouteTables(ctx context.Context, input *ec2.DescribeRou
 				NatGatewayId:                route.NatGatewayId,
 				EgressOnlyInternetGatewayId: route.EgressOnlyInternetGatewayId,
 				DestinationPrefixListId:     route.DestinationPrefixListId,
+				DestinationIpv6CidrBlock:    route.DestinationIpv6CidrBlock,
 			})
 		}
 		for _, assoc := range item.Associations {

--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -181,6 +181,7 @@ resource "aws_subnet" "nodes_z{{ $index }}" {
   availability_zone = "{{ $zone.name }}"
 
   {{ if $.isIPv6 }}
+  enable_dns64 = true
   ipv6_native = true
   assign_ipv6_address_on_creation = true
   ipv6_cidr_block = "${cidrsubnet({{ $.vpc.ipv6CidrBlock }}, 8, (({{ $index }} * 3)))}"
@@ -344,6 +345,16 @@ resource "aws_route" "private_utility_z{{ $index }}_nat" {
 }
 
 {{- if $.isIPv6 }}
+resource "aws_route" "private_utility_z{{ $index }}_nat_64" {
+  route_table_id         = aws_route_table.routetable_private_utility_z{{ $index }}.id
+  destination_ipv6_cidr_block  = "64:ff9b::/96"
+  nat_gateway_id         = aws_nat_gateway.natgw_z{{ $index }}.id
+
+  timeouts {
+    create = "5m"
+  }
+}
+
 resource "aws_route" "private_utility_z{{ $index }}_egw" {
   route_table_id         = aws_route_table.routetable_private_utility_z{{ $index }}.id
   destination_ipv6_cidr_block = "::/0"

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -826,6 +826,7 @@ func verifyCreation(
 		sshPublicKeyDigest = "46:ca:46:0e:8e:1d:bc:0c:45:31:ee:0f:43:5f:9b:f1"
 		allCIDR            = "0.0.0.0/0"
 		allCIDRIPV6        = "::/0"
+		nat64Prefix        = "64:ff9b::/96"
 	)
 
 	var (
@@ -1356,6 +1357,13 @@ func verifyCreation(
 							eoigs = append(eoigs, item)
 						}
 					}
+
+					expectedRoutes = append(expectedRoutes, &ec2.Route{
+						DestinationIpv6CidrBlock: awssdk.String(nat64Prefix),
+						NatGatewayId:             describeNatGatewaysOutput.NatGateways[0].NatGatewayId,
+						Origin:                   awssdk.String("CreateRoute"),
+						State:                    awssdk.String("active"),
+					})
 
 					expectedRoutes = append(expectedRoutes, &ec2.Route{
 						DestinationIpv6CidrBlock:    awssdk.String(allCIDRIPV6),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Enable `nat64` and `dns64` for IPv6 shoot clusters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Enable `nat64` and `dns64` for IPv6 shoot clusters.
```
