### PR TITLE
Allow deletion of duplicated zones

### DIFF
--- a/pkg/apis/aws/validation/infrastructure.go
+++ b/pkg/apis/aws/validation/infrastructure.go
@@ -189,23 +189,48 @@ func ValidateInfrastructureConfigUpdate(oldConfig, newConfig *apisaws.Infrastruc
 		newZones = newConfig.Networks.Zones
 	)
 
-	if len(oldZones) > len(newZones) {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("networks.zones"), "removing zones is not allowed"))
-		return allErrs
+	// TODO: @hebelsan remove check after duplicate zones got migrated
+	if !removedDuplicateZones(oldZones, newZones) {
+		if len(oldZones) > len(newZones) {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("networks.zones"), "removing zones is not allowed"))
+			return allErrs
+		}
+
+		for i, oldZone := range oldZones {
+			idxPath := field.NewPath("networks.zones").Index(i)
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldZone.Name, newConfig.Networks.Zones[i].Name, idxPath.Child("name"))...)
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldZone.Public, newConfig.Networks.Zones[i].Public, idxPath.Child("public"))...)
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldZone.Internal, newConfig.Networks.Zones[i].Internal, idxPath.Child("internal"))...)
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldZone.Workers, newConfig.Networks.Zones[i].Workers, idxPath.Child("workers"))...)
+		}
 	}
 
-	for i, oldZone := range oldZones {
-		idxPath := field.NewPath("networks.zones").Index(i)
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldZone.Name, newConfig.Networks.Zones[i].Name, idxPath.Child("name"))...)
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldZone.Public, newConfig.Networks.Zones[i].Public, idxPath.Child("public"))...)
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldZone.Internal, newConfig.Networks.Zones[i].Internal, idxPath.Child("internal"))...)
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldZone.Workers, newConfig.Networks.Zones[i].Workers, idxPath.Child("workers"))...)
-	}
 	if oldConfig.DualStack != nil && oldConfig.DualStack.Enabled && (newConfig.DualStack == nil || !newConfig.DualStack.Enabled) {
 		dualStackPath := field.NewPath("dualStack.enabled")
 		allErrs = append(allErrs, field.Forbidden(dualStackPath, "field can't be changed from \"true\" to \"false\""))
 	}
 	return allErrs
+}
+
+// removeDuplicateZones checks if duplicate zones got removed from the old
+// TODO: @hebelsan remove after duplicate zones got migrated
+func removedDuplicateZones(old []apisaws.Zone, new []apisaws.Zone) bool {
+	// old must have more zones than new, otherwise we would not be able to remove duplicates
+	if len(old) <= len(new) {
+		return false
+	}
+
+	oldZoneNames := sets.New[string]()
+	for _, zone := range old {
+		oldZoneNames.Insert(zone.Name)
+	}
+
+	newZoneNames := sets.New[string]()
+	for _, zone := range new {
+		newZoneNames.Insert(zone.Name)
+	}
+
+	return oldZoneNames.Equal(newZoneNames)
 }
 
 var (


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/platform aws

**What this PR does / why we need it**:
On AWS, some Shoots contain duplicate zone entries in their infraConfig.
This issue could only occur in older Shoots, created before a validation rule was introduced several years ago.
At the time, Terraformer did not flag this duplication, but the current flow reconciler is unable to handle it properly.
As a result, we need to remove these duplicate entries to ensure smooth reconciliation

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow deletion of duplicated zones in infraConfig section
```
