### PR TITLE
Always enable AWS load balancer controller for clusters with IPv6

### DIFF
--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -139,6 +139,14 @@ func (s *shoot) Mutate(_ context.Context, newObj, oldObj client.Object) error {
 		}
 	}
 
+	// Always enable AWS load balancer controller for IPv6-only and dual-stack clusters to ensure load balancing capabilities.
+	if gardencorev1beta1.IsIPv6SingleStack(shoot.Spec.Networking.IPFamilies) || len(shoot.Spec.Networking.IPFamilies) > 1 {
+		if controlPlaneConfig.LoadBalancerController == nil {
+			controlPlaneConfig.LoadBalancerController = &awsv1alpha1.LoadBalancerControllerConfig{}
+		}
+		controlPlaneConfig.LoadBalancerController.Enabled = true
+	}
+
 	shoot.Spec.Provider.ControlPlaneConfig = &runtime.RawExtension{
 		Object: controlPlaneConfig,
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:

Always enable AWS load balancer controller for clusters with IPv6.

AWS cloud controller manager only supports purely IPv4 load balancers. It will not work in IPv6-only environments and does not offer the full functionality in dual-stack environments. Therefore, this change always enabled the fully IPv6-capable AWS load balancer controller in case a shoot cluster with IPv6 is created.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
AWS load balancers controller is always enabled for IPv6-only and dual-stack shoot clusters.
```
