### PR TITLE
Allow admission to get workloadidentities

### DIFF
--- a/charts/gardener-extension-admission-aws/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-aws/charts/application/templates/rbac.yaml
@@ -41,6 +41,12 @@ rules:
   - watch
   - patch
   - update
+- apiGroups:
+  - security.gardener.cloud
+  resources:
+  - workloadidentities
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug
/platform aws

**What this PR does / why we need it**:
Fixes permissions. The validator webhook requires GET permissions over workload identities. https://github.com/gardener/gardener-extension-provider-aws/blob/7b03c432a2935b6d24a5ddf0cb7f8750cd9cf07b/pkg/admission/validator/credentialsbinding.go#L69-L71

Can we merge this before the next release of the provider?

cc @kon-angelo 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
