### PR TITLE
Enable migration from single-stack IPv4 to dual-stack IPv4, IPv6. 

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -135,8 +135,8 @@ func (s *shoot) validateShoot(_ context.Context, shoot *core.Shoot) error {
 
 func (s *shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.Shoot, cloudProfileSpec *gardencorev1beta1.CloudProfileSpec) error {
 	var (
-		fldPath            = field.NewPath("spec", "provider")
-		infraConfigFldPath = fldPath.Child("infrastructureConfig")
+		fldPath              = field.NewPath("spec", "provider")
+		infraConfigFldPath   = fldPath.Child("infrastructureConfig")
 		networkConfigFldPath = fldPath.Child("networking")
 	)
 
@@ -160,8 +160,7 @@ func (s *shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 		}
 	}
 
-
-	if errList := awsvalidation.ValidateNetworkingUpdate( oldShoot.Spec.Networking, shoot.Spec.Networking, networkConfigFldPath); len(errList) != 0 {
+	if errList := awsvalidation.ValidateNetworkingUpdate(oldShoot.Spec.Networking, shoot.Spec.Networking, networkConfigFldPath); len(errList) != 0 {
 		return errList.ToAggregate()
 	}
 

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -137,6 +137,7 @@ func (s *shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 	var (
 		fldPath            = field.NewPath("spec", "provider")
 		infraConfigFldPath = fldPath.Child("infrastructureConfig")
+		networkConfigFldPath = fldPath.Child("networking")
 	)
 
 	if oldShoot.Spec.Provider.InfrastructureConfig == nil {
@@ -157,6 +158,11 @@ func (s *shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 		if errList := awsvalidation.ValidateInfrastructureConfigUpdate(oldInfraConfig, infraConfig); len(errList) != 0 {
 			return errList.ToAggregate()
 		}
+	}
+
+
+	if errList := awsvalidation.ValidateNetworkingUpdate( oldShoot.Spec.Networking, shoot.Spec.Networking, networkConfigFldPath); len(errList) != 0 {
+		return errList.ToAggregate()
 	}
 
 	if errList := awsvalidation.ValidateWorkersUpdate(oldShoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers, fldPath.Child("workers")); len(errList) != 0 {

--- a/pkg/apis/aws/validation/shoot.go
+++ b/pkg/apis/aws/validation/shoot.go
@@ -91,6 +91,27 @@ func ValidateWorkersUpdate(oldWorkers, newWorkers []core.Worker, fldPath *field.
 	return allErrs
 }
 
+func ValidateNetworkingUpdate(oldNetworkConfig, networkConfig *core.Networking, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, ValidateIPFamiliesUpdate(oldNetworkConfig.IPFamilies, networkConfig.IPFamilies, fldPath.Child("ipFamilies"))...)
+	return allErrs
+}
+
+func ValidateIPFamiliesUpdate(oldIPFamilies, newIPFamilies []core.IPFamily, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if (len(oldIPFamilies) == 0 && len(newIPFamilies) == 0) ||
+		(len(oldIPFamilies) == 0 && len(newIPFamilies) == 1 && newIPFamilies[0] == core.IPFamilyIPv4) ||
+		(len(oldIPFamilies) == 1 && len(newIPFamilies) == 1 && oldIPFamilies[0] == newIPFamilies[0]) ||
+		(len(oldIPFamilies) == 2 && len(newIPFamilies) == 2) ||
+		(len(oldIPFamilies) == 1 && oldIPFamilies[0] == core.IPFamilyIPv4 && len(newIPFamilies) == 2 && newIPFamilies[0] == core.IPFamilyIPv4 && newIPFamilies[1] == core.IPFamilyIPv6) {
+		return allErrs
+	}
+
+	allErrs = append(allErrs, field.Invalid(fldPath, newIPFamilies, "Invalid IPFamilies update"))
+	return allErrs
+}
+
 func validateZones(zones []string, allowedZones sets.Set[string], fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for i, workerZone := range zones {

--- a/pkg/apis/aws/validation/shoot_test.go
+++ b/pkg/apis/aws/validation/shoot_test.go
@@ -48,6 +48,42 @@ var _ = Describe("Shoot validation", func() {
 		})
 	})
 
+	Describe("#ValidateNetworkingUpdate", func(){
+		var networkingPath = field.NewPath("spec", "networking")
+
+		It("should return no error because ipFamilies update was valid", func() {
+			oldNetworking := &core.Networking{
+				IPFamilies: []core.IPFamily{core.IPFamilyIPv4},
+			}
+			networking := &core.Networking{
+				IPFamilies: []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6},
+			}
+
+			errorList := ValidateNetworkingUpdate(oldNetworking, networking, networkingPath)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should return error because ipFamilies update was not valid", func() {
+			oldNetworking := &core.Networking{
+				IPFamilies: []core.IPFamily{core.IPFamilyIPv4},
+			}
+			networking := &core.Networking{
+				IPFamilies: []core.IPFamily{core.IPFamilyIPv6},
+			}
+
+			errorList := ValidateNetworkingUpdate(oldNetworking, networking, networkingPath)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.networking.ipFamilies"),
+				})),
+			))
+		})
+
+	})
+
 	Describe("#ValidateWorkerConfig", func() {
 		var (
 			worker   core.Worker

--- a/pkg/apis/aws/validation/shoot_test.go
+++ b/pkg/apis/aws/validation/shoot_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Shoot validation", func() {
 		})
 	})
 
