### PR TITLE
Support for configuring dedicated tenancy for VPC

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -280,6 +280,21 @@ See <a href="https://registry.terraform.io/providers/hashicorp/aws/latest/docs/g
 for details of the underlying terraform implementation.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>enableDedicatedTenancyForVPC</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EnableDedicatedTenancyForVPC allows to configure the VPC to use dedicated tenancy.
+If this field is set to true, all VMs created in this VPC will have dedicated tenancy enabled.
+This setting is immutable and cannot be changed once the VPC has been created.
+default: false</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="aws.provider.extensions.gardener.cloud/v1alpha1.WorkerConfig">WorkerConfig

--- a/pkg/apis/aws/types_infrastructure.go
+++ b/pkg/apis/aws/types_infrastructure.go
@@ -32,6 +32,11 @@ type InfrastructureConfig struct {
 	// See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging#ignoring-changes-in-all-resources
 	// for details of the underlying terraform implementation.
 	IgnoreTags *IgnoreTags
+
+	// EnableDedicatedTenancyForVPC allows to configure the VPC to use dedicated tenancy.
+	// If this field is set to true, all VMs created in this VPC will have dedicated tenancy enabled.
+	// This setting is immutable and cannot be changed once the VPC has been created.
+	EnableDedicatedTenancyForVPC *bool
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/aws/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/aws/v1alpha1/types_infrastructure.go
@@ -35,6 +35,13 @@ type InfrastructureConfig struct {
 	// for details of the underlying terraform implementation.
 	// +optional
 	IgnoreTags *IgnoreTags `json:"ignoreTags,omitempty"`
+
+	// EnableDedicatedTenancyForVPC allows to configure the VPC to use dedicated tenancy.
+	// If this field is set to true, all VMs created in this VPC will have dedicated tenancy enabled.
+	// This setting is immutable and cannot be changed once the VPC has been created.
+	// default: false
+	// +optional
+	EnableDedicatedTenancyForVPC *bool `json:"enableDedicatedTenancyForVPC,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/aws/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.conversion.go
@@ -641,6 +641,7 @@ func autoConvert_v1alpha1_InfrastructureConfig_To_aws_InfrastructureConfig(in *I
 		return err
 	}
 	out.IgnoreTags = (*aws.IgnoreTags)(unsafe.Pointer(in.IgnoreTags))
+	out.EnableDedicatedTenancyForVPC = (*bool)(unsafe.Pointer(in.EnableDedicatedTenancyForVPC))
 	return nil
 }
 
@@ -656,6 +657,7 @@ func autoConvert_aws_InfrastructureConfig_To_v1alpha1_InfrastructureConfig(in *a
 		return err
 	}
 	out.IgnoreTags = (*IgnoreTags)(unsafe.Pointer(in.IgnoreTags))
+	out.EnableDedicatedTenancyForVPC = (*bool)(unsafe.Pointer(in.EnableDedicatedTenancyForVPC))
 	return nil
 }
 

--- a/pkg/apis/aws/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.deepcopy.go
@@ -339,6 +339,11 @@ func (in *InfrastructureConfig) DeepCopyInto(out *InfrastructureConfig) {
 		*out = new(IgnoreTags)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.EnableDedicatedTenancyForVPC != nil {
+		in, out := &in.EnableDedicatedTenancyForVPC, &out.EnableDedicatedTenancyForVPC
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/aws/validation/infrastructure.go
+++ b/pkg/apis/aws/validation/infrastructure.go
@@ -176,6 +176,8 @@ func ValidateInfrastructureConfig(infra *apisaws.InfrastructureConfig, ipFamilie
 func ValidateInfrastructureConfigUpdate(oldConfig, newConfig *apisaws.InfrastructureConfig) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newConfig.EnableDedicatedTenancyForVPC, oldConfig.EnableDedicatedTenancyForVPC, field.NewPath("enableDedicatedTenancyForVPC"))...)
+
 	vpcPath := field.NewPath("networks.vpc")
 	oldVPC := oldConfig.Networks.VPC
 	newVPC := newConfig.Networks.VPC

--- a/pkg/apis/aws/validation/infrastructure_test.go
+++ b/pkg/apis/aws/validation/infrastructure_test.go
@@ -54,6 +54,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 					},
 				},
 			},
+			EnableDedicatedTenancyForVPC: ptr.To(false),
 		}
 	})
 
@@ -583,6 +584,18 @@ var _ = Describe("InfrastructureConfig validation", func() {
 					"Field": Equal("networks.zones[1].workers"),
 				})),
 			))
+		})
+
+		It("should forbid changing dedicated tenancy configuration", func() {
+			newInfrastructureConfig := infrastructureConfig.DeepCopy()
+			newInfrastructureConfig.EnableDedicatedTenancyForVPC = ptr.To(true)
+
+			errorList := ValidateInfrastructureConfigUpdate(infrastructureConfig, newInfrastructureConfig)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("enableDedicatedTenancyForVPC"),
+			}))))
 		})
 	})
 

--- a/pkg/apis/aws/zz_generated.deepcopy.go
+++ b/pkg/apis/aws/zz_generated.deepcopy.go
@@ -355,6 +355,11 @@ func (in *InfrastructureConfig) DeepCopyInto(out *InfrastructureConfig) {
 		*out = new(IgnoreTags)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.EnableDedicatedTenancyForVPC != nil {
+		in, out := &in.EnableDedicatedTenancyForVPC, &out.EnableDedicatedTenancyForVPC
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -765,7 +765,7 @@ func (c *Client) CreateVpc(ctx context.Context, desired *VPC) (*VPC, error) {
 		CidrBlock:                   aws.String(desired.CidrBlock),
 		AmazonProvidedIpv6CidrBlock: aws.Bool(desired.AssignGeneratedIPv6CidrBlock),
 		TagSpecifications:           desired.ToTagSpecifications(ec2types.ResourceTypeVpc),
-		InstanceTenancy:             ec2types.Tenancy(*desired.InstanceTenancy),
+		InstanceTenancy:             desired.InstanceTenancy,
 	}
 	output, err := c.EC2.CreateVpc(ctx, input)
 	if err != nil {
@@ -974,7 +974,7 @@ func (c *Client) fromVpc(ctx context.Context, item ec2types.Vpc, withAttributes 
 			return ""
 		}(),
 		DhcpOptionsId:   item.DhcpOptionsId,
-		InstanceTenancy: ptr.To(string(item.InstanceTenancy)),
+		InstanceTenancy: item.InstanceTenancy,
 		State:           ptr.To(string(item.State)),
 	}
 	var err error

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -765,6 +765,7 @@ func (c *Client) CreateVpc(ctx context.Context, desired *VPC) (*VPC, error) {
 		CidrBlock:                   aws.String(desired.CidrBlock),
 		AmazonProvidedIpv6CidrBlock: aws.Bool(desired.AssignGeneratedIPv6CidrBlock),
 		TagSpecifications:           desired.ToTagSpecifications(ec2types.ResourceTypeVpc),
+		InstanceTenancy:             ec2types.Tenancy(*desired.InstanceTenancy),
 	}
 	output, err := c.EC2.CreateVpc(ctx, input)
 	if err != nil {

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -217,7 +217,7 @@ type VPC struct {
 	EnableDnsHostnames           bool
 	AssignGeneratedIPv6CidrBlock bool
 	DhcpOptionsId                *string
-	InstanceTenancy              *string
+	InstanceTenancy              ec2types.Tenancy
 	State                        *string
 }
 

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -185,9 +185,9 @@ func (c *FlowContext) getIpFamilies() []v1beta1.IPFamily {
 func (c *FlowContext) ensureManagedVpc(ctx context.Context) error {
 	log := LogFromContext(ctx)
 	log.Info("using managed VPC")
-	instanceTenancy := ptr.To(string(ec2types.TenancyDefault))
+	instanceTenancy := ec2types.TenancyDefault
 	if c.config.EnableDedicatedTenancyForVPC != nil && *c.config.EnableDedicatedTenancyForVPC {
-		instanceTenancy = ptr.To(string(ec2types.TenancyDedicated))
+		instanceTenancy = ec2types.TenancyDedicated
 	}
 	desired := &awsclient.VPC{
 		Tags:                         c.commonTags,

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -185,12 +185,17 @@ func (c *FlowContext) getIpFamilies() []v1beta1.IPFamily {
 func (c *FlowContext) ensureManagedVpc(ctx context.Context) error {
 	log := LogFromContext(ctx)
 	log.Info("using managed VPC")
+	instanceTenancy := ptr.To(string(ec2types.TenancyDefault))
+	if c.config.EnableDedicatedTenancyForVPC != nil && *c.config.EnableDedicatedTenancyForVPC {
+		instanceTenancy = ptr.To(string(ec2types.TenancyDedicated))
+	}
 	desired := &awsclient.VPC{
 		Tags:                         c.commonTags,
 		EnableDnsSupport:             true,
 		EnableDnsHostnames:           true,
 		AssignGeneratedIPv6CidrBlock: (c.config.DualStack != nil && c.config.DualStack.Enabled) || isIPv6(c.getIpFamilies()),
 		DhcpOptionsId:                c.state.Get(IdentifierDHCPOptions),
+		InstanceTenancy:              instanceTenancy,
 	}
 
 	if c.config.Networks.VPC.CIDR == nil {

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -185,6 +185,8 @@ func (c *FlowContext) getIpFamilies() []v1beta1.IPFamily {
 func (c *FlowContext) ensureManagedVpc(ctx context.Context) error {
 	log := LogFromContext(ctx)
 	log.Info("using managed VPC")
+	// Default to shared tenancy unless dedicated tenancy is explicitly enabled.
+	// AWS API does this as well, so all VPCs created before have instanceTenancy = "default".
 	instanceTenancy := ec2types.TenancyDefault
 	if c.config.EnableDedicatedTenancyForVPC != nil && *c.config.EnableDedicatedTenancyForVPC {
 		instanceTenancy = ec2types.TenancyDedicated

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -18,6 +18,7 @@ import (
 	"text/template"
 	"time"
 
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"k8s.io/apimachinery/pkg/util/sets"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Add the option to configure [dedicated tenancy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/change-tenancy-vpc.html) for a gardener-managed VPC using a new property `enableDedicatedTenancyForVPC`.

**Which issue(s) this PR fixes**:
Fixes #1377 

**Special notes for your reviewer**:
* This PR introduces the property as immutable, you can set this only on VPC creation. Technically, AWS allows for _disabling_ this on an existing VPC, but there is no way back: enabling on an existing VPC is forbidden. But this seems dangerous, as it allows you to remove an important compliance configuration when there is no way back.
* While the property on AWS level is a simple `instanceTenancy` allowing for values `default` and `dedicated` (and for instances, there is an additional value `host`), this PR introduces a boolean config option `enableDedicatedTenancyForVPC`
* There was already [an existing property `awsclient.VPC.InstanceTenancy` of type `*string`](https://github.com/gardener/gardener-extension-provider-aws/blob/229638b4655819bd0483dadf33412404bb7f2830/pkg/aws/client/types.go#L219) while `instanceTenancy` in the aws-sdk is [a string-alias enum of type `Tenancy`](https://github.com/aws/aws-sdk-go-v2/blob/32873b942d0ba5f63d200a39321173123075aad4/service/ec2/api_op_CreateVpc.go#L67-L77). Not sure if this could/should be changed on our end such that we don't have the conversions from enum to string and back? This seems to have come in with the tf-to-flow migration, so not sure if this is coincidence or intentional.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Support for configuring dedicated tenancy for VPC with a new property `enableDedicatedTenancyForVPC`
```
