### PR TITLE
Change ToPort and FromPort in SecurityGroupRule to int32

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -1000,10 +1000,10 @@ func (c *Client) prepareRules(groupId string, rules []*SecurityGroupRule) (ingre
 				UserIdGroupPairs: nil,
 			}
 			if rule.FromPort != 0 {
-				ipPerm.FromPort = aws.Int32(int32(rule.FromPort))
+				ipPerm.FromPort = aws.Int32(rule.FromPort)
 			}
 			if rule.ToPort != 0 {
-				ipPerm.ToPort = aws.Int32(int32(rule.ToPort))
+				ipPerm.ToPort = aws.Int32(rule.ToPort)
 			}
 			for _, block := range rule.CidrBlocks {
 				ipPerm.IpRanges = append(ipPerm.IpRanges, ec2types.IpRange{CidrIp: aws.String(block)})
@@ -2214,10 +2214,10 @@ func fromIpPermission(groupId string, ipPerm ec2types.IpPermission, ruleType Sec
 		CidrBlocks: blocks,
 	}
 	if ipPerm.FromPort != nil {
-		rule.FromPort = int(*ipPerm.FromPort)
+		rule.FromPort = *ipPerm.FromPort
 	}
 	if ipPerm.ToPort != nil {
-		rule.ToPort = int(*ipPerm.ToPort)
+		rule.ToPort = *ipPerm.ToPort
 	}
 	if len(ipPerm.UserIdGroupPairs) == 1 && ipPerm.UserIdGroupPairs[0].GroupId != nil && *ipPerm.UserIdGroupPairs[0].GroupId == groupId {
 		rule.Self = true

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -311,8 +311,8 @@ const (
 // SecurityGroupRule contains the relevant fields of a EC2 security group rule resource.
 type SecurityGroupRule struct {
 	Type         SecurityGroupRuleType
-	FromPort     int
-	ToPort       int
+	FromPort     int32
+	ToPort       int32
 	Protocol     string
 	CidrBlocks   []string
 	CidrBlocksv6 []string


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/platform aws

**What this PR does / why we need it**:
Change ToPort and FromPort in SecurityGroupRule to int32.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
