### PR TITLE
Fix nil check after getting route table

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -1362,10 +1362,13 @@ func (c *FlowContext) deleteZoneRoutingTableAssociation(ctx context.Context, zon
 			if err != nil {
 				return err
 			}
-			for _, assoc := range routeTable.Associations {
-				if reflect.DeepEqual(subnetID, assoc.SubnetId) {
-					assocID = &assoc.RouteTableAssociationId
-					break
+			// if not found routeTable might be nil
+			if routeTable != nil {
+				for _, assoc := range routeTable.Associations {
+					if reflect.DeepEqual(subnetID, assoc.SubnetId) {
+						assocID = &assoc.RouteTableAssociationId
+						break
+					}
 				}
 			}
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/platform aws

**What this PR does / why we need it**:
We should check if routeTable is nil before accessing it's associations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix missing nil check after getting route table
```
