### PR TITLE
Upgrade `machine-controller-manager` dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/gardener/etcd-druid/api v0.30.1
 	github.com/gardener/external-dns-management v0.24.0
 	github.com/gardener/gardener v1.121.1
-	github.com/gardener/machine-controller-manager v0.58.0
+	github.com/gardener/machine-controller-manager v0.59.0
 	github.com/go-logr/logr v1.4.2
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/gardener/external-dns-management v0.24.0 h1:pniCIC42MeYKrDRn4hcWbzRUM
 github.com/gardener/external-dns-management v0.24.0/go.mod h1:BSqwJrgnQPqiYxM7C3jiQp1GnAFc06MAUjTP0lNPcsA=
 github.com/gardener/gardener v1.121.1 h1:4l8o/QRyIqzM/GrAbjkwW2cKgCiu3Q7TIgFcJUNzTbw=
 github.com/gardener/gardener v1.121.1/go.mod h1:IMyv50VIqnpV3Aka2Ac+zHSJU791JaKtWTtRDVOfNLI=
-github.com/gardener/machine-controller-manager v0.58.0 h1:JLMpuD+omliu/RwK0mA9Ce+MLObJq421Du1qmaAHmAU=
-github.com/gardener/machine-controller-manager v0.58.0/go.mod h1:TCU/KoudCMt2eV0Jnrq2D1TwgsrBCuhIVgV3j1el6Og=
+github.com/gardener/machine-controller-manager v0.59.0 h1:tmFbxGCTmKfGujPyM1MzYtRWNu/STPQHZ3JEXymIIZ4=
+github.com/gardener/machine-controller-manager v0.59.0/go.mod h1:TCU/KoudCMt2eV0Jnrq2D1TwgsrBCuhIVgV3j1el6Og=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-jose/go-jose/v4 v4.1.0 h1:cYSYxd3pw5zd2FSXk2vGdn9igQU2PS8MuxrCOCl0FdY=

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -113,7 +113,7 @@ images:
 - name: machine-controller-manager-provider-aws
   sourceRepository: github.com/gardener/machine-controller-manager-provider-aws
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-aws
-  tag: "v0.24.0"
+  tag: "v0.25.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR upgrades the following
1. machine-controller-manager `v0.58.0`->`v0.59.0`
2. machine-controller-manager-provider-aws `v0.24.0`->`v0.25.0`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator github.com/gardener/machine-controller-manager #1004 @timebertt
machine-controller-manager can manage machines without a target cluster by specifying `--target-kubeconfig=none`. See the [documentation](https://github.com/gardener/machine-controller-manager/blob/master/docs/FAQ.md#how-to-run-mcm-in-different-cluster-setups) for more details.
```
```other operator github.com/gardener/machine-controller-manager #991 @aaronfern
machine-controller-manager base image is updated to `gcr.io/distroless/static-debian12:nonroot`.
```
```other operator github.com/gardener/machine-controller-manager #1000 @aaronfern
add new label `node_name` to the `mcm_machine_info` metric
```
```bugfix operator github.com/gardener/machine-controller-manager #995 @takoverflow
Fixed a bug in the MachineSet controller where the machine status was set to `Terminating` even if attempt to delete the machine object failed.
```
```bugfix operator github.com/gardener/machine-controller-manager #979 @aaronfern
Fix a bug where MCM does not check if a pod has already been evicted before reattempting eviction blindly
```
```bugfix operator github.com/gardener/machine-controller-manager-provider-aws #199 @aaronfern
Fix an issue that caused make targets to fail by ensuring MCM is present in the mod cache
```
```bugfix user github.com/gardener/machine-controller-manager-provider-aws #197 @dimityrmirchev
A bug causing failure in retrieval of credentials when using workload identity due to missing region parameter was fixed.
```
```other operator github.com/gardener/machine-controller-manager-provider-aws #194 @aaronfern 
machine-controller-manager-provider-aws base image is updated to gcr.io/distroless/static-debian12:nonroot
```
