### PR TITLE
[release-v1.58] Automated cherry pick of #1109: Ignore alreadyDetached errors when detaching

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -2139,6 +2139,14 @@ func IsAlreadyAssociatedError(err error) bool {
 	return false
 }
 
+// IsAlreadyDetachedError returns true if the given error is a awserr.Error indicating that a NatGateway resource was already detached.
+func IsAlreadyDetachedError(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "Gateway.NotAttached" {
+		return true
+	}
+	return false
+}
+
 func ignoreNotFound(err error) error {
 	if err == nil || IsNotFoundError(err) {
 		return nil
@@ -2148,6 +2156,13 @@ func ignoreNotFound(err error) error {
 
 func ignoreAlreadyAssociated(err error) error {
 	if err == nil || IsAlreadyAssociatedError(err) {
+		return nil
+	}
+	return err
+}
+
+func IgnoreAlreadyDetached(err error) error {
+	if err == nil || IsAlreadyDetachedError(err) {
 		return nil
 	}
 	return err

--- a/pkg/controller/infrastructure/infraflow/delete.go
+++ b/pkg/controller/infrastructure/infraflow/delete.go
@@ -150,8 +150,8 @@ func (c *FlowContext) deleteInternetGateway(ctx context.Context) error {
 		return err
 	}
 	if current != nil {
-		log.Info("detaching...")
-		if err := c.client.DetachInternetGateway(ctx, *c.state.Get(IdentifierVPC), current.InternetGatewayId); err != nil {
+		log.Info("detaching...", "InternetGatewayId", current.InternetGatewayId)
+		if err := c.client.DetachInternetGateway(ctx, *c.state.Get(IdentifierVPC), current.InternetGatewayId); awsclient.IgnoreAlreadyDetached(err) != nil {
 			return err
 		}
 		log.Info("deleting...", "InternetGatewayId", current.InternetGatewayId)


### PR DESCRIPTION
/area robustness
/kind enhancement

Cherry pick of #1109 on release-v1.58.

#1109: Ignore alreadyDetached errors when detaching

**Release Notes:**
```other operator
Ignore alreadyDetached errors when detaching instead of erroring out
```