### PR TITLE
Replaced shortcodes

### DIFF
--- a/docs/tutorials/kubernetes-cluster-on-aws-with-gardener/kubernetes-cluster-on-aws-with-gardener.md
+++ b/docs/tutorials/kubernetes-cluster-on-aws-with-gardener/kubernetes-cluster-on-aws-with-gardener.md
@@ -20,7 +20,6 @@ Gardener allows you to create a Kubernetes cluster on different infrastructure p
 
     <img src="images/new-gardener-project.png">
 
-
 1. Choose *Secrets*, then the plus icon <img src="images/plus-icon.png"> and select *AWS*.
 
     <img src="images/create-secret-aws.png">
@@ -31,9 +30,9 @@ Gardener allows you to create a Kubernetes cluster on different infrastructure p
 
 1. [Create a new policy](https://console.aws.amazon.com/iam/home?#/policies) in AWS:
     1. Choose *Create policy*.
-        
+
         <img src="images/amazon-create-policy.png">
-    
+
     1. Paste the policy that you copied from the Gardener dashboard to this custom policy.
 
         <img src="images/amazon-create-policy-json.png">
@@ -43,7 +42,6 @@ Gardener allows you to create a Kubernetes cluster on different infrastructure p
     1. Fill in the name and description, then choose *Create policy*.
 
         <img src="images/amazon-review-policy.png">
-        
 
 1. [Create a new technical user](https://console.aws.amazon.com/iam/home?#/users$new?step=details) in AWS:
     1. Type in a username and select the access key credential type.
@@ -58,39 +56,37 @@ Gardener allows you to create a Kubernetes cluster on different infrastructure p
 
     <img src="images/finish-user.png">
 
-    {{% alert color="info"  title="Note" %}}
-    Note: After the user is created, `Access key ID` and `Secret access key` are generated and displayed. Remember to save them. The `Access key ID` is used later to create secrets for Gardener.
-    {{% /alert %}}
-
+    > [!NOTE]
+    > After the user is created, `Access key ID` and `Secret access key` are generated and displayed. Remember to save them. The `Access key ID` is used later to create secrets for Gardener.
 
     <img src="images/save-keys.png">
 
 1. On the Gardener dashboard, choose *Secrets* and then the plus sign <img src="images/plus-icon.png">. Select *AWS* from the drop down menu to add a new AWS secret.
 
-2. Create your secret.
+1. Create your secret.
 
     1. Type the name of your secret.
-    2. Copy and paste the `Access Key ID` and `Secret Access Key` you saved when you created the technical user on AWS.
-    3. Choose *Add secret*.
+    1. Copy and paste the `Access Key ID` and `Secret Access Key` you saved when you created the technical user on AWS.
+    1. Choose *Add secret*.
     <img src="images/add-aws-secret.png">
 
     >After completing these steps, you should see your newly created secret in the *Infrastructure Secrets* section.
 
     <img src="images/secret-stored.png">
 
-3. To create a new cluster, choose *Clusters* and then the plus sign in the upper right corner.
+1. To create a new cluster, choose *Clusters* and then the plus sign in the upper right corner.
 
     <img src="images/new-cluster.png">
 
-4. In the *Create Cluster* section:
+1. In the *Create Cluster* section:
     1. Select *AWS* in the *Infrastructure* tab.
-    2. Type the name of your cluster in the *Cluster Details* tab.
-    3. Choose the secret you created before in the *Infrastructure Details* tab.
-    4. Choose *Create*.
+    1. Type the name of your cluster in the *Cluster Details* tab.
+    1. Choose the secret you created before in the *Infrastructure Details* tab.
+    1. Choose *Create*.
 
     <img src="images/create-cluster.png">
 
-5. Wait for your cluster to get created.
+1. Wait for your cluster to get created.
 
     <img src="images/processing-cluster.png">
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Replaced shortcodes with improved Hugo blockquote syntax.

This way, notes will be rendered the same way in GitHub and the websites.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
