### PR TITLE
Fix IPv6 validation

### DIFF
--- a/pkg/apis/aws/validation/infrastructure.go
+++ b/pkg/apis/aws/validation/infrastructure.go
@@ -114,10 +114,11 @@ func ValidateInfrastructureConfig(infra *apisaws.InfrastructureConfig, ipFamilie
 		cidrs = append(cidrs, cidrvalidation.NewCIDR(zone.Public, publicPath))
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(publicPath, zone.Public)...)
 
+		internalPath := zonePath.Child("internal")
+		cidrs = append(cidrs, cidrvalidation.NewCIDR(zone.Internal, internalPath))
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(internalPath, zone.Internal)...)
+
 		if ipFamilies == nil || slices.Contains(ipFamilies, core.IPFamilyIPv4) {
-			internalPath := zonePath.Child("internal")
-			cidrs = append(cidrs, cidrvalidation.NewCIDR(zone.Internal, internalPath))
-			allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(internalPath, zone.Internal)...)
 
 			workerPath := zonePath.Child("workers")
 			cidrs = append(cidrs, cidrvalidation.NewCIDR(zone.Workers, workerPath))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Adds validation of the `ìnternal`-subnet CIDR in case of IPv6 (as required per documentation).

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add validation of internal-subnet CIDR for IPv6 shoots
```
