### PR TITLE
fix: publish oci-images to previously used repositories

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         args:
           - name: gardener-extension-provider-aws
-            oci-repository: extensions/provider-aws
+            oci-repository: gardener/extensions/provider-aws
             target: gardener-extension-provider-aws
             ocm-labels:
               name: gardener.cloud/cve-categorisation
@@ -42,7 +42,7 @@ jobs:
                 integrity_requirement: high
                 availability_requirement: high
           - name: gardener-extension-admission-aws
-            oci-repository: extensions/admission-aws
+            oci-repository: gardener/extensions/admission-aws
             target: gardener-extension-admission-aws
             ocm-labels:
               name: gardener.cloud/cve-categorisation

--- a/.github/workflows/head-update.yaml
+++ b/.github/workflows/head-update.yaml
@@ -14,4 +14,4 @@ jobs:
       - build
     permissions:
       id-token: write
-      content: write
+      contents: write


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
fix: publish oci-images to previously used repositories
```
