### PR TITLE
[release-v1.61] Automated cherry pick of #1299: [ci:component:github.com/gardener/machine-controller-manager-provider-aws:v0.23.0->v0.24.0]

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -99,7 +99,7 @@ images:
 - name: machine-controller-manager-provider-aws
   sourceRepository: github.com/gardener/machine-controller-manager-provider-aws
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-aws
-  tag: "v0.23.0"
+  tag: "v0.24.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/kind bug

Cherry pick of #1299 on release-v1.61.

#1299: [ci:component:github.com/gardener/machine-controller-manager-provider-aws:v0.23.0->v0.24.0]

**Release Notes:**
```other operator github.com/gardener/machine-controller-manager #981 @takoverflow
Resource exhaustion on machine creation results in a longer retry period
```
```bugfix operator github.com/gardener/machine-controller-manager #964 @takoverflow
A new termination queue to handle machines scheduled for deletion introduced to separate creation requests from deletion
```
```bugfix operator github.com/gardener/machine-controller-manager #985 @renormalize
machine-controller-manager version, and build information are printed at startup.
```
```other operator github.com/gardener/machine-controller-manager #968 @takoverflow
Integration test framework enhancements for resource and process cleanup
```
```feature operator github.com/gardener/machine-controller-manager #973 @acumino
Machine Controller Manager now supports a new machine deployment strategy called InPlaceUpdate.
```