### PR TITLE
Fix setting NAT ID only after available

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -1933,7 +1933,7 @@ func (c *Client) WaitForNATGatewayAvailable(ctx context.Context, id string) erro
 		if item, err := c.GetNATGateway(ctx, id); err != nil {
 			return false, err
 		} else {
-			return strings.EqualFold(item.State, string(ec2types.StateAvailable)), nil
+			return strings.EqualFold(item.State, string(ec2types.NatGatewayStateAvailable)), nil
 		}
 	})
 }

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -662,7 +662,7 @@ func (c *FlowContext) ensureEgressCIDRs(ctx context.Context) error {
 		return err
 	}
 	for _, nat := range nats {
-		if isNATGatewayDeletingOrFailed(nat) {
+		if nat.State != string(ec2types.NatGatewayStateAvailable) {
 			continue
 		}
 		egressIPs = append(egressIPs, fmt.Sprintf("%s/32", nat.PublicIP))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform aws

**What this PR does / why we need it**:
We should only persist state and set Nat ID after it's available.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix persisting NAT ID before NAT is available
```
