### PR TITLE
Route table duplicate "0.0.0.0/0" rule creation

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -2134,6 +2134,7 @@ func IsNotFoundError(err error) bool {
 // IsAlreadyAssociatedError returns true if the given error is a awserr.Error indicating that an AWS resource was already associated.
 func IsAlreadyAssociatedError(err error) bool {
 	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "Resource.AlreadyAssociated" {
+		aerr.Code()
 		return true
 	}
 	return false

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -2134,7 +2134,6 @@ func IsNotFoundError(err error) bool {
 // IsAlreadyAssociatedError returns true if the given error is a awserr.Error indicating that an AWS resource was already associated.
 func IsAlreadyAssociatedError(err error) bool {
 	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "Resource.AlreadyAssociated" {
-		aerr.Code()
 		return true
 	}
 	return false

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -6,10 +6,12 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -450,6 +452,17 @@ type Route struct {
 	NatGatewayId                *string
 	EgressOnlyInternetGatewayId *string
 	DestinationPrefixListId     *string
+}
+
+func (r *Route) DestinationId() (string, error) {
+	if v := ptr.Deref(r.DestinationCidrBlock, ""); v != "" {
+		return v, nil
+	} else if v := ptr.Deref(r.DestinationIpv6CidrBlock, ""); v != "" {
+		return v, nil
+	} else if v := ptr.Deref(r.DestinationPrefixListId, ""); v != "" {
+		return v, nil
+	}
+	return "", fmt.Errorf("no route destination found")
 }
 
 // RouteTableAssociation contains the relevant fields for a route association of an EC2 route table resource.

--- a/pkg/aws/client/updater.go
+++ b/pkg/aws/client/updater.go
@@ -136,7 +136,7 @@ func (u *updater) UpdateRouteTable(ctx context.Context, log logr.Logger, desired
 
 		deletionCandidateDestination, err := route.DestinationId()
 		if err != nil {
-			log.Error(err, "failed to find suitable destination for deletion candidate route route")
+			log.Error(err, "error deleting route", "route", route)
 			return false, err
 		}
 

--- a/pkg/aws/client/updater.go
+++ b/pkg/aws/client/updater.go
@@ -145,7 +145,7 @@ func (u *updater) UpdateRouteTable(ctx context.Context, log logr.Logger, desired
 		if !slices.ContainsFunc(desired.Routes, func(r *Route) bool {
 			desiredRouteDestination, err := r.DestinationId()
 			if err != nil {
-				log.Error(err, "failed to find suitable destination for desired route", "route")
+				log.Error(err, "error deleting route", "route", route)
 				return false
 			}
 			return deletionCandidateDestination == desiredRouteDestination

--- a/pkg/aws/client/updater.go
+++ b/pkg/aws/client/updater.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -22,7 +23,7 @@ import (
 type Updater interface {
 	UpdateVpc(ctx context.Context, desired, current *VPC) (modified bool, err error)
 	UpdateSecurityGroup(ctx context.Context, desired, current *SecurityGroup) (modified bool, err error)
-	UpdateRouteTable(ctx context.Context, log logr.Logger, desired, current *RouteTable, controlledCidrBlocks ...string) (modified bool, err error)
+	UpdateRouteTable(ctx context.Context, log logr.Logger, desired, current *RouteTable) (modified bool, err error)
 	UpdateSubnet(ctx context.Context, desired, current *Subnet) (modified bool, err error)
 	UpdateIAMInstanceProfile(ctx context.Context, desired, current *IAMInstanceProfile) (modified bool, err error)
 	UpdateIAMRole(ctx context.Context, desired, current *IAMRole) (modified bool, err error)
@@ -102,54 +103,70 @@ func (u *updater) UpdateSecurityGroup(ctx context.Context, desired, current *Sec
 	return true, nil
 }
 
-func (u *updater) UpdateRouteTable(ctx context.Context, log logr.Logger, desired, current *RouteTable, controlledCidrBlocks ...string) (modified bool, err error) {
-outerDelete:
-	for _, cr := range current.Routes {
-		for _, dr := range desired.Routes {
-			if reflect.DeepEqual(cr, dr) {
-				continue outerDelete
-			}
-		}
-		if cr.GatewayId != nil && *cr.GatewayId == "local" {
-			// ignore local gateway route
-			continue outerDelete
-		}
-		if cr.DestinationPrefixListId != nil {
-			// ignore VPC endpoint route table associations
-			continue outerDelete
-		}
-		routeCidrBlock := ptr.Deref(cr.DestinationCidrBlock, "")
-		found := false
-		for _, cidr := range controlledCidrBlocks {
-			if routeCidrBlock == cidr {
-				found = true
-				break
-			}
-		}
-		if !found {
-			// ignore unknown routes
+// TODO: Consider IPv4 xor IPv6 xor destination prefix lists as destination.
+func (u *updater) UpdateRouteTable(ctx context.Context, log logr.Logger, desired, current *RouteTable) (bool, error) {
+	var (
+		routesToDelete = []*Route{}
+		routesToCreate = []*Route{}
+		modified       = false
+	)
+
+	for _, r := range current.Routes {
+		if r == nil {
 			continue
 		}
-		if err = u.client.DeleteRoute(ctx, current.RouteTableId, cr); err != nil {
-			return
+		if !slices.Contains(desired.Routes, r) {
+			routesToDelete = append(routesToDelete, r)
 		}
-		log.Info("Deleted route", "cidr", routeCidrBlock)
-		modified = true
 	}
-outerCreate:
-	for _, dr := range desired.Routes {
-		for _, cr := range current.Routes {
-			if reflect.DeepEqual(cr, dr) {
-				continue outerCreate
+	for _, r := range desired.Routes {
+		if r == nil {
+			continue
+		}
+		if !slices.Contains(current.Routes, r) {
+			routesToCreate = append(routesToDelete, r)
+		}
+	}
+
+	for _, route := range routesToDelete {
+		if route.GatewayId != nil && *route.GatewayId == "local" {
+			// ignore local gateway route
+			continue
+		}
+
+		if route.DestinationPrefixListId != nil {
+			// ignore VPC endpoint route table associations
+			continue
+		}
+
+		// ignore all routes that are not managed by the infrastructure controller.
+		// These are known by their destination
+		if ok := slices.ContainsFunc(desired.Routes, func(r *Route) bool {
+			if *r.DestinationCidrBlock == *route.DestinationCidrBlock {
+				return true
 			}
+			return false
+		}); !ok {
+			continue
 		}
-		if err = u.client.CreateRoute(ctx, current.RouteTableId, dr); err != nil {
-			return
+
+		if err := u.client.DeleteRoute(ctx, current.RouteTableId, route); err != nil {
+			return modified, err
 		}
-		log.Info("Created route", "cidr", ptr.Deref(dr.DestinationCidrBlock, ""))
+
+		log.Info("Deleted route", "cidr", routeCidrBlock)
+	}
+
+	for _, route := range routesToCreate {
+		if err := u.client.CreateRoute(ctx, current.RouteTableId, route); err != nil {
+			return modified, err
+		}
+
+		log.Info("Created route", "cidr", ptr.Deref(route.DestinationCidrBlock, ""))
 		modified = true
 	}
-	return
+
+	return modified, nil
 }
 
 func (u *updater) UpdateSubnet(ctx context.Context, desired, current *Subnet) (modified bool, err error) {

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -1207,7 +1207,7 @@ func (c *FlowContext) ensurePrivateRoutingTable(zoneName string) flow.TaskFn {
 			}
 			child.Set(IdentifierZoneRouteTable, created.RouteTableId)
 			child.SetObject(ObjectZoneRouteTable, created)
-			if _, err := c.updater.UpdateRouteTable(ctx, log, desired, created, allIPv4); err != nil {
+			if _, err := c.updater.UpdateRouteTable(ctx, log, desired, created); err != nil {
 				return err
 			}
 		}

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -458,7 +458,7 @@ func (c *FlowContext) ensureMainRouteTable(ctx context.Context) error {
 		c.state.Set(IdentifierMainRouteTable, current.RouteTableId)
 		c.state.SetObject(ObjectMainRouteTable, current)
 		log.Info("updating route table...")
-		if _, err := c.updater.UpdateRouteTable(ctx, log, desired, current, allIPv4); err != nil {
+		if _, err := c.updater.UpdateRouteTable(ctx, log, desired, current); err != nil {
 			return err
 		}
 	} else {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an issue where the "0.0.0.0/0" route creation would fail if the nat-gateway was previously deleted.
```
