### PR TITLE
Drop support for Shoots with Kubernetes version <= 1.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.30 | 1.30.0+ | [![Gardener v1.30 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.30%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.30%20AWS) |
 | Kubernetes 1.29 | 1.29.0+ | [![Gardener v1.29 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.29%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.29%20AWS) |
 | Kubernetes 1.28 | 1.28.0+ | [![Gardener v1.28 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.28%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.28%20AWS) |
-| Kubernetes 1.27 | 1.27.0+ | [![Gardener v1.27 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.27%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.27%20AWS) |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.31 | 1.31.0+ | [![Gardener v1.31 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.31%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.31%20AWS) |
 | Kubernetes 1.30 | 1.30.0+ | [![Gardener v1.30 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.30%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.30%20AWS) |
 | Kubernetes 1.29 | 1.29.0+ | [![Gardener v1.29 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.29%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.29%20AWS) |
-| Kubernetes 1.28 | 1.28.0+ | [![Gardener v1.28 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.28%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.28%20AWS) |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -660,7 +660,7 @@ spec:
     nodes: 10.250.0.0/16
     type: calico
   kubernetes:
-    version: 1.28.2
+    version: 1.32.0
   maintenance:
     autoUpdate:
       kubernetesVersion: true
@@ -751,7 +751,7 @@ spec:
     nodes: 10.250.0.0/16
     type: calico
   kubernetes:
-    version: 1.28.2
+    version: 1.32.0
   maintenance:
     autoUpdate:
       kubernetesVersion: true
@@ -800,7 +800,7 @@ spec:
     - IPv6
     type: calico
   kubernetes:
-    version: 1.28.2
+    version: 1.32.2
   ...
   addons:
     kubernetesDashboard:

--- a/example/10-fake-shoot-controlplane.yaml
+++ b/example/10-fake-shoot-controlplane.yaml
@@ -166,7 +166,7 @@ spec:
         - --service-account-signing-key-file=/srv/kubernetes/service-account-key/id_rsa
         - --service-account-key-file=/srv/kubernetes/service-account-key-bundle/bundle.key
         - --v=2
-        image: registry.k8s.io/kube-apiserver:v1.28.2
+        image: registry.k8s.io/kube-apiserver:v1.32.0
         imagePullPolicy: IfNotPresent
         name: kube-apiserver
         ports:

--- a/example/30-controlplane.yaml
+++ b/example/30-controlplane.yaml
@@ -36,7 +36,7 @@ spec:
       networking:
         pods: 10.250.0.0/19
       kubernetes:
-        version: 1.28.2
+        version: 1.32.0
       hibernation:
         enabled: false
     status:

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -38,7 +38,7 @@ spec:
     kind: Shoot
     spec:
       kubernetes:
-        version: 1.28.2
+        version: 1.32.0
     status:
       lastOperation:
         state: Succeeded

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -15,20 +15,6 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-aws
   repository: registry.k8s.io/provider-aws/cloud-controller-manager
-  tag: "v1.27.10"
-  targetVersion: "1.27.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-aws
-  repository: registry.k8s.io/provider-aws/cloud-controller-manager
   tag: "v1.28.11"
   targetVersion: "1.28.x"
   labels:

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -15,20 +15,6 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-aws
   repository: registry.k8s.io/provider-aws/cloud-controller-manager
-  tag: "v1.28.11"
-  targetVersion: "1.28.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-aws
-  repository: registry.k8s.io/provider-aws/cloud-controller-manager
   tag: "v1.29.8"
   targetVersion: "1.29.x"
   labels:

--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Shoot mutator", func() {
 				},
 				Spec: gardencorev1beta1.ShootSpec{
 					Kubernetes: gardencorev1beta1.Kubernetes{
-						Version: "1.28.2",
+						Version: "1.29.0",
 					},
 					SeedName: ptr.To("aws"),
 					Provider: gardencorev1beta1.Provider{
@@ -81,7 +81,7 @@ var _ = Describe("Shoot mutator", func() {
 				},
 				Spec: gardencorev1beta1.ShootSpec{
 					Kubernetes: gardencorev1beta1.Kubernetes{
-						Version: "1.28.2",
+						Version: "1.29.0",
 					},
 					SeedName: ptr.To("aws"),
 					Provider: gardencorev1beta1.Provider{

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -195,7 +195,7 @@ var _ = Describe("ValuesProvider", func() {
 						Pods: &cidr,
 					},
 					Kubernetes: gardencorev1beta1.Kubernetes{
-						Version: "1.28.2",
+						Version: "1.29.0",
 					},
 				},
 			},
@@ -527,7 +527,7 @@ var _ = Describe("ValuesProvider", func() {
 					aws.AWSCustomRouteControllerName:  enabledFalse,
 					aws.AWSLoadBalancerControllerName: enabledFalse,
 					aws.CSINodeName: utils.MergeMaps(enabledTrue, map[string]interface{}{
-						"kubernetesVersion": "1.28.2",
+						"kubernetesVersion": "1.29.0",
 						"driver": map[string]interface{}{
 							"volumeAttachLimit": "42",
 						},
@@ -547,7 +547,7 @@ var _ = Describe("ValuesProvider", func() {
 					aws.AWSCustomRouteControllerName:  enabledFalse,
 					aws.AWSLoadBalancerControllerName: enabledFalse,
 					aws.CSINodeName: utils.MergeMaps(enabledTrue, map[string]interface{}{
-						"kubernetesVersion": "1.28.2",
+						"kubernetesVersion": "1.29.0",
 						"driver": map[string]interface{}{
 							"volumeAttachLimit": "42",
 						},
@@ -567,7 +567,7 @@ var _ = Describe("ValuesProvider", func() {
 					aws.AWSCustomRouteControllerName:  enabledTrue,
 					aws.AWSLoadBalancerControllerName: enabledFalse,
 					aws.CSINodeName: utils.MergeMaps(enabledTrue, map[string]interface{}{
-						"kubernetesVersion": "1.28.2",
+						"kubernetesVersion": "1.29.0",
 						"driver": map[string]interface{}{
 							"volumeAttachLimit": "42",
 						},
@@ -603,7 +603,7 @@ var _ = Describe("ValuesProvider", func() {
 					aws.AWSCustomRouteControllerName:  enabledFalse,
 					aws.AWSLoadBalancerControllerName: albChartValues,
 					aws.CSINodeName: utils.MergeMaps(enabledTrue, map[string]interface{}{
-						"kubernetesVersion": "1.28.2",
+						"kubernetesVersion": "1.29.0",
 						"driver": map[string]interface{}{
 							"volumeAttachLimit": "42",
 						},

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Ensurer", func() {
 		ctx  = context.TODO()
 
 		dummyContext   = gcontext.NewGardenContext(nil, nil)
-		eContextK8s127 gcontext.GardenContext
+		eContextK8s129 gcontext.GardenContext
 		eContextK8s131 gcontext.GardenContext
 
 		shoot131 *gardencorev1beta1.Shoot
@@ -76,7 +76,7 @@ var _ = Describe("Ensurer", func() {
 	})
 
 	JustBeforeEach(func() {
-		eContextK8s127 = gcontext.NewInternalGardenContext(
+		eContextK8s129 = gcontext.NewInternalGardenContext(
 			&extensionscontroller.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "shoot--project--foo",
@@ -87,7 +87,7 @@ var _ = Describe("Ensurer", func() {
 					},
 					Spec: gardencorev1beta1.ShootSpec{
 						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.27.1",
+							Version: "1.29.0",
 						},
 						Provider: gardencorev1beta1.Provider{
 							InfrastructureConfig: &runtime.RawExtension{
@@ -152,10 +152,10 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should add missing elements to kube-apiserver deployment (< 1.31)", func() {
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s127, dep, nil)
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, "1.27.1")
+			checkKubeAPIServerDeployment(dep, "1.29.0")
 		})
 
 		It("should add missing elements to kube-apiserver deployment (k8s >= 1.31)", func() {
@@ -197,10 +197,10 @@ var _ = Describe("Ensurer", func() {
 				},
 			}
 
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s127, dep, nil)
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, "1.27.5")
+			checkKubeAPIServerDeployment(dep, "1.29.0")
 		})
 	})
 
@@ -235,10 +235,10 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should add missing elements to kube-controller-manager deployment (< 1.31)", func() {
-			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s127, dep, nil)
+			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeControllerManagerDeployment(dep, "1.27.1")
+			checkKubeControllerManagerDeployment(dep, "1.29.0")
 		})
 
 		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.31)", func() {
@@ -280,10 +280,10 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
-			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s127, dep, nil)
+			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeControllerManagerDeployment(dep, "1.27.5")
+			checkKubeControllerManagerDeployment(dep, "1.29.0")
 		})
 	})
 
@@ -313,10 +313,10 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should add missing elements to kube-scheduler deployment (< 1.31)", func() {
-			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s127, dep, nil)
+			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeSchedulerDeployment(dep, "1.27.1")
+			checkKubeSchedulerDeployment(dep, "1.29.0")
 		})
 
 		It("should add missing elements to kube-scheduler deployment (k8s >= 1.31)", func() {
@@ -353,10 +353,10 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should add missing elements to cluster-autoscaler deployment (< 1.31)", func() {
-			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s127, dep, nil)
+			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s129, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkClusterAutoscalerDeployment(dep, "1.27.5")
+			checkClusterAutoscalerDeployment(dep, "1.29.0")
 		})
 
 		It("should add missing elements to cluster-autoscaler deployment (>= 1.31)", func() {
@@ -394,7 +394,7 @@ ExecStart=/opt/bin/mtu-customizer.sh
 			ensurer := NewEnsurer(logger, c)
 
 			// Call EnsureAdditionalUnits method and check the result
-			err := ensurer.EnsureAdditionalUnits(ctx, eContextK8s127, &units, nil)
+			err := ensurer.EnsureAdditionalUnits(ctx, eContextK8s129, &units, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(units).To(ConsistOf(oldUnit, additionalUnit))
 		})
@@ -471,7 +471,7 @@ done
 				ensurer := NewEnsurer(logger, c)
 
 				// Call EnsureAdditionalFiles method and check the result
-				err = ensurer.EnsureAdditionalFiles(ctx, eContextK8s127, &files, nil)
+				err = ensurer.EnsureAdditionalFiles(ctx, eContextK8s129, &files, nil)
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(files).To(ConsistOf(oldFile, additionalFile, ecrConfig, ecrBin))
 			})
@@ -503,7 +503,7 @@ done
 				ensurer := NewEnsurer(logger, c)
 
 				// Call EnsureAdditionalFiles method and check the result
-				err := ensurer.EnsureAdditionalFiles(ctx, eContextK8s127, &files, nil)
+				err := ensurer.EnsureAdditionalFiles(ctx, eContextK8s129, &files, nil)
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(files).To(ConsistOf(oldFile, additionalFile))
 			})
@@ -579,7 +579,7 @@ done
 				})
 
 				It("without ECR access", func() {
-					opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s127, semver.MustParse("1.27.0"), oldUnitOptions, nil)
+					opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s129, semver.MustParse("1.29.0"), oldUnitOptions, nil)
 					Expect(err).To(Not(HaveOccurred()))
 					Expect(opts).To(Equal(newUnitOptions))
 				})
@@ -589,7 +589,7 @@ done
 				newUnitOptions[0].Value += addCmdOption("--image-credential-provider-config=/opt/gardener/ecr-credential-provider-config.json")
 				newUnitOptions[0].Value += addCmdOption("--image-credential-provider-bin-dir=/opt/bin/")
 
-				opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s127, semver.MustParse("1.27.0"), oldUnitOptions, nil)
+				opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, eContextK8s129, semver.MustParse("1.29.0"), oldUnitOptions, nil)
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(opts).To(Equal(newUnitOptions))
 			})
@@ -630,7 +630,7 @@ done
 				Expect(&kubeletConfig).To(Equal(newKubeletConfig))
 			},
 
-			Entry("kubelet < 1.31", semver.MustParse("1.27.1"), map[string]bool{"InTreePluginAWSUnregister": true}),
+			Entry("kubelet < 1.31", semver.MustParse("1.29.0"), map[string]bool{"InTreePluginAWSUnregister": true}),
 			Entry("kubelet >= 1.31", semver.MustParse("1.31.1"), map[string]bool{}),
 		)
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform aws

**What this PR does / why we need it**:
Drop support for Shoots, Seeds and Gardens with Kubernetes version <= 1.28.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12409

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`provider-aws` no longer supports Shoots with Кubernetes version <= 1.28.
```
