### PR TITLE
add gosec-report to ocm-component-descriptors

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,28 @@ jobs:
         run: |
           set -eu
           make verify-extended
+          tar czf gosec-report.tar.gz gosec-report.sarif
+      - name: add-report-to-component-descriptor
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
+        with:
+          blobs-directory: .
+          ocm-resources: |
+            name: gosec-report
+            relation: local
+            access:
+              type: localBlob
+              localReference: gosec-report.tar.gz
+            labels:
+              - name: gardener.cloud/purposes
+                value:
+                  - lint
+                  - sast
+                  - pybandit
+              - name: gardener.cloud/comment
+                value: |
+                  we use gosec (linter) for SAST Scans.
+                  see: https://github.com/securego/gosec
+                  enabled by: https://github.com/gardener/gardener-extension-provider-aws/pull/112
 
   oci-images:
     name: Build OCI-Images

--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -5,6 +5,14 @@ labels:
       teamname: gardener/gardener-extension-provider-aws-maintainers
       github_hostname: github.com
 
+main-source:
+  labels:
+    - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1
+      value: |
+        policy: skip
+        comment: |
+          we use gosec for SAST Scanning. See attached log.
+
 resources:
   # todo: resolve double-maintenance w/ charts/gardener-extension-provider-aws/templates/_images.tpl
   - name: alpine


### PR DESCRIPTION
As a left-over from migration from concourse-pipeline, gosec-report was no longer attached to Component-Descriptors. Add reports again for future releases.

Consider explicitly passing --report-fname to avoid hardcoding default name: https://github.com/gardener/gardener/pull/12274

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
add gosec-report to Component-Descriptor (again)
```
