### PR TITLE
Set IPv4 CIDR to empty string for IPv6 only shoots.

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -681,13 +681,17 @@ func (c *FlowContext) ensureZones(ctx context.Context) error {
 		tagsPublic[TagKeyRolePublicELB] = TagValueELB
 		tagsPrivate := c.commonTagsWithSuffix(helper.GetSuffixSubnetPrivate())
 		tagsPrivate[TagKeyRolePrivateELB] = TagValueELB
+		workersCIDR := zone.Workers
+		if !isIPv4(c.getIpFamilies()) {
+			workersCIDR = ""
+		}
 		desired = append(desired,
 			&awsclient.Subnet{
 				Tags:                                    tagsWorkers,
 				VpcId:                                   c.state.Get(IdentifierVPC),
 				AvailabilityZone:                        zone.Name,
 				AssignIpv6AddressOnCreation:             ptr.To(isIPv6(c.getIpFamilies())),
-				CidrBlock:                               zone.Workers,
+				CidrBlock:                               workersCIDR,
 				Ipv6Native:                              ptr.To(!isIPv4(c.getIpFamilies())),
 				EnableResourceNameDnsAAAARecordOnLaunch: ptr.To(!isIPv4(c.getIpFamilies())),
 				EnableDns64:                             ptr.To(!isIPv4(c.getIpFamilies())),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform aws

**What this PR does / why we need it**:
With  https://github.com/gardener/gardener-extension-provider-aws/pull/1158 we use the IPv4 range for the subnet ID if present. 
However, the worker subnet is created as IPv6 only subnet without IPv4 range. During reconciliation, the worker subnet is considered as missing though a subnet with the required IPv6 range exists. 

With this change, we use an empty string as IPv4 CIDRBlock, even if the range is configured in the spec.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug user
Fixes an issue, where reconciliation of IPv6 shoots fails, when an IPv4 range for the worker subnet is configured.
```
