### PR TITLE
Fix terraform deploy and integration tests for IPv6.

### DIFF
--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -205,9 +205,7 @@ output "{{ $.outputKeys.subnetsNodesPrefix }}{{ $index }}" {
 // Therefore, internal and public subnets must not be IPv6 native.
 resource "aws_subnet" "private_utility_z{{ $index }}" {
   vpc_id            = {{ $.vpc.id }}
-  {{ if $.isIPv4 }}
   cidr_block        = "{{ $zone.internal }}"
-  {{ end }}
   availability_zone = "{{ $zone.name }}"
   {{ if $.isIPv6 }}
   assign_ipv6_address_on_creation = true

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -693,14 +693,9 @@ func newProviderConfigConfigureZones(vpc awsv1alpha1.VPC, configureZoneIPs bool)
 			VPC: vpc,
 			Zones: []awsv1alpha1.Zone{
 				{
-					Name: availabilityZone,
-					Internal: func() string {
-						if configureZoneIPs {
-							return "10.250.112.0/22"
-						}
-						return ""
-					}(),
-					Public: "10.250.96.0/22",
+					Name:     availabilityZone,
+					Internal: "10.250.112.0/22",
+					Public:   "10.250.96.0/22",
 					Workers: func() string {
 						if configureZoneIPs {
 							return "10.250.0.0/19"


### PR DESCRIPTION
Unfortunately, https://github.com/gardener/gardener-extension-provider-aws/pull/1108 breaks terraform deploy and integrations tests for IPv6.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed terraform deploy and integration tests for IPv6.
```
