### PR TITLE
Fix routing table association deletion

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -1274,13 +1274,11 @@ func (c *FlowContext) deleteRoutingTableAssociations(zoneName string) flow.TaskF
 func (c *FlowContext) deleteZoneRoutingTableAssociation(ctx context.Context, zoneName string,
 	zoneRouteTable bool, subnetKey, assocKey string) error {
 	child := c.getSubnetZoneChild(zoneName)
-	if child.Get(assocKey) == nil {
-		return nil
-	}
 	subnetID := child.Get(subnetKey)
 	if subnetID == nil {
 		return fmt.Errorf("missing subnet id")
 	}
+
 	assocID := child.Get(assocKey)
 	if assocID == nil {
 		// unclear situation: load route table to search for association
@@ -1303,11 +1301,12 @@ func (c *FlowContext) deleteZoneRoutingTableAssociation(ctx context.Context, zon
 			}
 		}
 	}
+
+	log := LogFromContext(ctx)
 	if assocID == nil {
-		child.Delete(assocKey)
+		log.Info("No association ID found, nothing to delete", "SubnetID", subnetID)
 		return nil
 	}
-	log := LogFromContext(ctx)
 	log.Info("deleting...", "RouteTableAssociationId", *assocID)
 	if err := c.client.DeleteRouteTableAssociation(ctx, *assocID); err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
Fix cleanup of routing table associations.
If no routing table association is found, we should also check in the routing table retrieved by the client.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix cleanup of routing table associations
```
