### PR TITLE
Improve Documentation and Admission Checks for IPv6/Dual-Stack and Pod Overlay Network.

### DIFF
--- a/docs/usage/ipv6.md
+++ b/docs/usage/ipv6.md
@@ -149,13 +149,28 @@ An egress-only internet gateway is required for outbound internet traffic (IPv6)
 
 ### Migration of IPv4-only Shoot Clusters to Dual-Stack
 
-Eventually, migration should be as easy as changing the `.spec.networking.ipFamilies` field in the `Shoot` resource from `IPv4` to `IPv4, IPv6`.
-However, as of now, this is not supported.
+To migrate an IPv4-only shoot cluster to Dual-Stack simply change the `.spec.networking.ipFamilies` field in the `Shoot` resource from `IPv4` to `IPv4, IPv6` as shown below.
 
-It is worth recognizing that the migration from an IPv4-only shoot cluster to a dual-stack shoot cluster involves rolling of the nodes/workload as well.
-Nodes will not get a new IPv6 address assigned automatically.
-The same is true for pods as well.
-Once the migration is supported, the detailed caveats will be documented here.
+```yaml
+kind: Shoot
+apiVersion: core.gardener.cloud/v1beta1
+metadata:
+  ...
+spec:
+  ...
+  networking:
+    type: ...
+    ipFamilies:
+      - IPv4
+      - IPv6
+  ...
+```
+
+You can find more information about the process and the steps required [here](https://gardener.cloud/docs/gardener/networking/dual-stack-networking-migration/).
+
+> [!WARNING]
+> Please note that the dual-stack migration requires the IPv4-only cluster to run in native routing mode, i.e. pod overlay network needs to be disabled.
+> The default quota of routes per route table in AWS is 50. This restricts the cluster size to about 50 nodes. Therefore, please adapt (if necessary) the routes per route table limit in the Amazon Virtual Private Cloud quotas accordingly before switching to native routing. The maximum setting is currently 1000.
 
 ### Load Balancer Configuration
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:

Improve Documentation and Admission Checks for IPv6/Dual-Stack and Pod Overlay Network.

Previously, it was possible to directly try to migrate an IPv4-only cluster with pod overlay network. This results in a non-working cluster with a broken pod network. Therefore, we now prevent the dual-stack migration unless the cluster is already working in native routing mode, i.e. unless the overlay network was disabled.

In addition to that, the IPv6 documentation is updated to reflect the fact that dual-stack migration is now possible.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Enabling IPv6 without disabling overlay network is no longer possible.
```
