### PR TITLE
[release-v1.59] Automated cherry pick of #1159: [ci:component:github.com/gardener/machine-controller-manager-provider-aws:v0.21.0->v0.22.0]

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -114,7 +114,7 @@ images:
 - name: machine-controller-manager-provider-aws
   sourceRepository: github.com/gardener/machine-controller-manager-provider-aws
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-aws
-  tag: "v0.21.0"
+  tag: "v0.22.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/kind bug

Cherry pick of #1159 on release-v1.59.

#1159: [ci:component:github.com/gardener/machine-controller-manager-provider-aws:v0.21.0->v0.22.0]

**Release Notes:**
```bugfix operator github.com/gardener/machine-controller-manager-provider-aws #180 @renormalize
Fixed a panic that occurs while fetching the status of a VM backing a machine from the provider.
```
```other operator github.com/gardener/machine-controller-manager-provider-aws #179 @thiyyakat
Added `gosec` for Static Application Security Testing (SAST).
```
```other developer github.com/gardener/machine-controller-manager-provider-aws #179 @thiyyakat
The `gardener/machine-controller-manager` dependency has been updated to `v0.55.1`. [Release Notes](https://redirect.github.com/gardener/machine-controller-manager/releases/tag/v0.55.1)
```
```other developer github.com/gardener/machine-controller-manager-provider-aws #179 @thiyyakat
Updated go lang version to `1.23.3`
```