### PR TITLE
Exclude data volumes from worker pool hash calculation for in-place updates

### DIFF
--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -90,7 +90,7 @@ spec:
     maximum: 1
     maxSurge: 1
     maxUnavailable: 0
-    updateStrategy: AutoRollingUpdate
+    updateStrategy: AutoRollingUpdate # AutoRollingUpdate/AutoInPlaceUpdate/ManualInPlaceUpdate
   # labels:
   #   key: value
   # annotations:

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -392,6 +392,8 @@ func computeEBSDeviceNameForIndex(index int) (string, error) {
 	return deviceNamePrefix + deviceNameSuffix[index:index+1], nil
 }
 
+// ComputeAdditionalHashDataV1 computes additional hash data for the worker pool. It returns a slice of strings containing the
+// additional data used for hashing.
 func ComputeAdditionalHashDataV1(pool extensionsv1alpha1.WorkerPool) []string {
 	var additionalData []string
 
@@ -417,6 +419,8 @@ func ComputeAdditionalHashDataV1(pool extensionsv1alpha1.WorkerPool) []string {
 	return additionalData
 }
 
+// ComputeAdditionalHashDataV2 computes additional hash data for the worker pool. It returns a slice of strings containing the
+// additional data used for hashing. The function takes into account the worker pool's update strategy and the worker configuration.
 func ComputeAdditionalHashDataV2(pool extensionsv1alpha1.WorkerPool, workerConfig awsapi.WorkerConfig) []string {
 	var additionalData = ComputeAdditionalHashDataV1(pool)
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -344,7 +344,7 @@ func (w *WorkerDelegate) computeBlockDevices(pool extensionsv1alpha1.WorkerPool,
 }
 
 func (w *WorkerDelegate) generateWorkerPoolHash(pool extensionsv1alpha1.WorkerPool, workerConfig awsapi.WorkerConfig) (string, error) {
-	return worker.WorkerPoolHash(pool, w.cluster, computeAdditionalHashDataV1(pool), computeAdditionalHashDataV2(pool, workerConfig))
+	return worker.WorkerPoolHash(pool, w.cluster, ComputeAdditionalHashDataV1(pool), ComputeAdditionalHashDataV2(pool, workerConfig))
 }
 
 func computeEBSForVolume(volume extensionsv1alpha1.Volume) (map[string]interface{}, error) {
@@ -392,32 +392,35 @@ func computeEBSDeviceNameForIndex(index int) (string, error) {
 	return deviceNamePrefix + deviceNameSuffix[index:index+1], nil
 }
 
-func computeAdditionalHashDataV1(pool extensionsv1alpha1.WorkerPool) []string {
+func ComputeAdditionalHashDataV1(pool extensionsv1alpha1.WorkerPool) []string {
 	var additionalData []string
 
 	if pool.Volume != nil && pool.Volume.Encrypted != nil {
 		additionalData = append(additionalData, strconv.FormatBool(*pool.Volume.Encrypted))
 	}
 
-	for _, dv := range pool.DataVolumes {
-		additionalData = append(additionalData, dv.Size)
+	// Do not include data volumes in the hash if the update strategy is InPlace.
+	if !gardencorev1beta1helper.IsUpdateStrategyInPlace(pool.UpdateStrategy) {
+		for _, dv := range pool.DataVolumes {
+			additionalData = append(additionalData, dv.Size)
 
-		if dv.Type != nil {
-			additionalData = append(additionalData, *dv.Type)
-		}
+			if dv.Type != nil {
+				additionalData = append(additionalData, *dv.Type)
+			}
 
-		if dv.Encrypted != nil {
-			additionalData = append(additionalData, strconv.FormatBool(*dv.Encrypted))
+			if dv.Encrypted != nil {
+				additionalData = append(additionalData, strconv.FormatBool(*dv.Encrypted))
+			}
 		}
 	}
 
 	return additionalData
 }
 
-func computeAdditionalHashDataV2(pool extensionsv1alpha1.WorkerPool, workerConfig awsapi.WorkerConfig) []string {
-	var additionalData = computeAdditionalHashDataV1(pool)
+func ComputeAdditionalHashDataV2(pool extensionsv1alpha1.WorkerPool, workerConfig awsapi.WorkerConfig) []string {
+	var additionalData = ComputeAdditionalHashDataV1(pool)
 
-	// Do not include providerConfig in hash if the update strategy is InPlace.
+	// Do not include providerConfig in the hash if the update strategy is InPlace.
 	if gardencorev1beta1helper.IsUpdateStrategyInPlace(pool.UpdateStrategy) {
 		return additionalData
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Data volumes are also excluded from the hash calculation for in-place updates similar to provider config.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10219

**Special notes for your reviewer**:
Follow-up of https://github.com/gardener/gardener-extension-provider-aws/pull/1276

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
