### PR TITLE
fix gatewayEndpoints naming validation

### DIFF
--- a/pkg/apis/aws/validation/infrastructure.go
+++ b/pkg/apis/aws/validation/infrastructure.go
@@ -21,7 +21,7 @@ import (
 )
 
 // valid values for networks.vpc.gatewayEndpoints
-var gatewayEndpointPattern = regexp.MustCompile(`^\w+(\.\w+)*$`)
+var gatewayEndpointPattern = regexp.MustCompile(`^[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)*$`)
 
 // ValidateInfrastructureConfigAgainstCloudProfile validates the given `InfrastructureConfig` against the given `CloudProfile`.
 func ValidateInfrastructureConfigAgainstCloudProfile(oldInfra, infra *apisaws.InfrastructureConfig, shoot *core.Shoot, cloudProfileSpec *gardencorev1beta1.CloudProfileSpec, fldPath *field.Path) field.ErrorList {

--- a/pkg/apis/aws/validation/infrastructure_test.go
+++ b/pkg/apis/aws/validation/infrastructure_test.go
@@ -401,13 +401,13 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				Expect(errorList).To(BeEmpty())
 			})
 
-			It("should reject non-alphanumeric endpoints", func() {
-				infrastructureConfig.Networks.VPC.GatewayEndpoints = []string{"s3", "my-endpoint"}
+			It("should reject non-domain name endpoints", func() {
+				infrastructureConfig.Networks.VPC.GatewayEndpoints = []string{"s3", "my_endpoint", "guardduty-data"}
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, familyIPv4, &nodes, &pods, &services)
 				Expect(errorList).To(ConsistOfFields(Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
 					"Field":    Equal("networks.vpc.gatewayEndpoints[1]"),
-					"BadValue": Equal("my-endpoint"),
+					"BadValue": Equal("my_endpoint"),
 					"Detail":   Equal("must be a valid domain name"),
 				}))
 			})


### PR DESCRIPTION
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:
gatewayEndpoints naming follows domain naming. current code allowed for A-Za-z0-9\_ (which is wrong and misses \- char)

**Which issue(s) this PR fixes**:
Fixes #1442

**Special notes for your reviewer**:
