### PR TITLE
Set AWS_REGION for cloud controller manager

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
@@ -78,6 +78,8 @@ spec:
         - name: AWS_SHARED_CREDENTIALS_FILE
           value: /srv/cloudprovider/credentialsFile
         {{- end }}
+        - name: AWS_REGION
+          value: {{ .Values.region }}
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -18,3 +18,5 @@ vpa:
   resourcePolicy: {}
 
 useWorkloadIdentity: false
+
+region: eu-west-1

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -565,6 +565,7 @@ func getCCMChartValues(
 			"server": serverSecret.Name,
 		},
 		"useWorkloadIdentity": useWorkloadIdentity,
+		"region":              cp.Spec.Region,
 	}
 
 	if cpConfig.CloudControllerManager != nil {

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -291,6 +291,7 @@ var _ = Describe("ValuesProvider", func() {
 					"server": "cloud-controller-manager-server",
 				},
 				"useWorkloadIdentity": false,
+				"region":              "europe",
 			})
 			crcChartValues = map[string]interface{}{
 				"podLabels": map[string]interface{}{

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -128,7 +128,7 @@ var _ = Describe("ValuesProvider", func() {
 
 		encoder = codec.EncoderForVersion(info.Serializer, apisawsv1alpha1.SchemeGroupVersion)
 
-		region = "europe"
+		region = "eu-west-1"
 		cidr = "10.250.0.0/19"
 
 		cp = &extensionsv1alpha1.ControlPlane{
@@ -254,7 +254,7 @@ var _ = Describe("ValuesProvider", func() {
 				"podLabels": map[string]interface{}{
 					"maintenance.gardener.cloud/restart": "true",
 				},
-				"region":               "europe",
+				"region":               "eu-west-1",
 				"mode":                 "ipv4",
 				"primaryIPFamily":      "ipv4",
 				"nodeCIDRMaskSizeIPv4": int32(24),
@@ -291,13 +291,13 @@ var _ = Describe("ValuesProvider", func() {
 					"server": "cloud-controller-manager-server",
 				},
 				"useWorkloadIdentity": false,
-				"region":              "europe",
+				"region":              "eu-west-1",
 			})
 			crcChartValues = map[string]interface{}{
 				"podLabels": map[string]interface{}{
 					"maintenance.gardener.cloud/restart": "true",
 				},
-				"region":      "europe",
+				"region":      "eu-west-1",
 				"enabled":     true,
 				"replicas":    0,
 				"clusterName": "test",
@@ -308,7 +308,7 @@ var _ = Describe("ValuesProvider", func() {
 				"useWorkloadIdentity": false,
 			}
 			albChartValues = map[string]interface{}{
-				"region":                "europe",
+				"region":                "eu-west-1",
 				"vpcId":                 "vpc-1234",
 				"enabled":               true,
 				"replicaCount":          0,
@@ -580,7 +580,7 @@ var _ = Describe("ValuesProvider", func() {
 			It("should return correct shoot control plane chart when ca is secret found", func() {
 				setLoadBalancerControllerEnabled(cp, nil)
 				albChartValues := map[string]interface{}{
-					"region":                "europe",
+					"region":                "eu-west-1",
 					"enabled":               true,
 					"clusterName":           "test",
 					"webhookCertSecretName": awsLoadBalancerControllerWebhook,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
When using workload identity I observe the following error in cloud controller manager.

```
W0612 06:40:35.700604       1 instances_v2.go:90] Failed to get node topology. Moving on without setting labels: "operation error EC2: DescribeInstanceTopology, get identity: get credentials: failed to refresh cached credentials, failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, failed to resolve service endpoint, endpoint rule error, Invalid Configuration: Missing Region"
E0612 06:40:35.948326       1 topology.go:95] Error describing instance topology: "operation error EC2: DescribeInstanceTopology, get identity: get credentials: failed to refresh cached credentials, failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, failed to resolve service endpoint, endpoint rule error, Invalid Configuration: Missing Region"
```

This error is fixed when `AWS_REGION` env variable is set for the CCM deployment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing `cloud-controller-manager` to fail to get node topology because of missing region configuration was fixed.
```
