### PR TITLE
Minor nits after wrong rebase in #1068

### DIFF
--- a/pkg/apis/aws/helper/scheme.go
+++ b/pkg/apis/aws/helper/scheme.go
@@ -28,7 +28,6 @@ var (
 func init() {
 	Scheme = runtime.NewScheme()
 	utilruntime.Must(install.AddToScheme(Scheme))
-	utilruntime.Must(extensionsv1alpha1.AddToScheme(Scheme))
 
 	decoder = serializer.NewCodecFactory(Scheme, serializer.EnableStrict).UniversalDecoder()
 }
@@ -49,16 +48,16 @@ func CloudProfileConfigFromCluster(cluster *controller.Cluster) (*api.CloudProfi
 	return cloudProfileConfig, nil
 }
 
-// InfrastructureConfigFromCluster decodes the InfrastructureConfig for a shoot cluster
+// InfrastructureConfigFromCluster decodes the infrastructure configuration for a cluster
 func InfrastructureConfigFromCluster(cluster *controller.Cluster) (*api.InfrastructureConfig, error) {
-	var infra *api.InfrastructureConfig
+	var infrastructureConfig *api.InfrastructureConfig
 	if cluster != nil && cluster.Shoot != nil && cluster.Shoot.Spec.Provider.InfrastructureConfig != nil && cluster.Shoot.Spec.Provider.InfrastructureConfig.Raw != nil {
-		infra = &api.InfrastructureConfig{}
-		if _, _, err := decoder.Decode(cluster.Shoot.Spec.Provider.InfrastructureConfig.Raw, nil, infra); err != nil {
-			return nil, fmt.Errorf("could not decode infrastructure of shoot '%s': %w", k8sclient.ObjectKeyFromObject(cluster.Shoot), err)
+		infrastructureConfig = &api.InfrastructureConfig{}
+		if _, _, err := decoder.Decode(cluster.Shoot.Spec.Provider.InfrastructureConfig.Raw, nil, infrastructureConfig); err != nil {
+			return nil, fmt.Errorf("could not decode infrastructureConfig of shoot '%s': %w", k8sclient.ObjectKeyFromObject(cluster.Shoot), err)
 		}
 	}
-	return infra, nil
+	return infrastructureConfig, nil
 }
 
 // InfrastructureConfigFromInfrastructure extracts the InfrastructureConfig from the


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform aws

**What this PR does / why we need it**:
In #1068, we pushed https://github.com/gardener/gardener-extension-provider-aws/compare/eec15e76a4a8701b62c53dc27ac573f401255f50..b1e406fe7aad165f30746e3bf616340bffb21639 to address https://github.com/gardener/gardener-extension-provider-aws/pull/1068#discussion_r1776785054. However the last rebase (ref https://github.com/gardener/gardener-extension-provider-aws/compare/b1e406fe7aad165f30746e3bf616340bffb21639..ea73612e83e2c28e687dccfc1aed0e64a3c5a07e) reverted these changes.
Later on the issue was fixed in https://github.com/gardener/gardener-extension-provider-aws/pull/1086.
This PR adds minor nits so that https://github.com/gardener/gardener-extension-provider-aws/pull/1086 gets the same as https://github.com/gardener/gardener-extension-provider-aws/compare/eec15e76a4a8701b62c53dc27ac573f401255f50..b1e406fe7aad165f30746e3bf616340bffb21639.  

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
