### PR TITLE
Reintroduce external image upload to cd script.

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -5,3 +5,32 @@ set -o nounset
 set -o pipefail
 
 "$(dirname $0)"/hack/component_descriptor "$(dirname $0)"/..
+
+descriptor_out_file="${COMPONENT_DESCRIPTOR_PATH}"
+
+repo_root_dir="$(dirname $0)"/..
+
+if [[ -d "$repo_root_dir/charts/" ]]; then
+  for image_tpl_path in "$repo_root_dir/charts/"*"/templates/_images.tpl"; do
+    if [[ ! -f "$image_tpl_path" ]]; then
+      continue
+    fi
+
+    outputFile=$(sed 's/{{-//' $image_tpl_path | sed 's/}}//' | sed 's/define//' | sed 's/-//' | sed 's/end//' | sed 's/"//' | sed 's/"//' |sed 's/image.//' |  sed -e 's/^[ \t]*//' | awk -v RS= '{for (i=1; i<=NF; i++) printf "%s%s", $i, (i==NF?"\n":" ")}')
+    echo "enriching component descriptor from ${image_tpl_path}"
+
+    while read p; do
+      line="$(echo -e "$p")"
+      IFS=' ' read -r -a array <<< "$line"
+      IFS=': ' read -r -a imageAndTag <<< ${array[1]}
+
+      NAME=${array[0]}
+      REPOSITORY=${imageAndTag[0]}
+      TAG=${imageAndTag[1]}
+
+      ${ADD_DEPENDENCIES_CMD} --container-image-dependencies "{\"name\": \"${NAME}\", \"image_reference\": \"${REPOSITORY}:${TAG}\", \"version\": \"$TAG\"}"
+    done < <(echo "$outputFile")
+  done
+fi
+
+cp "${BASE_DEFINITION_PATH}" "${descriptor_out_file}"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind regression
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update component-descriptor script to include external images again
```
