### PR TITLE
Use backup operator secret for backupbucket integration test

### DIFF
--- a/.ci/testruns/default/templates/testrun.yaml
+++ b/.ci/testruns/default/templates/testrun.yaml
@@ -40,6 +40,18 @@ spec:
       secretKeyRef:
         name: route53-operator-aws
         key: secretAccessKey
+  - name: ACCESS_KEY_ID_BACKUP
+    type: env
+    valueFrom:
+      secretKeyRef:
+        name: backup-operator-aws
+        key: accessKeyID
+  - name: SECRET_ACCESS_KEY_BACKUP
+    type: env
+    valueFrom:
+      secretKeyRef:
+        name: backup-operator-aws
+        key: secretAccessKey
 
   testflow:
   - name: infrastructure-test-tf

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ hack/tools/bin
 *.html
 .vscode
 .idea
+*.swp
 .DS_Store
 *~
 

--- a/.test-defs/backupbucket-test.yaml
+++ b/.test-defs/backupbucket-test.yaml
@@ -11,9 +11,9 @@ spec:
     - >-
       go test -timeout=0 ./test/integration/backupbucket
       --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
-      --kubeconfig=$TM_KUBECONFIG_PATH/testmachinery.config
-      --access-key-id=${ACCESS_KEY_ID}
-      --secret-access-key=${SECRET_ACCESS_KEY}
+      --kubeconfig=${TM_KUBECONFIG_PATH}/testmachinery.config
+      --access-key-id=${ACCESS_KEY_ID_BACKUP}
+      --secret-access-key=${SECRET_ACCESS_KEY_BACKUP}
       --region=${REGION}
       --use-existing-cluster=${USE_EXISTING_CLUSTER}
       --log-level=${LOG_LEVEL}

--- a/test/integration/backupbucket/helper_test.go
+++ b/test/integration/backupbucket/helper_test.go
@@ -128,7 +128,7 @@ func deleteBackupBucket(ctx context.Context, c client.Client, backupBucket *exte
 }
 
 func waitUntilBackupBucketReady(ctx context.Context, c client.Client, backupBucket *extensionsv1alpha1.BackupBucket) {
-	err := extensions.WaitUntilExtensionObjectReady(
+	Expect(extensions.WaitUntilExtensionObjectReady(
 		ctx,
 		c,
 		log,
@@ -138,11 +138,7 @@ func waitUntilBackupBucketReady(ctx context.Context, c client.Client, backupBuck
 		30*time.Second,
 		5*time.Minute,
 		nil,
-	)
-	if err != nil {
-		log.Info("BackupBucket is not ready yet; this is expected during initial reconciliation", "error", err)
-	}
-	Expect(err).To(Succeed(), "BackupBucket did not become ready: %s", backupBucket.Name)
+	)).To(Succeed(), "BackupBucket did not become ready: %s", backupBucket.Name)
 	log.Info("BackupBucket is ready", "backupBucket", backupBucket)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind test
/platform aws

**What this PR does / why we need it**:
This PR changes the backupbucket integration test from using the shoot-operator secret to using the newly created dedicated backup-operator secret to get the aws `s3.Client`.
In addition, a useless log message is removed and `.swp` files are added to `.gitignore`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

