### PR TITLE
set primary-ip-family flag for aws-ipam-controller

### DIFF
--- a/charts/internal/seed-controlplane/charts/aws-ipam-controller/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/aws-ipam-controller/templates/deployment.yaml
@@ -55,6 +55,7 @@ spec:
         - --leader-election-namespace=kube-system
         - --cluster-cidrs={{ .Values.podNetwork }}
         - --mode={{ .Values.mode }}
+        - --primary-ip-family={{ .Values.primaryIPFamily }}
         - --node-cidr-mask-size-ipv4={{ .Values.nodeCIDRMaskSizeIPv4 }}
         - --node-cidr-mask-size-ipv6={{ .Values.nodeCIDRMaskSizeIPv6 }}
         - --log-level=info

--- a/charts/internal/seed-controlplane/charts/aws-ipam-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/aws-ipam-controller/values.yaml
@@ -34,3 +34,4 @@ global:
 nodeCIDRMaskSizeIPv4: 24
 nodeCIDRMaskSizeIPv6: 80
 mode: ipv6
+primaryIPFamily: ipv4

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -140,7 +140,7 @@ images:
 - name: aws-ipam-controller
   sourceRepository: github.com/gardener/aws-ipam-controller
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/aws-ipam-controller
-  tag: "v0.2.0"
+  tag: "v0.4.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -643,9 +643,11 @@ func getIPAMChartValues(
 	scaledDown bool,
 ) (map[string]interface{}, error) {
 	mode := "ipv4"
+	primaryIPFamily := "ipv4"
 	if networkingConfig := cluster.Shoot.Spec.Networking; networkingConfig != nil {
 		if len(networkingConfig.IPFamilies) == 2 {
 			mode = "dual-stack"
+			primaryIPFamily = strings.ToLower(string(cluster.Shoot.Spec.Networking.IPFamilies[0]))
 		} else if slices.Contains(networkingConfig.IPFamilies, v1beta1.IPFamilyIPv6) {
 			mode = "ipv6"
 		}
@@ -688,6 +690,7 @@ func getIPAMChartValues(
 		},
 		"region":               cp.Spec.Region,
 		"mode":                 mode,
+		"primaryIPFamily":      primaryIPFamily,
 		"nodeCIDRMaskSizeIPv4": nodeCidrMaskSizeIPv4,
 		"nodeCIDRMaskSizeIPv6": nodeCidrMaskSizeIPv6,
 	}

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -255,6 +255,7 @@ var _ = Describe("ValuesProvider", func() {
 				},
 				"region":               "europe",
 				"mode":                 "ipv4",
+				"primaryIPFamily":      "ipv4",
 				"nodeCIDRMaskSizeIPv4": int32(24),
 				"replicas":             0,
 				"clusterName":          "test",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Set `primary-ip-family` flag for `aws-ipam-controller`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Requires: https://github.com/gardener/aws-ipam-controller/pull/83 which is in updated aws-ipam-controller image.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Set `primary-ip-family` flag for `aws-ipam-controller`
```
