### PR TITLE
Set user agent when creating AWS clients

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -135,7 +135,7 @@ func NewClient(authConfig AuthConfig) (*Client, error) {
 					middleware.BuildOutput, middleware.Metadata, error,
 				) {
 					req, ok := input.Request.(*smithyhttp.Request)
-					userAgent := []string{"Gardener Extension for AWS provider"}
+					userAgent := []string{"gardener-extension-provider-aws"}
 
 					if ok {
 						header := req.Header["User-Agent"]

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -30,6 +30,8 @@ import (
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/go-logr/logr"
 	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -122,6 +124,34 @@ func NewClient(authConfig AuthConfig) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	cfg.APIOptions = append(cfg.APIOptions, func(stack *middleware.Stack) error {
+		return stack.Build.Add(
+			middleware.BuildMiddlewareFunc(
+				"addUserAgent",
+				func(
+					ctx context.Context, input middleware.BuildInput, handler middleware.BuildHandler,
+				) (
+					middleware.BuildOutput, middleware.Metadata, error,
+				) {
+					req, ok := input.Request.(*smithyhttp.Request)
+					userAgent := []string{"Gardener Extension for AWS provider"}
+
+					if ok {
+						header := req.Header["User-Agent"]
+						if len(header) == 0 {
+							header = userAgent
+						} else {
+							header = append(userAgent, header...)
+						}
+						req.Header["User-Agent"] = header
+					}
+					return handler.HandleBuild(ctx, input)
+				},
+			),
+			middleware.Before,
+		)
+	})
 
 	return &Client{
 		EC2:                           *ec2.NewFromConfig(cfg),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area audit-logging
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Adds information to the UserAgent string of the created client to make it easier to identify calls made by clients created by the extension provider.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Clients created by the AWS extension provider will now identify themselves by adding to the `user-agent` header of their calls.
```
