### PR TITLE
Add comment for volume-modifier-for-k8s image deprecation

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -168,6 +168,8 @@ images:
   # We cannot use the upstream repository here as it is not reachable using IPv6.
   # NOTE: Please make sure to copy new image versions when updating the version by adding them to
   #       https://github.com/gardener/ci-infra/blob/master/config/images/images.yaml.
+  # NOTE: volume-modifier-for-k8s has been deprecated in favor of the native Kubernetes VolumeAttributesClass API.
+  #       we can get rid of this image once we remove K8s v1.31 support (VolumeAttributesClass graduated to beta).
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/ebs-csi-driver/volume-modifier-for-k8s
   tag: "v0.5.1"
   labels:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Add reminder to remove deprecated image.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
