### PR TITLE
Allow creation or more that one IPv6 shoot in one VPC

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -842,7 +842,7 @@ func (c *FlowContext) addSubnetReconcileTasks(g *flow.Graph, desired, current *a
 	}
 	suffix := fmt.Sprintf("%s-%s", zoneName, subnetKey)
 	if ptr.Deref(desired.AssignIpv6AddressOnCreation, true) {
-		return c.AddTask(g, "ensure subnet "+suffix,
+		return c.AddTask(g, "ensure IPv6 subnet "+suffix,
 			c.ensureSubnetIPv6(subnetKey, desired, current),
 			Timeout(defaultTimeout)), nil
 	}


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform aws

**What this PR does / why we need it**:
Due to the static IPv6 CIDR calculation subnets of multiple shoots get the same CIDR and the creation fails for all but one shoot. This PR retries the subnet creation with the next /64 CIDR block in case of an `InvalidSubnet.Conflict` error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug user
Now it is possible to create more than shoot with IPv6 networking in the same VPC.

```
