### PR TITLE
change exported consts to unexported

### DIFF
--- a/test/integration/backupbucket/backupbucket_test.go
+++ b/test/integration/backupbucket/backupbucket_test.go
@@ -58,8 +58,8 @@ var (
 )
 
 const (
-	BackupBucketSecretName = "backupbucket"
-	GardenNamespaceName    = "garden"
+	backupBucketSecretName = "backupbucket"
+	gardenNamespaceName    = "garden"
 )
 
 var runTest = func(tc *TestContext, backupBucket *v1alpha1.BackupBucket) {
@@ -188,7 +188,7 @@ var _ = BeforeSuite(func() {
 	By("creating aws provider secret")
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      BackupBucketSecretName,
+			Name:      backupBucketSecretName,
 			Namespace: testName,
 		},
 		Data: map[string][]byte{

--- a/test/integration/backupbucket/helper_test.go
+++ b/test/integration/backupbucket/helper_test.go
@@ -85,7 +85,6 @@ func deleteNamespace(ctx context.Context, c client.Client, namespace *corev1.Nam
 
 func ensureGardenNamespace(ctx context.Context, c client.Client) (*corev1.Namespace, bool) {
 	gardenNamespaceAlreadyExists := false
-	gardenNamespaceName := "garden"
 	gardenNamespace := &corev1.Namespace{}
 	err := c.Get(ctx, client.ObjectKey{Name: gardenNamespaceName}, gardenNamespace)
 	if err != nil {
@@ -211,7 +210,7 @@ func newBackupBucket(name, region string) *extensionsv1alpha1.BackupBucket {
 			},
 			Region: region,
 			SecretRef: corev1.SecretReference{
-				Name:      BackupBucketSecretName,
+				Name:      backupBucketSecretName,
 				Namespace: name,
 			},
 		},


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind test
/platform aws

**What this PR does / why we need it**:
just a small fix that changes 2 const vars to not being exported anymore since it's not required.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

