### PR TITLE
Revert "Filter pod ranges for IPv4 CIDRs to configure Custom-Route-Co…

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -612,26 +612,11 @@ func getCRCChartValues(
 			mode = "ipv6"
 		}
 	}
-
-	var podNetworks []string
-
-	if slices.Contains(cluster.Shoot.Spec.Networking.IPFamilies, v1beta1.IPFamilyIPv4) {
-		for _, podCIDR := range extensionscontroller.GetPodNetwork(cluster) {
-			_, cidr, err := net.ParseCIDR(podCIDR)
-			if err != nil {
-				return nil, err
-			}
-			if cidr.IP.To4() != nil {
-				podNetworks = append(podNetworks, podCIDR)
-			}
-		}
-	}
-
 	values := map[string]interface{}{
 		"enabled":     true,
 		"replicas":    extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 		"clusterName": cp.Namespace,
-		"podNetwork":  strings.Join(podNetworks, ","),
+		"podNetwork":  strings.Join(extensionscontroller.GetPodNetwork(cluster), ","),
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-cloudprovider": checksums[v1beta1constants.SecretNameCloudProvider],
 		},

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -188,8 +188,7 @@ var _ = Describe("ValuesProvider", func() {
 						},
 					},
 					Networking: &gardencorev1beta1.Networking{
-						Pods:       &cidr,
-						IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+						Pods: &cidr,
 					},
 					Kubernetes: gardencorev1beta1.Kubernetes{
 						Version: "1.28.2",
@@ -229,11 +228,10 @@ var _ = Describe("ValuesProvider", func() {
 			values, err := vp.GetConfigChartValues(ctx, cp, cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{
-				"vpcID":            "vpc-1234",
-				"subnetID":         "subnet-acbd1234",
-				"clusterName":      namespace,
-				"zone":             "eu-west-1a",
-				"nodeIPFamilyIPv4": "ipv4",
+				"vpcID":       "vpc-1234",
+				"subnetID":    "subnet-acbd1234",
+				"clusterName": namespace,
+				"zone":        "eu-west-1a",
 			}))
 		})
 	})
@@ -251,7 +249,7 @@ var _ = Describe("ValuesProvider", func() {
 				},
 				"nodeCIDRMaskSizeIPv6": int32(64),
 				"enabled":              true,
-				"podNetwork":           cidr,
+				"podNetwork":           "192.168.0.0/16",
 				"podLabels": map[string]interface{}{
 					"maintenance.gardener.cloud/restart": "true",
 				},


### PR DESCRIPTION
…ntroller. (#1138)"

We have the same functionality with release v0.10.0 of aws-custom-route-controller. 

This reverts commit 9592ab4cc2a277d9ce31db31e51d8e80b98b413e.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
