### PR TITLE
Add IPv4 address to internal subnet for IPv6 only shoots.

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -684,6 +684,8 @@ func (c *FlowContext) ensureZones(ctx context.Context) error {
 				EnableResourceNameDnsAAAARecordOnLaunch: ptr.To(!isIPv4(c.ipFamilies)),
 				EnableDns64:                             ptr.To(!isIPv4(c.ipFamilies)),
 			},
+			// Load balancers can only be deployed to subnets that have an IPv4 CIDR.
+			// Therefore, internal and public subnets must not be IPv6 native.
 			&awsclient.Subnet{
 				Tags:                        tagsPrivate,
 				VpcId:                       c.state.Get(IdentifierVPC),

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -685,13 +685,11 @@ func (c *FlowContext) ensureZones(ctx context.Context) error {
 				EnableDns64:                             ptr.To(!isIPv4(c.ipFamilies)),
 			},
 			&awsclient.Subnet{
-				Tags:                                    tagsPrivate,
-				VpcId:                                   c.state.Get(IdentifierVPC),
-				AvailabilityZone:                        zone.Name,
-				AssignIpv6AddressOnCreation:             ptr.To(isIPv6(c.ipFamilies)),
-				CidrBlock:                               zone.Internal,
-				Ipv6Native:                              ptr.To(!isIPv4(c.ipFamilies)),
-				EnableResourceNameDnsAAAARecordOnLaunch: ptr.To(!isIPv4(c.ipFamilies)),
+				Tags:                        tagsPrivate,
+				VpcId:                       c.state.Get(IdentifierVPC),
+				AvailabilityZone:            zone.Name,
+				AssignIpv6AddressOnCreation: ptr.To(isIPv6(c.ipFamilies)),
+				CidrBlock:                   zone.Internal,
 			},
 			&awsclient.Subnet{
 				Tags:                        tagsPublic,

--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -209,10 +209,8 @@ resource "aws_subnet" "private_utility_z{{ $index }}" {
   {{ end }}
   availability_zone = "{{ $zone.name }}"
   {{ if $.isIPv6 }}
-  ipv6_native = true
   assign_ipv6_address_on_creation = true
   ipv6_cidr_block = "${cidrsubnet({{ $.vpc.ipv6CidrBlock }}, 8, (1 + ({{ $index }} * 3)))}"
-  enable_resource_name_dns_aaaa_record_on_launch = true
   {{- else if $.dualStack.enabled }}
   ipv6_cidr_block = "${cidrsubnet({{ $.vpc.ipv6CidrBlock }}, 8, (1 + ({{ $index }} * 3)))}"
   assign_ipv6_address_on_creation = false

--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -201,7 +201,8 @@ resource "aws_subnet" "nodes_z{{ $index }}" {
 output "{{ $.outputKeys.subnetsNodesPrefix }}{{ $index }}" {
   value = aws_subnet.nodes_z{{ $index }}.id
 }
-
+// Load balancers can only be deployed to subnets that have an IPv4 CIDR.
+// Therefore, internal and public subnets must not be IPv6 native.
 resource "aws_subnet" "private_utility_z{{ $index }}" {
   vpc_id            = {{ $.vpc.id }}
   {{ if $.isIPv4 }}


### PR DESCRIPTION
The purpose of the internal subnet is to deploy internal load balancers. Since a load balancer can only be deployed to a subnet that has an IPv4 range, we need to assign an IPv4 range to the internal subnet.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed an issue preventing the deployment of internal load balancers in IPv6-only shoots.
```
