### PR TITLE
Add IPv6 address to bastion VM for IPv6 shoots.

### DIFF
--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -288,6 +288,11 @@ func ensureBastionInstance(ctx context.Context, logger logr.Logger, bastion *ext
 		},
 	}
 
+	if opt.IPv6 {
+		input.NetworkInterfaces[0].Ipv6AddressCount = aws.Int32(1)
+		input.NetworkInterfaces[0].PrimaryIpv6 = aws.Bool(true)
+	}
+
 	logger.Info("Running new bastion instance")
 
 	_, err = awsClient.EC2.RunInstances(ctx, input)

--- a/pkg/controller/bastion/options.go
+++ b/pkg/controller/bastion/options.go
@@ -36,6 +36,7 @@ type Options struct {
 	InstanceName             string
 	InstanceType             string
 	ImageID                  string
+	IPv6                     bool
 
 	// set later during reconciling phase
 	BastionSecurityGroupID string
@@ -88,6 +89,8 @@ func DetermineOptions(ctx context.Context, bastion *extensionsv1alpha1.Bastion, 
 		return nil, fmt.Errorf("failed to find image AMI by region: %w", err)
 	}
 
+	ipV6 := cluster.Shoot.Spec.Networking != nil && slices.Contains(cluster.Shoot.Spec.Networking.IPFamilies, gardencorev1beta1.IPFamilyIPv6)
+
 	return &Options{
 		Shoot:                    cluster.Shoot,
 		SubnetID:                 subnetID,
@@ -98,6 +101,7 @@ func DetermineOptions(ctx context.Context, bastion *extensionsv1alpha1.Bastion, 
 		InstanceName:             instanceName,
 		InstanceType:             vmDetails.MachineTypeName,
 		ImageID:                  ami,
+		IPv6:                     ipV6,
 	}, nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add IPv6 address to bastion VM for IPv6 shoots
```
