### PR TITLE
Ignore alreadyDetached errors when detaching

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -2139,6 +2139,14 @@ func IsAlreadyAssociatedError(err error) bool {
 	return false
 }
 
+// IsAlreadyDetachedError returns true if the given error is a awserr.Error indicating that a NatGateway resource was already detached.
+func IsAlreadyDetachedError(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "Gateway.NotAttached" {
+		return true
+	}
+	return false
+}
+
 func ignoreNotFound(err error) error {
 	if err == nil || IsNotFoundError(err) {
 		return nil
@@ -2148,6 +2156,13 @@ func ignoreNotFound(err error) error {
 
 func ignoreAlreadyAssociated(err error) error {
 	if err == nil || IsAlreadyAssociatedError(err) {
+		return nil
+	}
+	return err
+}
+
+func IgnoreAlreadyDetached(err error) error {
+	if err == nil || IsAlreadyDetachedError(err) {
 		return nil
 	}
 	return err

--- a/pkg/controller/infrastructure/infraflow/delete.go
+++ b/pkg/controller/infrastructure/infraflow/delete.go
@@ -150,8 +150,8 @@ func (c *FlowContext) deleteInternetGateway(ctx context.Context) error {
 		return err
 	}
 	if current != nil {
-		log.Info("detaching...")
-		if err := c.client.DetachInternetGateway(ctx, *c.state.Get(IdentifierVPC), current.InternetGatewayId); err != nil {
+		log.Info("detaching...", "InternetGatewayId", current.InternetGatewayId)
+		if err := c.client.DetachInternetGateway(ctx, *c.state.Get(IdentifierVPC), current.InternetGatewayId); awsclient.IgnoreAlreadyDetached(err) != nil {
 			return err
 		}
 		log.Info("deleting...", "InternetGatewayId", current.InternetGatewayId)


### PR DESCRIPTION
also improve logging

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Ignore already detached Gateways when trying to detach them. This can happen if a previous reconciliation failed immediately after detaching.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
