### PR TITLE
[release-v1.62] Automated cherry pick of #1336: allow specifying which version-part to bump for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,12 @@
 name: Release
 on:
   workflow_dispatch:
+    inputs:
+      next-version:
+        type: choice
+        options:
+          - bump-minor
+          - bump-patch
 
 
 jobs:
@@ -17,4 +23,4 @@ jobs:
       github-app-secret-key: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}
     with:
       release-commit-target: branch
-      next-version: bump-minor
+      next-version: ${{ inputs-next-version }}


### PR DESCRIPTION
/area delivery
/kind enhancement

Cherry pick of #1336 on release-v1.62.

#1336: allow specifying which version-part to bump for releases

**Release Notes:**
```other developer
allow specifying which version-part to bump for releases
```