### PR TITLE
Fix route table association deletion

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -1347,12 +1347,9 @@ func (c *FlowContext) deleteZoneRoutingTableAssociation(ctx context.Context, zon
 	zoneRouteTable bool, subnetKey, assocKey string) error {
 	child := c.getSubnetZoneChild(zoneName)
 	subnetID := child.Get(subnetKey)
-	if subnetID == nil {
-		return fmt.Errorf("missing subnet id")
-	}
-
 	assocID := child.Get(assocKey)
-	if assocID == nil {
+
+	if assocID == nil && subnetID != nil {
 		// unclear situation: load route table to search for association
 		var routeTableID *string
 		if zoneRouteTable {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
Fix flow: Ignore subnet not found in infra state while deleting routing table associations

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`c.client.GetRouteTable` already ignores not found error.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix flow: Ignore subnet not found in infra state while deleting routing table associations
```