### PR TITLE
in IPv6 and dual stack shoot cluster external load balancers will get…

### DIFF
--- a/pkg/webhook/shoot/loadbalancer_service.go
+++ b/pkg/webhook/shoot/loadbalancer_service.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shoot
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (m *mutator) mutateService(_ context.Context, service *corev1.Service) error {
+	if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
+		for _, v := range service.Spec.IPFamilies {
+			if v == corev1.IPv6Protocol {
+				service.Annotations["service.beta.kubernetes.io/aws-load-balancer-ip-address-type"] = "dualstack"
+				service.Annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"] = "internet-facing"
+				service.Annotations["service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"] = "instance"
+				service.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "external"
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/webhook/shoot/loadbalancer_service_test.go
+++ b/pkg/webhook/shoot/loadbalancer_service_test.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shoot
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Mutator", func() {
+	loadBalancerServiceMapMeta := metav1.ObjectMeta{Name: "externalLoadbalancer", Namespace: metav1.NamespaceSystem}
+	DescribeTable("#mutateService",
+		func(service *corev1.Service) {
+			mutator := &mutator{}
+			service.Annotations = make(map[string]string, 1)
+			err := mutator.mutateService(context.TODO(), service)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(service.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-ip-address-type", "dualstack"))
+			Expect(service.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-scheme", "internet-facing"))
+			Expect(service.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-nlb-target-type", "instance"))
+			Expect(service.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-type", "external"))
+
+		},
+
+		Entry("no data", &corev1.Service{ObjectMeta: loadBalancerServiceMapMeta, Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol}}}),
+		Entry("no data", &corev1.Service{ObjectMeta: loadBalancerServiceMapMeta, Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}}}),
+	)
+	DescribeTable("#mutateService",
+		func(service *corev1.Service) {
+			mutator := &mutator{}
+			service.Annotations = make(map[string]string, 1)
+			err := mutator.mutateService(context.TODO(), service)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(service.Annotations).ToNot(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-ip-address-type", "dualstack"))
+			Expect(service.Annotations).ToNot(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-scheme", "internet-facing"))
+			Expect(service.Annotations).ToNot(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-nlb-target-type", "instance"))
+			Expect(service.Annotations).ToNot(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-type", "external"))
+
+		},
+
+		Entry("no data", &corev1.Service{ObjectMeta: loadBalancerServiceMapMeta, Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol}}}),
+	)
+})


### PR DESCRIPTION
… the dual stack load balancer annotation

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
In IPv6 and dual stack shoot cluster external load balancers will get the aws dual stack load balancer annotations in order to work properly. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
In IPv6 and dual stack shoot cluster external load balancers will get the aws dual stack load balancer annotations in order to work properly. 
```
