### PR TITLE
[release-v1.62] Automated cherry pick of #1365: run `make generate` for release- and bump-commits

### DIFF
--- a/.ci/prepare_release
+++ b/.ci/prepare_release
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-"$(dirname $0)"/hack/prepare_release "$(dirname $0)"/.. github.com/gardener gardener-extension-provider-aws

--- a/.github/actions/prepare-release/action.yaml
+++ b/.github/actions/prepare-release/action.yaml
@@ -1,0 +1,13 @@
+name: Prepare-Release
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.24.4'
+    - name: prepare-release
+      shell: bash
+      run: |
+        set -eu
+        make generate

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,7 @@ jobs:
     uses: gardener/cc-utils/.github/workflows/prepare.yaml@master
     with:
       mode: ${{ inputs.mode }}
+      version-commit-callback-action-path: .github/actions/prepare-release
 
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,3 +24,4 @@ jobs:
     with:
       release-commit-target: branch
       next-version: ${{ inputs.next-version }}
+      next-version-callback-action-path: .github/actions/prepare-release


### PR DESCRIPTION
/area delivery
/kind bug

Cherry pick of #1365 on release-v1.62.

#1365: run `make generate` for release- and bump-commits

**Release Notes:**
```other developer
run `make generate` for release- and bump-commits (again)
```