### PR TITLE
Log panics in reconcile

### DIFF
--- a/pkg/controller/infrastructure/flow_reconciler.go
+++ b/pkg/controller/infrastructure/flow_reconciler.go
@@ -51,6 +51,14 @@ func (f *FlowReconciler) Reconcile(ctx context.Context, infra *extensionsv1alpha
 	)
 	f.log.V(1).Info("reconcileWithFlow")
 
+	defer func() {
+		// recover from panic if one occurred to log it and panic again afterward.
+		if r := recover(); r != nil {
+			f.log.Error(fmt.Errorf("panic: %v", r), "flow reconciliation panicked")
+			panic(r)
+		}
+	}()
+
 	// when the function is called, we may have: a. no state, b. terraform state (migration) or c. flow state. In case of a TF state
 	// because no explicit migration to the new flow format is necessary, we simply return an empty state.
 	fsOk, err := hasFlowState(infra.Status.State)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area disaster-recovery
/kind enhancement
/platform aws

**What this PR does / why we need it**:
If the reconcile function panics we don't know in which shoot the panic occurred.
With this PR we will recover the panic, log a message and panic again afterward.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Recover from panics in the reconcile function to log them 
```