-	Describe("#ValidateNetworkingUpdate", func(){
+	Describe("#ValidateNetworkingUpdate", func() {
 		var networkingPath = field.NewPath("spec", "networking")
 
 		It("should return no error because ipFamilies update was valid", func() {

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -663,7 +663,7 @@ func getIPAMChartValues(
 	mode := "ipv4"
 	primaryIPFamily := "ipv4"
 	condition := gardencorev1beta1helper.GetCondition(cluster.Shoot.Status.Constraints, "ToDualStackMigration")
-	if ( condition == nil || condition.Status != "Progressing"){
+	if condition == nil || condition.Status != "Progressing" {
 		if networkingConfig := cluster.Shoot.Spec.Networking; networkingConfig != nil {
 			if len(networkingConfig.IPFamilies) == 2 {
 				mode = "dual-stack"
@@ -673,7 +673,7 @@ func getIPAMChartValues(
 			}
 		}
 	}
-	
+
 	nodeCidrMaskSizeIPv4 := int32(24)
 	nodeCidrMaskSizeIPv6 := int32(64)
 	if cluster.Shoot.Spec.Kubernetes.KubeControllerManager != nil && cluster.Shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize != nil {
@@ -869,7 +869,7 @@ func getControlPlaneShootChartValues(
 	ipamControllerEnabled := false
 	networkingConfig := cluster.Shoot.Spec.Networking
 	condition := gardencorev1beta1helper.GetCondition(cluster.Shoot.Status.Constraints, "ToDualStackMigration")
-	if (networkingConfig != nil && slices.Contains(networkingConfig.IPFamilies, v1beta1.IPFamilyIPv6)) && ( condition == nil || condition.Status != "Progressing"){
+	if (networkingConfig != nil && slices.Contains(networkingConfig.IPFamilies, v1beta1.IPFamilyIPv6)) && (condition == nil || condition.Status != "Progressing") {
 		ipamControllerEnabled = true
 	}
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -14,16 +14,15 @@ import (
 	"strconv"
 	"strings"
 
-
 	"github.com/Masterminds/semver/v3"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	genericworkeractuator "github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
@@ -473,7 +472,7 @@ func ComputeInstanceMetadata(workerConfig *awsapi.WorkerConfig, cluster *control
 func isIPv6(c *controller.Cluster) bool {
 	condition := gardencorev1beta1helper.GetCondition(c.Shoot.Status.Constraints, "ToDualStackMigration")
 	if condition != nil && condition.Status == "Progressing" {
-	return false
+		return false
 	}
 	networking := c.Shoot.Spec.Networking
 	if networking != nil {

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
@@ -22,6 +23,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
@@ -469,6 +471,10 @@ func ComputeInstanceMetadata(workerConfig *awsapi.WorkerConfig, cluster *control
 }
 
 func isIPv6(c *controller.Cluster) bool {
+	condition := gardencorev1beta1helper.GetCondition(c.Shoot.Status.Constraints, "ToDualStackMigration")
+	if condition != nil && condition.Status == "Progressing" {
+	return false
+	}
 	networking := c.Shoot.Spec.Networking
 	if networking != nil {
 		ipFamilies := networking.IPFamilies

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -21,12 +21,12 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	securityv1alpha1constants "github.com/gardener/gardener/pkg/apis/security/v1alpha1/constants"
 	"github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -172,8 +172,8 @@ func (e *ensurer) EnsureKubeControllerManagerDeployment(ctx context.Context, gct
 	allocateNodeCIDRs := true
 	networkingConfig := cluster.Shoot.Spec.Networking
 	condition := gardencorev1beta1helper.GetCondition(cluster.Shoot.Status.Constraints, "ToDualStackMigration")
-	if (networkingConfig != nil && slices.Contains(networkingConfig.IPFamilies, v1beta1.IPFamilyIPv6)) && ( condition == nil || condition.Status != "Progressing"){
-			allocateNodeCIDRs = false
+	if (networkingConfig != nil && slices.Contains(networkingConfig.IPFamilies, v1beta1.IPFamilyIPv6)) && (condition == nil || condition.Status != "Progressing") {
+		allocateNodeCIDRs = false
 	}
 	if c := extensionswebhook.ContainerWithName(ps.Containers, "kube-controller-manager"); c != nil {
 		ensureKubeControllerManagerCommandLineArgs(c, k8sVersion, allocateNodeCIDRs)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
To migrate shoots from single stack IPv4 to dual-stack IPv4,IPv6 networking, we track the current migration state in the shoot state. This PR adds checks to read the respective constraint in the shoot and configure components accordingly. Moreover, it adds validation to allow only the transition from `[IPv4]->[IPv4, IPv6]`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add support for single-stack to dual-stack networking migration.
```
