### PR TITLE
[release-v1.62] Automated cherry pick of #1335: fix: declare alpine and pause-images in ocm-component-descriptor

### DIFF
--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -4,3 +4,21 @@ labels:
     - type: githubTeam
       teamname: gardener/gardener-extension-provider-aws-maintainers
       github_hostname: github.com
+
+resources:
+  # todo: resolve double-maintenance w/ charts/gardener-extension-provider-aws/templates/_images.tpl
+  - name: alpine
+    version: '3.20.3'
+    type: ociImage
+    relation: external
+    access:
+      type: ociRegistry
+      imageReference: registry-1.docker.io/library/alpine:3.20.3
+  # todo: resolve double-maintenance w/ charts/gardener-extension-provider-aws/templates/_images.tpl
+  - name: pause
+    version: '3.10'
+    type: ociImage
+    relation: external
+    access:
+      type: ociRegistry
+      imageReference: registry.k8s.io/pause:3.10


### PR DESCRIPTION
/area delivery
/kind bug

Cherry pick of #1335 on release-v1.62.

#1335: fix: declare alpine and pause-images in ocm-component-descriptor

**Release Notes:**
```other developer
fix: declare alpine and pause-images in ocm-component-descriptor
```