### PR TITLE
Support virtualCapacities in nodeTemplates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	go.uber.org/mock v0.5.2
 	golang.org/x/time v0.12.0
 	golang.org/x/tools v0.35.0
+	gopkg.in/inf.v0 v0.9.1
 	k8s.io/api v0.33.2
 	k8s.io/apiextensions-apiserver v0.33.2
 	k8s.io/apimachinery v0.33.2
@@ -186,7 +187,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	helm.sh/helm/v3 v3.18.4 // indirect


### PR DESCRIPTION
**How to categorize this PR?**

/area auto-scaling
/kind enhancement
/platform aws

**What this PR does / why we need it**:
- removes requirement that nodeTemplate.Capacities have to be non-empty, since `nodeTemplate.virtualCapacity` may be set
- adds validation for extended resources (only in `nodetemplate.VirtualCapacity`, regular capacity validation is kept as they are for backward compatibility)

**Which issue(s) this PR fixes**:
Fixes #1238

**Special notes for your reviewer**:
Nothing

**Release note**:
```other operator
nodeTemplate.Capacity is now allowed to be empty. Extended resources, memory and GPU are now validated as whole and non-negative numbers.
```
