### PR TITLE
Fix decoding of infraConfig

### DIFF
--- a/pkg/apis/aws/helper/scheme.go
+++ b/pkg/apis/aws/helper/scheme.go
@@ -45,11 +45,11 @@ func CloudProfileConfigFromCluster(cluster *controller.Cluster) (*api.CloudProfi
 	return cloudProfileConfig, nil
 }
 
-// InfrastructureFromCluster decodes the infrastructure for a shoot cluster
-func InfrastructureFromCluster(cluster *controller.Cluster) (*extensionsv1alpha1.Infrastructure, error) {
-	var infra *extensionsv1alpha1.Infrastructure
+// InfrastructureConfigFromCluster decodes the InfrastructureConfig for a shoot cluster
+func InfrastructureConfigFromCluster(cluster *controller.Cluster) (*api.InfrastructureConfig, error) {
+	var infra *api.InfrastructureConfig
 	if cluster != nil && cluster.Shoot != nil && cluster.Shoot.Spec.Provider.InfrastructureConfig != nil && cluster.Shoot.Spec.Provider.InfrastructureConfig.Raw != nil {
-		infra = &extensionsv1alpha1.Infrastructure{}
+		infra = &api.InfrastructureConfig{}
 		if _, _, err := decoder.Decode(cluster.Shoot.Spec.Provider.InfrastructureConfig.Raw, nil, infra); err != nil {
 			return nil, fmt.Errorf("could not decode infrastructure of shoot '%s': %w", k8sclient.ObjectKeyFromObject(cluster.Shoot), err)
 		}

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -362,11 +362,7 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx gcon
 		}
 
 		if k8sGreaterEqual127 {
-			infra, err := helper.InfrastructureFromCluster(cluster)
-			if err != nil {
-				return nil, err
-			}
-			infraConfig, err := helper.InfrastructureConfigFromInfrastructure(infra)
+			infraConfig, err := helper.InfrastructureConfigFromCluster(cluster)
 			if err != nil {
 				return nil, err
 			}
@@ -587,11 +583,7 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.Garde
 		return nil
 	}
 
-	infra, err := helper.InfrastructureFromCluster(cluster)
-	if err != nil {
-		return err
-	}
-	infraConfig, err := helper.InfrastructureConfigFromInfrastructure(infra)
+	infraConfig, err := helper.InfrastructureConfigFromCluster(cluster)
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -71,8 +71,7 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		)
-		infraConfig    *v1alpha1.InfrastructureConfig
-		infrastructure *extensionsv1alpha1.Infrastructure
+		infraConfig *v1alpha1.InfrastructureConfig
 	)
 
 	BeforeEach(func() {
@@ -85,21 +84,6 @@ var _ = Describe("Ensurer", func() {
 				Kind:       "InfrastructureConfig",
 			},
 		}
-		infrastructure = &extensionsv1alpha1.Infrastructure{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),
-				Kind:       "Infrastructure",
-			},
-			Spec: extensionsv1alpha1.InfrastructureSpec{
-				DefaultSpec: extensionsv1alpha1.DefaultSpec{
-					Type: aws.Type,
-					ProviderConfig: &runtime.RawExtension{
-						Object: infraConfig,
-					},
-				},
-			},
-		}
-
 	})
 
 	JustBeforeEach(func() {
@@ -112,7 +96,7 @@ var _ = Describe("Ensurer", func() {
 						},
 						Provider: gardencorev1beta1.Provider{
 							InfrastructureConfig: &runtime.RawExtension{
-								Raw: encode(infrastructure),
+								Raw: encode(infraConfig),
 							},
 						},
 					},
@@ -134,7 +118,7 @@ var _ = Describe("Ensurer", func() {
 						},
 						Provider: gardencorev1beta1.Provider{
 							InfrastructureConfig: &runtime.RawExtension{
-								Raw: encode(infrastructure),
+								Raw: encode(infraConfig),
 							},
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
Fix bug in decoding of infraConfig which was introduced with https://github.com/gardener/gardener-extension-provider-aws/pull/1068 by @Kostov6 and @ialidzhikov.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
