### PR TITLE
Add label-based trust to head-update build job

### DIFF
--- a/.github/workflows/head-update.yaml
+++ b/.github/workflows/head-update.yaml
@@ -2,21 +2,35 @@ name: Build
 on:
   push:
   pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  pull_request_target:
+    types:
+      - labeled
+  merge_group:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && github.event.label.name == 'reviewed/ok-to-test') }}
     uses: ./.github/workflows/build.yaml
     with:
       mode: snapshot
+    secrets: inherit
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
+      pull-requests: write
 
   component-descriptor:
+    if: ${{ github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && github.event.label.name == 'reviewed/ok-to-test') }}
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
     needs:
       - build
+    secrets: inherit
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind regression
/platform aws

**What this PR does / why we need it**:

Adds label-based trust to the head update build job so oci artifacts can be published from PRs of forked repos.

PRs with the label `reviewed/ok-to-test` will publish their build results. 


**Special notes for your reviewer**:
@AndreasBurger 


