### PR TITLE
[GEP-33] Capabilities based MachineClass creation

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1332,7 +1332,7 @@ github.com/gardener/gardener/pkg/apis/core/v1beta1.Capabilities
 </em>
 </td>
 <td>
-<p>Capabilities if the machine image.</p>
+<p>Capabilities of the machine image.</p>
 </td>
 </tr>
 </tbody>

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1324,6 +1324,17 @@ string
 <p>Architecture is the CPU architecture of the machine image.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>capabilities</code></br>
+<em>
+github.com/gardener/gardener/pkg/apis/core/v1beta1.Capabilities
+</em>
+</td>
+<td>
+<p>Capabilities if the machine image.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="aws.provider.extensions.gardener.cloud/v1alpha1.MachineImageVersion">MachineImageVersion

--- a/pkg/admission/validator/cloudprofile.go
+++ b/pkg/admission/validator/cloudprofile.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	awsvalidation "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/validation"
 )
 
@@ -47,5 +48,10 @@ func (cp *cloudProfile) Validate(_ context.Context, newObj, _ client.Object) err
 		return err
 	}
 
-	return awsvalidation.ValidateCloudProfileConfig(cpConfig, cloudProfile.Spec.MachineImages, cloudProfile.Spec.Capabilities, providerConfigPath).ToAggregate()
+	capabilitiesDefinition, err := helper.ConvertV1beta1CapabilitiesDefinitions(cloudProfile.Spec.Capabilities)
+	if err != nil {
+		return field.InternalError(field.NewPath("spec").Child("capabilities"), err)
+	}
+
+	return awsvalidation.ValidateCloudProfileConfig(cpConfig, cloudProfile.Spec.MachineImages, capabilitiesDefinition, providerConfigPath).ToAggregate()
 }

--- a/pkg/admission/validator/namespacedcloudprofile.go
+++ b/pkg/admission/validator/namespacedcloudprofile.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -164,14 +164,14 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.Cloud
 func validateMachineImageCapabilities(machineImage core.MachineImage, version gardencorev1beta1.MachineImageVersion, providerImageVersion api.MachineImageVersion, capabilitiesDefinition []gardencorev1beta1.CapabilityDefinition) field.ErrorList {
 	allErrs := field.ErrorList{}
 	path := field.NewPath("spec.providerConfig.machineImages")
-	defaultedCapabilitySets := v1beta1helper.GetCapabilitySetsWithAppliedDefaults(version.CapabilitySets, capabilitiesDefinition)
+	defaultedCapabilitySets := gardencorev1beta1helper.GetCapabilitySetsWithAppliedDefaults(version.CapabilitySets, capabilitiesDefinition)
 	regionsCapabilitiesMap := map[string][]gardencorev1beta1.Capabilities{}
 
 	// 1. Create an error for each capabilitySet in the providerConfig that is not defined in the core machine image version
 	for _, capabilitySet := range providerImageVersion.CapabilitySets {
 		isFound := false
 		for _, coreDefaultedCapabilitySet := range defaultedCapabilitySets {
-			defaultedProviderCapabilities := v1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilitySet.Capabilities, capabilitiesDefinition)
+			defaultedProviderCapabilities := gardencorev1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilitySet.Capabilities, capabilitiesDefinition)
 			if helper.AreCapabilitiesEqual(coreDefaultedCapabilitySet.Capabilities, defaultedProviderCapabilities) {
 				isFound = true
 			}
@@ -191,7 +191,7 @@ func validateMachineImageCapabilities(machineImage core.MachineImage, version ga
 	for _, coreDefaultedCapabilitySet := range defaultedCapabilitySets {
 		isFound := false
 		for _, capabilitySet := range providerImageVersion.CapabilitySets {
-			defaultedProviderCapabilities := v1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilitySet.Capabilities, capabilitiesDefinition)
+			defaultedProviderCapabilities := gardencorev1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilitySet.Capabilities, capabilitiesDefinition)
 			if helper.AreCapabilitiesEqual(coreDefaultedCapabilitySet.Capabilities, defaultedProviderCapabilities) {
 				isFound = true
 			}
@@ -208,7 +208,7 @@ func validateMachineImageCapabilities(machineImage core.MachineImage, version ga
 		for region, regionCapabilities := range regionsCapabilitiesMap {
 			isFound := false
 			for _, capabilities := range regionCapabilities {
-				regionDefaultedCapabilities := v1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilities, capabilitiesDefinition)
+				regionDefaultedCapabilities := gardencorev1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilities, capabilitiesDefinition)
 				if helper.AreCapabilitiesEqual(regionDefaultedCapabilities, coreDefaultedCapabilitySet.Capabilities) {
 					isFound = true
 				}

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -166,7 +166,7 @@ func (s *shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 	if shoot.DeletionTimestamp == nil {
 		// If the Shoot is being deleted, we do not validate the workers against the cloud
 		// profile, as the workers will be deleted anyway.
-		if errList := awsvalidation.ValidateWorkersAgainstCloudProfileOnUpdate(oldShoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers, shoot.Spec.Region, awsCloudProfile, fldPath.Child("workers")); len(errList) != 0 {
+		if errList := awsvalidation.ValidateWorkersAgainstCloudProfileOnUpdate(oldShoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers, shoot.Spec.Region, awsCloudProfile, cloudProfileSpec.MachineTypes, cloudProfileSpec.Capabilities, fldPath.Child("workers")); len(errList) != 0 {
 			return errList.ToAggregate()
 		}
 	}
@@ -184,7 +184,7 @@ func (s *shoot) validateShootCreation(ctx context.Context, shoot *core.Shoot, cl
 		return err
 	}
 
-	if errList := awsvalidation.ValidateWorkersAgainstCloudProfileOnCreation(shoot.Spec.Provider.Workers, shoot.Spec.Region, awsCloudProfile, fldPath.Child("workers")); len(errList) != 0 {
+	if errList := awsvalidation.ValidateWorkersAgainstCloudProfileOnCreation(shoot.Spec.Provider.Workers, shoot.Spec.Region, awsCloudProfile, cloudProfileSpec.MachineTypes, cloudProfileSpec.Capabilities, fldPath.Child("workers")); len(errList) != 0 {
 		return errList.ToAggregate()
 	}
 

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Shoot validator", func() {
 			imageName    = "Foo"
 			imageVersion = "1.0.0"
 			architecture = ptr.To("analog")
+			machineType  = "large"
 		)
 
 		BeforeEach(func() {
@@ -77,6 +78,11 @@ var _ = Describe("Shoot validator", func() {
 					Name: "aws",
 				},
 				Spec: gardencorev1beta1.CloudProfileSpec{
+					MachineTypes: []gardencorev1beta1.MachineType{
+						{
+							Name: machineType,
+						},
+					},
 					Regions: []gardencorev1beta1.Region{
 						{
 							Name: regionName,
@@ -174,6 +180,7 @@ var _ = Describe("Shoot validator", func() {
 								},
 								Zones: []string{"zone1"},
 								Machine: core.Machine{
+									Type: machineType,
 									Image: &core.ShootMachineImage{
 										Name:    imageName,
 										Version: imageVersion,
@@ -251,6 +258,7 @@ var _ = Describe("Shoot validator", func() {
 			It("should return err when worker image is not present in CloudConfiguration", func() {
 				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 				shoot.Spec.Provider.Workers[0].Machine = core.Machine{
+					Type: machineType,
 					Image: &core.ShootMachineImage{
 						Name:    "Bar",
 						Version: imageVersion,
@@ -274,6 +282,7 @@ var _ = Describe("Shoot validator", func() {
 						Name:    "Bar",
 						Version: imageVersion,
 					},
+					Type:         "large",
 					Architecture: architecture,
 				}
 
@@ -289,6 +298,7 @@ var _ = Describe("Shoot validator", func() {
 
 				newShoot := shoot.DeepCopy()
 				shoot.Spec.Provider.Workers[0].Machine = core.Machine{
+					Type: machineType,
 					Image: &core.ShootMachineImage{
 						Name:    "Bar",
 						Version: imageVersion,
@@ -372,6 +382,9 @@ var _ = Describe("Shoot validator", func() {
 					{
 						Name:           "worker-1",
 						ProviderConfig: &runtime.RawExtension{Raw: []byte("foo")},
+						Machine: core.Machine{
+							Type: machineType,
+						},
 					},
 				}
 
@@ -390,6 +403,9 @@ var _ = Describe("Shoot validator", func() {
 						Name:   "worker-1",
 						Volume: nil,
 						Zones:  nil,
+						Machine: core.Machine{
+							Type: machineType,
+						},
 					},
 				}
 

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -282,7 +282,7 @@ var _ = Describe("Shoot validator", func() {
 						Name:    "Bar",
 						Version: imageVersion,
 					},
-					Type:         "large",
+					Type:         machineType,
 					Architecture: architecture,
 				}
 

--- a/pkg/apis/aws/helper/capabilities.go
+++ b/pkg/apis/aws/helper/capabilities.go
@@ -18,7 +18,7 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -99,8 +99,8 @@ func ValidateCapabilities(capabilities gardencorev1beta1.Capabilities, capabilit
 // AreCapabilitiesCompatible checks if two sets of capabilities are compatible.
 // It applies defaults from the capability definitions to both sets before checking compatibility.
 func AreCapabilitiesCompatible(capabilities1, capabilities2 gardencorev1beta1.Capabilities, capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition) bool {
-	defaultedCapabilities1 := v1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilities1, capabilitiesDefinitions)
-	defaultedCapabilities2 := v1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilities2, capabilitiesDefinitions)
+	defaultedCapabilities1 := gardencorev1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilities1, capabilitiesDefinitions)
+	defaultedCapabilities2 := gardencorev1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilities2, capabilitiesDefinitions)
 
 	isSupported := true
 	commonCapabilities := getCapabilitiesIntersection(defaultedCapabilities1, defaultedCapabilities2)
@@ -205,7 +205,7 @@ func selectBestCapabilitySet[T HasCapabilities](
 
 	// Normalize capability sets by applying defaults
 	for i := range normalizedSets {
-		normalizedSets[i].SetCapabilities(v1beta1helper.GetCapabilitiesWithAppliedDefaults(
+		normalizedSets[i].SetCapabilities(gardencorev1beta1helper.GetCapabilitiesWithAppliedDefaults(
 			normalizedSets[i].GetCapabilities(),
 			capabilitiesDefinitions,
 		))

--- a/pkg/apis/aws/helper/capabilities.go
+++ b/pkg/apis/aws/helper/capabilities.go
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helper
+
+// This file contains helper functions for capabilities handling, e.g. conversion, comparison, validation.
+// These functions can be used by different providers and should not contain any provider-specific logic.
+// All functions in this file should be transitioned into the Gardener core repository over time once the
+// implementation is stable.
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	gardencoreapi "github.com/gardener/gardener/pkg/api"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ConvertV1beta1CapabilitiesDefinitions converts core.CapabilityDefinition objects to v1beta1.CapabilityDefinition objects.
+func ConvertV1beta1CapabilitiesDefinitions(capabilitiesDefinitions []gardencore.CapabilityDefinition) ([]gardencorev1beta1.CapabilityDefinition, error) {
+	var v1beta1CapabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition
+	for _, capabilityDefinition := range capabilitiesDefinitions {
+		var v1beta1CapabilityDefinition gardencorev1beta1.CapabilityDefinition
+		err := gardencoreapi.Scheme.Convert(&capabilityDefinition, &v1beta1CapabilityDefinition, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert capability definition: %w", err)
+		}
+		v1beta1CapabilitiesDefinitions = append(v1beta1CapabilitiesDefinitions, v1beta1CapabilityDefinition)
+	}
+	return v1beta1CapabilitiesDefinitions, nil
+}
+
+// AreCapabilitiesEqual checks if two capabilities are semantically equal.
+func AreCapabilitiesEqual(a, b gardencorev1beta1.Capabilities) bool {
+	return areCapabilitiesSubsetOf(a, b) && areCapabilitiesSubsetOf(b, a)
+}
+
+// areCapabilitiesSubsetOf verifies if all keys and values in `source` exist in `target`.
+func areCapabilitiesSubsetOf(source, target gardencorev1beta1.Capabilities) bool {
+	for key, valuesSource := range source {
+		valuesTarget, exists := target[key]
+		if !exists {
+			return false
+		}
+		for _, value := range valuesSource {
+			if !slices.Contains(valuesTarget, value) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// ValidateCapabilities validates the capabilities of a machine type or machine image against the capabilitiesDefinition located in a cloud profile at spec.capabilities.
+// It checks if the capabilities are supported by the cloud profile and if the architecture is defined correctly.
+// It returns a list of field errors if any validation fails.
+func ValidateCapabilities(capabilities gardencorev1beta1.Capabilities, capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// create map from capabilitiesDefinitions
+	capabilitiesDefinition := make(map[string][]string)
+	for _, capabilityDefinition := range capabilitiesDefinitions {
+		capabilitiesDefinition[capabilityDefinition.Name] = capabilityDefinition.Values
+	}
+	supportedCapabilityKeys := slices.Collect(maps.Keys(capabilitiesDefinition))
+
+	// Check if all capabilities are supported by the cloud profile
+	for capabilityKey, capability := range capabilities {
+		supportedValues, keyExists := capabilitiesDefinition[capabilityKey]
+		if !keyExists {
+			allErrs = append(allErrs, field.NotSupported(fldPath, capabilityKey, supportedCapabilityKeys))
+			continue
+		}
+		for i, value := range capability {
+			if !slices.Contains(supportedValues, value) {
+				allErrs = append(allErrs, field.NotSupported(fldPath.Child(capabilityKey).Index(i), value, supportedValues))
+			}
+		}
+	}
+
+	// Check additional requirements for architecture
+	// - must be defined when multiple architectures are supported by the cloud profile
+	supportedArchitectures := capabilitiesDefinition[v1beta1constants.ArchitectureName]
+	architectures := capabilities[v1beta1constants.ArchitectureName]
+	if len(supportedArchitectures) > 1 && len(architectures) != 1 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child(v1beta1constants.ArchitectureName), architectures, "must define exactly one architecture when multiple architectures are supported by the cloud profile"))
+	}
+
+	return allErrs
+}
+
+// AreCapabilitiesCompatible checks if two sets of capabilities are compatible.
+// It applies defaults from the capability definitions to both sets before checking compatibility.
+func AreCapabilitiesCompatible(capabilities1, capabilities2 gardencorev1beta1.Capabilities, capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition) bool {
+	defaultedCapabilities1 := v1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilities1, capabilitiesDefinitions)
+	defaultedCapabilities2 := v1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilities2, capabilitiesDefinitions)
+
+	isSupported := true
+	commonCapabilities := getCapabilitiesIntersection(defaultedCapabilities1, defaultedCapabilities2)
+	// If the intersection has at least one value for each capability, the capabilities are supported.
+	for _, values := range commonCapabilities {
+		if len(values) == 0 {
+			isSupported = false
+			break
+		}
+	}
+
+	return isSupported
+}
+
+// getCapabilitiesIntersection returns the intersection of multiple capabilities objects.
+func getCapabilitiesIntersection(capabilitiesList ...gardencorev1beta1.Capabilities) gardencorev1beta1.Capabilities {
+	intersection := make(gardencorev1beta1.Capabilities)
+
+	if len(capabilitiesList) == 0 {
+		return intersection
+	}
+
+	// Initialize intersection with the first capabilities object
+	maps.Copy(intersection, capabilitiesList[0])
+
+	intersect := func(slice1, slice2 []string) []string {
+		elementSet1 := sets.New(slice1...)
+		elementSet2 := sets.New(slice2...)
+
+		return elementSet1.Intersection(elementSet2).UnsortedList()
+	}
+
+	// Iterate through the remaining capabilities objects and refine the intersection
+	for _, capabilities := range capabilitiesList[1:] {
+		for key, values := range intersection {
+			intersection[key] = intersect(values, capabilities[key])
+		}
+	}
+
+	return intersection
+}
+
+// HasCapabilities defines an interface for types that contain Capabilities
+type HasCapabilities interface {
+	GetCapabilities() gardencorev1beta1.Capabilities
+	SetCapabilities(gardencorev1beta1.Capabilities)
+}
+
+// FindBestCapabilitySet finds the most appropriate capability set from the provided capability sets
+// based on the requested machine capabilities and the definitions of capabilities.
+func FindBestCapabilitySet[T HasCapabilities](
+	capabilitySets []T,
+	machineCapabilities gardencorev1beta1.Capabilities,
+	capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition,
+) (T, error) {
+	var zeroValue T
+	compatibleCapabilitySets := findCompatibleCapabilitySets(capabilitySets, machineCapabilities, capabilitiesDefinitions)
+
+	if len(compatibleCapabilitySets) == 0 {
+		return zeroValue, fmt.Errorf("no compatible capability set found")
+	}
+
+	bestMatch, err := selectBestCapabilitySet(compatibleCapabilitySets, capabilitiesDefinitions)
+	if err != nil {
+		return zeroValue, err
+	}
+	return bestMatch, nil
+}
+
+// findCompatibleCapabilitySets returns all capability sets that are compatible with the given machine capabilities.
+func findCompatibleCapabilitySets[T HasCapabilities](
+	capabilitySets []T, machineCapabilities gardencorev1beta1.Capabilities, capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition,
+) []T {
+	var compatibleSets []T
+	for _, capabilitySet := range capabilitySets {
+		if AreCapabilitiesCompatible(capabilitySet.GetCapabilities(), machineCapabilities, capabilitiesDefinitions) {
+			compatibleSets = append(compatibleSets, capabilitySet)
+		}
+	}
+	return compatibleSets
+}
+
+// selectBestCapabilitySet selects the most appropriate capability set based on the priority
+// of capabilities and their values as defined in capabilitiesDefinitions.
+//
+// Selection follows a priority-based approach:
+// 1. Capabilities are ordered by priority in the definitions list (highest priority first)
+// 2. Within each capability, values are ordered by preference (most preferred first)
+// 3. Selection is determined by the first capability value difference found
+func selectBestCapabilitySet[T HasCapabilities](
+	compatibleSets []T,
+	capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition,
+) (T, error) {
+	var zeroValue T
+	if len(compatibleSets) == 1 {
+		return compatibleSets[0], nil
+	}
+
+	// Apply capability defaults for better comparison
+	normalizedSets := make([]T, len(compatibleSets))
+	copy(normalizedSets, compatibleSets)
+
+	// Normalize capability sets by applying defaults
+	for i := range normalizedSets {
+		normalizedSets[i].SetCapabilities(v1beta1helper.GetCapabilitiesWithAppliedDefaults(
+			normalizedSets[i].GetCapabilities(),
+			capabilitiesDefinitions,
+		))
+	}
+
+	// Evaluate capability sets based on capability definitions priority
+	remainingSets := normalizedSets
+
+	// For each capability (in priority order)
+	for _, capabilityDef := range capabilitiesDefinitions {
+		// For each preferred value (in preference order)
+		for _, capabilityValue := range capabilityDef.Values {
+			var setsWithPreferredValue []T
+
+			// Find sets that support this capability value
+			for _, set := range remainingSets {
+				if slices.Contains(set.GetCapabilities()[capabilityDef.Name], capabilityValue) {
+					setsWithPreferredValue = append(setsWithPreferredValue, set)
+				}
+			}
+
+			// If we found sets with this value, narrow down our selection
+			if len(setsWithPreferredValue) > 0 {
+				remainingSets = setsWithPreferredValue
+
+				// If only one set remains, we've found our match
+				if len(remainingSets) == 1 {
+					return remainingSets[0], nil
+				}
+			}
+		}
+	}
+
+	// If we couldn't determine a single best match, this indicates a problem with the cloud profile
+	if len(remainingSets) != 1 {
+		return zeroValue, fmt.Errorf("found multiple capability sets with identical capabilities; this indicates an invalid cloudprofile was admitted. Please open a bug report at https://github.com/gardener/gardener/issues")
+	}
+
+	return remainingSets[0], nil
+}

--- a/pkg/apis/aws/helper/helper.go
+++ b/pkg/apis/aws/helper/helper.go
@@ -6,13 +6,21 @@ package helper
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/gardener/gardener/extensions/pkg/util"
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 
 	api "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
 )
 
 // FindInstanceProfileForPurpose takes a list of instance profiles and tries to find the first entry
@@ -75,44 +83,241 @@ func FindSubnetForPurposeAndZone(subnets []api.Subnet, purpose, zone string) (*a
 	return nil, fmt.Errorf("no subnet with purpose %q in zone %q found", purpose, zone)
 }
 
-// FindMachineImage takes a list of machine images and tries to find the first entry
-// whose name, version, architecture and zone matches with the given name, version, architecture and region. If no such entry is
+// FindImageInCloudProfile takes a list of machine images and tries to find the first entry
+// whose name, version, region, architecture, capabilities and zone matches with the given ones. If no such entry is
 // found then an error will be returned.
-func FindMachineImage(machineImages []api.MachineImage, name, version string, arch *string) (*api.MachineImage, error) {
-	for _, machineImage := range machineImages {
-		if machineImage.Architecture == nil {
-			machineImage.Architecture = ptr.To(v1beta1constants.ArchitectureAMD64)
-		}
-		if machineImage.Name == name && machineImage.Version == version && ptr.Equal(arch, machineImage.Architecture) {
-			return &machineImage, nil
-		}
+func FindImageInCloudProfile(
+	cloudProfileConfig *api.CloudProfileConfig,
+	name, version, region string,
+	arch *string,
+	machineCapabilities gardencorev1beta1.Capabilities,
+	capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition,
+) (*api.CapabilitySet, error) {
+	if cloudProfileConfig == nil {
+		return nil, fmt.Errorf("cloud profile config is nil")
 	}
-	return nil, fmt.Errorf("no machine image found with name %q, architecture %q and version %q", name, *arch, version)
+	machineImages := cloudProfileConfig.MachineImages
+
+	capabilitySet, err := findCapabilitySetFromMachineImages(machineImages, name, version, region, arch, machineCapabilities, capabilitiesDefinitions)
+	if err != nil {
+		return nil, fmt.Errorf("could not find an AMI for region %q, image %q, version %q that supports %v: %w", region, name, version, machineCapabilities, err)
+	}
+
+	if capabilitySet != nil && len(capabilitySet.Regions) > 0 && capabilitySet.Regions[0].AMI != "" {
+		return capabilitySet, nil
+	}
+	return nil, fmt.Errorf("could not find an AMI for region %q, image %q, version %q that supports %v", region, name, version, machineCapabilities)
 }
 
-// FindAMIForRegionFromCloudProfile takes a list of machine images, and the desired image name, version, architecture and region. It tries
-// to find the image with the given name, architecture and version in the desired region. If it cannot be found then an error
-// is returned.
-func FindAMIForRegionFromCloudProfile(cloudProfileConfig *api.CloudProfileConfig, imageName, imageVersion, regionName string, arch *string) (string, error) {
-	if cloudProfileConfig != nil {
-		for _, machineImage := range cloudProfileConfig.MachineImages {
-			if machineImage.Name != imageName {
+// FindImageInWorkerStatus takes a list of machine images from the worker status and tries to find the first entry
+// whose name, version, architecture, capabilities and zone matches with the given ones. If no such entry is
+// found then an error will be returned.
+func FindImageInWorkerStatus(machineImages []api.MachineImage, name string, version string, architecture *string, machineCapabilities gardencorev1beta1.Capabilities, capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition) (*api.MachineImage, error) {
+	// If no capabilitiesDefinitions are specified, return the (legacy) architecture format field as no Capabilities are used.
+	if len(capabilitiesDefinitions) == 0 {
+		for _, statusMachineImage := range machineImages {
+			if statusMachineImage.Architecture == nil {
+				statusMachineImage.Architecture = ptr.To(v1beta1constants.ArchitectureAMD64)
+			}
+			if statusMachineImage.Name == name && statusMachineImage.Version == version && ptr.Equal(architecture, statusMachineImage.Architecture) {
+				return &statusMachineImage, nil
+			}
+		}
+		return nil, fmt.Errorf("no machine image found for image %q with version %q and architecture %q", name, version, *architecture)
+	}
+
+	// If capabilitiesDefinitions are specified, we need to find the best matching capability set.
+	for _, statusMachineImage := range machineImages {
+		var statusMachineImageV1alpha1 v1alpha1.MachineImage
+		if err := v1alpha1.Convert_aws_MachineImage_To_v1alpha1_MachineImage(&statusMachineImage, &statusMachineImageV1alpha1, nil); err != nil {
+			return nil, fmt.Errorf("failed to convert machine image: %w", err)
+		}
+		if statusMachineImage.Name == name && statusMachineImage.Version == version && AreCapabilitiesCompatible(statusMachineImageV1alpha1.Capabilities, machineCapabilities, capabilitiesDefinitions) {
+			return &statusMachineImage, nil
+		}
+	}
+	return nil, fmt.Errorf("no machine image found for image %q with version %q and capabilities %v", name, version, machineCapabilities)
+}
+
+func findCapabilitySetFromMachineImages(
+	machineImages []api.MachineImages,
+	imageName, imageVersion, region string,
+	arch *string,
+	machineCapabilities gardencorev1beta1.Capabilities,
+	capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition,
+) (*api.CapabilitySet, error) {
+	for _, machineImage := range machineImages {
+		if machineImage.Name != imageName {
+			continue
+		}
+		for _, version := range machineImage.Versions {
+			if imageVersion != version.Version {
 				continue
 			}
-			for _, version := range machineImage.Versions {
-				if imageVersion != version.Version {
-					continue
-				}
+
+			if len(capabilitiesDefinitions) == 0 {
 				for _, mapping := range version.Regions {
-					if regionName == mapping.Name && ptr.Equal(arch, mapping.Architecture) {
-						return mapping.AMI, nil
+					if region == mapping.Name && ptr.Equal(arch, mapping.Architecture) {
+						return &api.CapabilitySet{
+							Regions:      []api.RegionAMIMapping{mapping},
+							Capabilities: core.Capabilities{},
+						}, nil
 					}
+				}
+				continue
+			}
+
+			bestMatch, err := FindBestCapabilitySet(version.CapabilitySets, machineCapabilities, capabilitiesDefinitions, region)
+			if err != nil {
+				return nil, fmt.Errorf("could not determine best capabilitySet %w", err)
+			}
+
+			return bestMatch, nil
+		}
+	}
+	return nil, nil
+}
+
+// FindBestCapabilitySet finds the most appropriate capability set from the provided capability sets
+// based on the requested machine capabilities and the definitions of capabilities.
+func FindBestCapabilitySet(
+	capabilitySets []api.CapabilitySet,
+	machineCapabilities gardencorev1beta1.Capabilities,
+	capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition,
+	regionName string,
+) (*api.CapabilitySet, error) {
+	compatibleCapabilitySets, err := findCompatibleCapabilitySets(capabilitySets, machineCapabilities, capabilitiesDefinitions, regionName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(compatibleCapabilitySets) == 0 {
+		return nil, fmt.Errorf("no compatible capability set found")
+	}
+
+	// Convert the slice of values to a slice of pointers
+	compatiblePointers := make([]*api.CapabilitySet, len(compatibleCapabilitySets))
+	for i := range compatibleCapabilitySets {
+		compatiblePointers[i] = &compatibleCapabilitySets[i]
+	}
+	bestMatch, err := SelectBestCapabilitySet(compatiblePointers, capabilitiesDefinitions)
+	if err != nil {
+		return nil, err
+	}
+	return bestMatch, nil
+}
+
+// HasCapabilities defines an interface for types that contain Capabilities
+type HasCapabilities interface {
+	GetCapabilities() core.Capabilities
+	SetCapabilities(core.Capabilities)
+}
+
+// TODO @Roncossek move this function gardener/gardener fpr reusability in other extensions
+
+// SelectBestCapabilitySet selects the most appropriate capability set based on the priority
+// of capabilities and their values as defined in capabilitiesDefinitions.
+//
+// Selection follows a priority-based approach:
+// 1. Capabilities are ordered by priority in the definitions list (highest priority first)
+// 2. Within each capability, values are ordered by preference (most preferred first)
+// 3. Selection is determined by the first capability value difference found
+func SelectBestCapabilitySet[T HasCapabilities](
+	compatibleSets []T,
+	capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition,
+) (T, error) {
+	var zeroValue T
+	if len(compatibleSets) == 1 {
+		return compatibleSets[0], nil
+	}
+
+	// Apply capability defaults for better comparison
+	normalizedSets := make([]T, len(compatibleSets))
+	copy(normalizedSets, compatibleSets)
+
+	coreCapabilitiesDefinitions, err := GetCoreCapabilitiesDefinitions(capabilitiesDefinitions)
+	if err != nil {
+		return zeroValue, err
+	}
+
+	// Normalize capability sets by applying defaults
+	for i := range normalizedSets {
+		normalizedSets[i].SetCapabilities(gardencorehelper.GetCapabilitiesWithAppliedDefaults(
+			normalizedSets[i].GetCapabilities(),
+			coreCapabilitiesDefinitions,
+		))
+	}
+
+	// Evaluate capability sets based on capability definitions priority
+	remainingSets := normalizedSets
+
+	// For each capability (in priority order)
+	for _, capabilityDef := range capabilitiesDefinitions {
+		// For each preferred value (in preference order)
+		for _, capabilityValue := range capabilityDef.Values {
+			var setsWithPreferredValue []T
+
+			// Find sets that support this capability value
+			for _, set := range remainingSets {
+				if slices.Contains(set.GetCapabilities()[capabilityDef.Name], capabilityValue) {
+					setsWithPreferredValue = append(setsWithPreferredValue, set)
+				}
+			}
+
+			// If we found sets with this value, narrow down our selection
+			if len(setsWithPreferredValue) > 0 {
+				remainingSets = setsWithPreferredValue
+
+				// If only one set remains, we've found our match
+				if len(remainingSets) == 1 {
+					return remainingSets[0], nil
 				}
 			}
 		}
 	}
 
-	return "", fmt.Errorf("could not find an AMI for region %q, name %q and architecture %q in version %q", regionName, imageName, *arch, imageVersion)
+	// If we couldn't determine a single best match, this indicates a problem with the cloud profile
+	if len(remainingSets) != 1 {
+		return zeroValue, fmt.Errorf("found multiple capability sets with identical capabilities; this indicates an invalid cloudprofile was admitted. Please open a bug report at https://github.com/gardener/gardener/issues")
+	}
+
+	return remainingSets[0], nil
+}
+
+// findCompatibleCapabilitySets returns all capability sets that are compatible with the given machine capabilities.
+func findCompatibleCapabilitySets(
+	capabilitySets []api.CapabilitySet,
+	machineCapabilities gardencorev1beta1.Capabilities,
+	capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition,
+	regionName string,
+) ([]api.CapabilitySet, error) {
+	var compatibleSets []api.CapabilitySet
+
+	for _, capabilitySet := range capabilitySets {
+		var regionAMIMapping *api.RegionAMIMapping
+		for _, region := range capabilitySet.Regions {
+			if region.Name == regionName {
+				regionAMIMapping = &region
+			}
+		}
+		if regionAMIMapping == nil {
+			continue
+		}
+		var v1alphaCapabilitySet v1alpha1.CapabilitySet
+		err := v1alpha1.Convert_aws_CapabilitySet_To_v1alpha1_CapabilitySet(&capabilitySet, &v1alphaCapabilitySet, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert capability set: %w", err)
+		}
+
+		if AreCapabilitiesCompatible(v1alphaCapabilitySet.Capabilities, machineCapabilities, capabilitiesDefinitions) {
+			compatibleSets = append(compatibleSets,
+				api.CapabilitySet{
+					Regions:      []api.RegionAMIMapping{*regionAMIMapping},
+					Capabilities: capabilitySet.Capabilities,
+				})
+		}
+	}
+	return compatibleSets, nil
 }
 
 // FindDataVolumeByName takes a list of data volumes and a data volume name. It tries to find the data volume entry for
@@ -128,13 +333,80 @@ func FindDataVolumeByName(dataVolumes []api.DataVolume, name string) *api.DataVo
 
 // DecodeBackupBucketConfig decodes the `BackupBucketConfig` from the given `RawExtension`.
 func DecodeBackupBucketConfig(decoder runtime.Decoder, config *runtime.RawExtension) (*api.BackupBucketConfig, error) {
-	backupbucketConfig := &api.BackupBucketConfig{}
+	backupBucketConfig := &api.BackupBucketConfig{}
 
 	if config != nil && config.Raw != nil {
-		if err := util.Decode(decoder, config.Raw, backupbucketConfig); err != nil {
+		if err := util.Decode(decoder, config.Raw, backupBucketConfig); err != nil {
 			return nil, err
 		}
 	}
 
-	return backupbucketConfig, nil
+	return backupBucketConfig, nil
+}
+
+// AreCapabilitiesCompatible checks if two sets of capabilities are compatible.
+// It applies defaults from the capability definitions to both sets before checking compatibility.
+// TODO @Roncossek remove this function once the gardener-core is updated to a version that contains it.
+// github.com/gardener/gardener/pkg/apis/core/v1beta1/helper
+func AreCapabilitiesCompatible(capabilities1, capabilities2 gardencorev1beta1.Capabilities, capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition) bool {
+	defaultedCapabilities1 := v1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilities1, capabilitiesDefinitions)
+	defaultedCapabilities2 := v1beta1helper.GetCapabilitiesWithAppliedDefaults(capabilities2, capabilitiesDefinitions)
+
+	isSupported := true
+	commonCapabilities := getCapabilitiesIntersection(defaultedCapabilities1, defaultedCapabilities2)
+	// If the intersection has at least one value for each capability, the capabilities are supported.
+	for _, values := range commonCapabilities {
+		if len(values) == 0 {
+			isSupported = false
+			break
+		}
+	}
+
+	return isSupported
+}
+
+// TODO @Roncossek remove this function once the gardener-core is updated to a version that contains it.
+// github.com/gardener/gardener/pkg/apis/core/v1beta1/helper
+func getCapabilitiesIntersection(capabilitiesList ...gardencorev1beta1.Capabilities) gardencorev1beta1.Capabilities {
+	intersection := make(gardencorev1beta1.Capabilities)
+
+	if len(capabilitiesList) == 0 {
+		return intersection
+	}
+
+	// Initialize intersection with the first capabilities object
+	maps.Copy(intersection, capabilitiesList[0])
+
+	intersect := func(slice1, slice2 []string) []string {
+		elementSet1 := sets.New(slice1...)
+		elementSet2 := sets.New(slice2...)
+
+		return elementSet1.Intersection(elementSet2).UnsortedList()
+	}
+
+	// Iterate through the remaining capabilities objects and refine the intersection
+	for _, capabilities := range capabilitiesList[1:] {
+		for key, values := range intersection {
+			intersection[key] = intersect(values, capabilities[key])
+		}
+	}
+
+	return intersection
+}
+
+// GetCoreCapabilitiesDefinitions function in the helper package.
+// TODO @Roncossek remove this function once the gardener-core is updated to a version that contains it.
+// GetCoreCapabilitiesDefinitions converts v1beta1.CapabilityDefinition objects to core.CapabilityDefinition objects.
+// gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
+func GetCoreCapabilitiesDefinitions(capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition) ([]core.CapabilityDefinition, error) {
+	var coreCapabilitiesDefinitions []core.CapabilityDefinition
+	for _, capabilityDefinition := range capabilitiesDefinitions {
+		var coreCapabilityDefinition core.CapabilityDefinition
+		err := gardencorev1beta1.Convert_v1beta1_CapabilityDefinition_To_core_CapabilityDefinition(&capabilityDefinition, &coreCapabilityDefinition, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert capability definition: %w", err)
+		}
+		coreCapabilitiesDefinitions = append(coreCapabilitiesDefinitions, coreCapabilityDefinition)
+	}
+	return coreCapabilitiesDefinitions, nil
 }

--- a/pkg/apis/aws/helper/helper_test.go
+++ b/pkg/apis/aws/helper/helper_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,43 +72,80 @@ var _ = Describe("Helper", func() {
 		Entry("entry exists", []api.Subnet{{ID: "bar", Purpose: "baz", Zone: "europe"}}, "baz", "europe", &api.Subnet{ID: "bar", Purpose: "baz", Zone: "europe"}, false),
 	)
 
-	DescribeTable("#FindMachineImage",
-		func(machineImages []api.MachineImage, name, version string, arch *string, expectedMachineImage *api.MachineImage, expectErr bool) {
-			machineImage, err := FindMachineImage(machineImages, name, version, arch)
-			expectResults(machineImage, expectedMachineImage, err, expectErr)
-		},
+	DescribeTableSubtree("Select Worker Images", func(hasCapabilities bool) {
+		var capabilitiesDefinitions []v1beta1.CapabilityDefinition
+		var machineCapabilities v1beta1.Capabilities
+		var imageCapabilities *core.Capabilities
+		region := "europe"
 
-		Entry("list is nil", nil, "foo", "1.2.3", ptr.To("foo"), nil, true),
-		Entry("empty list", []api.MachineImage{}, "foo", "1.2.3", ptr.To("foo"), nil, true),
-		Entry("entry not found (no name)", []api.MachineImage{{Name: "bar", Version: "1.2.3"}}, "foo", "1.2.ś", ptr.To("foo"), nil, true),
-		Entry("entry not found (no version)", []api.MachineImage{{Name: "bar", Version: "1.2.3"}}, "foo", "1.2.3", ptr.To("foo"), nil, true),
-		Entry("entry not found (no architecture)", []api.MachineImage{{Name: "bar", Version: "1.2.3", Architecture: ptr.To("bar")}}, "foo", "1.2.3", ptr.To("foo"), nil, true),
-		Entry("entry exists if architecture is nil", []api.MachineImage{{Name: "bar", Version: "1.2.3"}}, "bar", "1.2.3", ptr.To("amd64"), &api.MachineImage{Name: "bar", Version: "1.2.3", Architecture: ptr.To("amd64")}, false),
-		Entry("entry exists", []api.MachineImage{{Name: "bar", Version: "1.2.3", Architecture: ptr.To("foo")}}, "bar", "1.2.3", ptr.To("foo"), &api.MachineImage{Name: "bar", Version: "1.2.3", Architecture: ptr.To("foo")}, false),
-	)
-
-	DescribeTable("#FindAMIForRegion",
-		func(profileImages []api.MachineImages, imageName, version, regionName string, arch *string, expectedAMI string) {
-			cfg := &api.CloudProfileConfig{}
-			cfg.MachineImages = profileImages
-			ami, err := FindAMIForRegionFromCloudProfile(cfg, imageName, version, regionName, arch)
-
-			Expect(ami).To(Equal(expectedAMI))
-			if expectedAMI != "" {
-				Expect(err).NotTo(HaveOccurred())
-			} else {
-				Expect(err).To(HaveOccurred())
+		if hasCapabilities {
+			capabilitiesDefinitions = []v1beta1.CapabilityDefinition{
+				{Name: "architecture", Values: []string{"amd64", "arm64"}},
+				{Name: "capability1", Values: []string{"value1", "value2", "value3"}},
 			}
-		},
+			machineCapabilities = v1beta1.Capabilities{
+				"architecture": []string{"amd64"},
+				"capability1":  []string{"value2"},
+			}
+			imageCapabilities = &core.Capabilities{
+				"architecture": []string{"amd64"},
+				"capability1":  []string{"value2"},
+			}
+		}
 
-		Entry("list is nil", nil, "ubuntu", "1", "europe", ptr.To("foo"), ""),
+		DescribeTable("#FindImageInWorkerStatus",
+			func(machineImages []api.MachineImage, name, version string, arch *string, expectedMachineImage *api.MachineImage, expectErr bool) {
+				if hasCapabilities {
+					machineCapabilities["architecture"] = []string{*arch}
+					if expectedMachineImage != nil {
+						expectedMachineImage.Capabilities = *imageCapabilities
+						expectedMachineImage.Architecture = nil
+					}
+				}
+				machineImage, err := FindImageInWorkerStatus(machineImages, name, version, arch, machineCapabilities, capabilitiesDefinitions)
+				expectResults(machineImage, expectedMachineImage, err, expectErr)
+			},
 
-		Entry("profile empty list", []api.MachineImages{}, "ubuntu", "1", "europe", ptr.To("foo"), ""),
-		Entry("profile entry not found (image does not exist)", makeProfileMachineImages("debian", "1", "europe", "0", ptr.To("foo")), "ubuntu", "1", "europe", ptr.To("foo"), ""),
-		Entry("profile entry not found (version does not exist)", makeProfileMachineImages("ubuntu", "2", "europe", "0", ptr.To("foo")), "ubuntu", "1", "europe", ptr.To("foo"), ""),
-		Entry("profile entry not found (architecture does not exist)", makeProfileMachineImages("ubuntu", "1", "europe", "0", ptr.To("bar")), "ubuntu", "1", "europe", ptr.To("foo"), ""),
-		Entry("profile entry", makeProfileMachineImages("ubuntu", "1", "europe", "ami-1234", ptr.To("foo")), "ubuntu", "1", "europe", ptr.To("foo"), "ami-1234"),
-		Entry("profile non matching region", makeProfileMachineImages("ubuntu", "1", "europe", "ami-1234", ptr.To("foo")), "ubuntu", "1", "china", ptr.To("foo"), ""),
+			Entry("list is nil", nil, "bar", "1.2.3", ptr.To("amd64"), nil, true),
+			Entry("empty list", []api.MachineImage{}, "image", "1.2.3", ptr.To("amd64"), nil, true),
+			Entry("entry not found (no name)", makeStatusMachineImages("bar", "1.2.3", "ami-1234", ptr.To("amd64"), imageCapabilities), "foo", "1.2.3", ptr.To("amd64"), nil, true),
+			Entry("entry not found (no version)", makeStatusMachineImages("bar", "1.2.3", "ami-1234", ptr.To("amd64"), imageCapabilities), "bar", "1.2.ś", ptr.To("amd64"), nil, true),
+			Entry("entry not found (no architecture)", []api.MachineImage{{Name: "bar", Version: "1.2.3", Architecture: ptr.To("arm64"), Capabilities: core.Capabilities{"architecture": []string{"arm64"}}}}, "bar", "1.2.3", ptr.To("amd64"), nil, true),
+			Entry("entry exists if architecture is nil", makeStatusMachineImages("bar", "1.2.3", "ami-1234", nil, imageCapabilities), "bar", "1.2.3", ptr.To("amd64"), &api.MachineImage{Name: "bar", Version: "1.2.3", AMI: "ami-1234", Architecture: ptr.To("amd64")}, false),
+			Entry("entry exists", makeStatusMachineImages("bar", "1.2.3", "ami-1234", ptr.To("amd64"), imageCapabilities), "bar", "1.2.3", ptr.To("amd64"), &api.MachineImage{Name: "bar", Version: "1.2.3", AMI: "ami-1234", Architecture: ptr.To("amd64")}, false),
+		)
+
+		DescribeTable("#FindImageInCloudProfile",
+			func(profileImages []api.MachineImages, imageName, version, regionName string, arch *string, expectedAMI string) {
+				if hasCapabilities {
+					machineCapabilities["architecture"] = []string{*arch}
+				}
+				cfg := &api.CloudProfileConfig{}
+				cfg.MachineImages = profileImages
+
+				capabilitySet, err := FindImageInCloudProfile(cfg, imageName, version, regionName, arch, machineCapabilities, capabilitiesDefinitions)
+
+				if expectedAMI != "" {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(capabilitySet.Regions[0].AMI).To(Equal(expectedAMI))
+				} else {
+					Expect(err).To(HaveOccurred())
+				}
+			},
+
+			Entry("list is nil", nil, "ubuntu", "1", region, ptr.To("amd64"), ""),
+
+			Entry("profile empty list", []api.MachineImages{}, "ubuntu", "1", region, ptr.To("amd64"), ""),
+			Entry("profile entry not found (image does not exist)", makeProfileMachineImages("debian", "1", region, "0", ptr.To("amd64"), imageCapabilities), "ubuntu", "1", region, ptr.To("amd64"), ""),
+			Entry("profile entry not found (version does not exist)", makeProfileMachineImages("ubuntu", "2", region, "0", ptr.To("amd64"), imageCapabilities), "ubuntu", "1", region, ptr.To("amd64"), ""),
+			Entry("profile entry not found (architecture does not exist)", makeProfileMachineImages("ubuntu", "1", region, "0", ptr.To("amd64"), imageCapabilities), "ubuntu", "1", region, ptr.To("arm64"), ""),
+			Entry("profile entry", makeProfileMachineImages("ubuntu", "1", region, "ami-1234", ptr.To("amd64"), imageCapabilities), "ubuntu", "1", region, ptr.To("amd64"), "ami-1234"),
+			Entry("profile non matching region", makeProfileMachineImages("ubuntu", "1", region, "ami-1234", ptr.To("amd64"), imageCapabilities), "ubuntu", "1", "china", ptr.To("amd64"), ""),
+		)
+
+	},
+		Entry("without capabilities", false),
+		Entry("with capabilities", true),
 	)
 
 	DescribeTable("#FindDataVolumeByName",
@@ -186,24 +224,67 @@ func equalBackupBucketConfig(a, b *api.BackupBucketConfig) bool {
 }
 
 //nolint:unparam
-func makeProfileMachineImages(name, version, region, ami string, arch *string) []api.MachineImages {
-	versions := []api.MachineImageVersion{
-		{
-			Version: version,
-			Regions: []api.RegionAMIMapping{
-				{
-					Name:         region,
-					AMI:          ami,
-					Architecture: arch,
+func makeProfileMachineImages(name, version, region, ami string, arch *string, capabilities *core.Capabilities) []api.MachineImages {
+	var versions []api.MachineImageVersion
+	if capabilities == nil {
+		versions = []api.MachineImageVersion{
+			{
+				Version: version,
+				Regions: []api.RegionAMIMapping{
+					{
+						Name:         region,
+						AMI:          ami,
+						Architecture: arch,
+					},
 				},
 			},
-		},
+		}
+	} else {
+		versions = []api.MachineImageVersion{
+			{
+				Version: version,
+				CapabilitySets: []api.CapabilitySet{
+					{
+						Capabilities: *capabilities,
+						Regions: []api.RegionAMIMapping{
+							{
+								Name: region,
+								AMI:  ami,
+							},
+						},
+					},
+				},
+			},
+		}
 	}
 
 	return []api.MachineImages{
 		{
 			Name:     name,
 			Versions: versions,
+		},
+	}
+}
+
+//nolint:unparam
+func makeStatusMachineImages(name, version, ami string, arch *string, capabilities *core.Capabilities) []api.MachineImage {
+	if capabilities != nil {
+		(*capabilities)["architecture"] = []string{ptr.Deref(arch, "")}
+		return []api.MachineImage{
+			{
+				Name:         name,
+				Version:      version,
+				AMI:          ami,
+				Capabilities: *capabilities,
+			},
+		}
+	}
+	return []api.MachineImage{
+		{
+			Name:         name,
+			Version:      version,
+			AMI:          ami,
+			Architecture: arch,
 		},
 	}
 }

--- a/pkg/apis/aws/types_cloudprofile.go
+++ b/pkg/apis/aws/types_cloudprofile.go
@@ -48,6 +48,16 @@ type CapabilitySet struct {
 	Capabilities core.Capabilities
 }
 
+// GetCapabilities returns the Capabilities of a CapabilitySet
+func (cs *CapabilitySet) GetCapabilities() core.Capabilities {
+	return cs.Capabilities
+}
+
+// SetCapabilities sets the Capabilities on a CapabilitySet
+func (cs *CapabilitySet) SetCapabilities(capabilities core.Capabilities) {
+	cs.Capabilities = capabilities
+}
+
 // RegionAMIMapping is a mapping to the correct AMI for the machine image in the given region.
 type RegionAMIMapping struct {
 	// Name is the name of the region.

--- a/pkg/apis/aws/types_cloudprofile.go
+++ b/pkg/apis/aws/types_cloudprofile.go
@@ -5,7 +5,7 @@
 package aws
 
 import (
-	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -45,16 +45,16 @@ type CapabilitySet struct {
 	// Regions is a mapping to the correct AMI for the machine image in the supported regions.
 	Regions []RegionAMIMapping
 	// Capabilities that are supported by the AMIs in this set.
-	Capabilities core.Capabilities
+	Capabilities gardencorev1beta1.Capabilities
 }
 
 // GetCapabilities returns the Capabilities of a CapabilitySet
-func (cs *CapabilitySet) GetCapabilities() core.Capabilities {
+func (cs *CapabilitySet) GetCapabilities() gardencorev1beta1.Capabilities {
 	return cs.Capabilities
 }
 
 // SetCapabilities sets the Capabilities on a CapabilitySet
-func (cs *CapabilitySet) SetCapabilities(capabilities core.Capabilities) {
+func (cs *CapabilitySet) SetCapabilities(capabilities gardencorev1beta1.Capabilities) {
 	cs.Capabilities = capabilities
 }
 

--- a/pkg/apis/aws/types_worker.go
+++ b/pkg/apis/aws/types_worker.go
@@ -5,7 +5,7 @@
 package aws
 
 import (
-	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -100,7 +100,7 @@ type MachineImage struct {
 	// Architecture is the CPU architecture of the machine image.
 	Architecture *string
 	// Capabilities of the machine image.
-	Capabilities core.Capabilities
+	Capabilities gardencorev1beta1.Capabilities
 }
 
 // VolumeType is a constant for volume types.

--- a/pkg/apis/aws/types_worker.go
+++ b/pkg/apis/aws/types_worker.go
@@ -5,6 +5,7 @@
 package aws
 
 import (
+	"github.com/gardener/gardener/pkg/apis/core"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -98,6 +99,8 @@ type MachineImage struct {
 	AMI string
 	// Architecture is the CPU architecture of the machine image.
 	Architecture *string
+	// Capabilities of the machine image.
+	Capabilities core.Capabilities
 }
 
 // VolumeType is a constant for volume types.

--- a/pkg/apis/aws/v1alpha1/types_worker.go
+++ b/pkg/apis/aws/v1alpha1/types_worker.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -110,6 +111,8 @@ type MachineImage struct {
 	// Architecture is the CPU architecture of the machine image.
 	// +optional
 	Architecture *string `json:"architecture,omitempty"`
+	// Capabilities of the machine image.
+	Capabilities gardencorev1beta1.Capabilities `json:"capabilities,omitempty"`
 }
 
 // VolumeType is a constant for volume types.

--- a/pkg/apis/aws/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.conversion.go
@@ -13,7 +13,6 @@ import (
 	unsafe "unsafe"
 
 	aws "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
-	core "github.com/gardener/gardener/pkg/apis/core"
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
@@ -422,7 +421,7 @@ func Convert_aws_BackupBucketConfig_To_v1alpha1_BackupBucketConfig(in *aws.Backu
 
 func autoConvert_v1alpha1_CapabilitySet_To_aws_CapabilitySet(in *CapabilitySet, out *aws.CapabilitySet, s conversion.Scope) error {
 	out.Regions = *(*[]aws.RegionAMIMapping)(unsafe.Pointer(&in.Regions))
-	out.Capabilities = *(*core.Capabilities)(unsafe.Pointer(&in.Capabilities))
+	out.Capabilities = *(*v1beta1.Capabilities)(unsafe.Pointer(&in.Capabilities))
 	return nil
 }
 
@@ -897,7 +896,7 @@ func autoConvert_v1alpha1_MachineImage_To_aws_MachineImage(in *MachineImage, out
 	out.Version = in.Version
 	out.AMI = in.AMI
 	out.Architecture = (*string)(unsafe.Pointer(in.Architecture))
-	out.Capabilities = *(*core.Capabilities)(unsafe.Pointer(&in.Capabilities))
+	out.Capabilities = *(*v1beta1.Capabilities)(unsafe.Pointer(&in.Capabilities))
 	return nil
 }
 

--- a/pkg/apis/aws/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.conversion.go
@@ -897,6 +897,7 @@ func autoConvert_v1alpha1_MachineImage_To_aws_MachineImage(in *MachineImage, out
 	out.Version = in.Version
 	out.AMI = in.AMI
 	out.Architecture = (*string)(unsafe.Pointer(in.Architecture))
+	out.Capabilities = *(*core.Capabilities)(unsafe.Pointer(&in.Capabilities))
 	return nil
 }
 
@@ -910,6 +911,7 @@ func autoConvert_aws_MachineImage_To_v1alpha1_MachineImage(in *aws.MachineImage,
 	out.Version = in.Version
 	out.AMI = in.AMI
 	out.Architecture = (*string)(unsafe.Pointer(in.Architecture))
+	out.Capabilities = *(*v1beta1.Capabilities)(unsafe.Pointer(&in.Capabilities))
 	return nil
 }
 

--- a/pkg/apis/aws/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/aws/v1alpha1/zz_generated.deepcopy.go
@@ -578,6 +578,21 @@ func (in *MachineImage) DeepCopyInto(out *MachineImage) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Capabilities != nil {
+		in, out := &in.Capabilities, &out.Capabilities
+		*out = make(v1beta1.Capabilities, len(*in))
+		for key, val := range *in {
+			var outVal []string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make(v1beta1.CapabilityValues, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
+		}
+	}
 	return
 }
 

--- a/pkg/apis/aws/validation/cloudprofile.go
+++ b/pkg/apis/aws/validation/cloudprofile.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -158,12 +158,12 @@ func validateMachineImageMapping(machineImages []core.MachineImage, cpConfig *ap
 				if err := gardencoreapi.Scheme.Convert(&version, &v1beta1Version, nil); err != nil {
 					return append(allErrs, field.InternalError(machineImageVersionPath, err))
 				}
-				defaultedCapabilitySets := v1beta1helper.GetCapabilitySetsWithAppliedDefaults(v1beta1Version.CapabilitySets, capabilitiesDefinitions)
+				defaultedCapabilitySets := gardencorev1beta1helper.GetCapabilitySetsWithAppliedDefaults(v1beta1Version.CapabilitySets, capabilitiesDefinitions)
 				for idxCapability, defaultedCapabilitySet := range defaultedCapabilitySets {
 					isFound := false
 					// search for the corresponding imageVersion.CapabilitySet
 					for _, providerCapabilitySet := range imageVersion.CapabilitySets {
-						providerDefaultedCapabilities := v1beta1helper.GetCapabilitiesWithAppliedDefaults(providerCapabilitySet.Capabilities, capabilitiesDefinitions)
+						providerDefaultedCapabilities := gardencorev1beta1helper.GetCapabilitiesWithAppliedDefaults(providerCapabilitySet.Capabilities, capabilitiesDefinitions)
 						if helper.AreCapabilitiesEqual(defaultedCapabilitySet.Capabilities, providerDefaultedCapabilities) {
 							isFound = true
 						}

--- a/pkg/apis/aws/validation/cloudprofile.go
+++ b/pkg/apis/aws/validation/cloudprofile.go
@@ -9,19 +9,22 @@ import (
 	"maps"
 	"slices"
 
+	gardencoreapi "github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/core"
-	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
 	apisaws "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 )
 
 // ValidateCloudProfileConfig validates a CloudProfileConfig object.
-func ValidateCloudProfileConfig(cpConfig *apisaws.CloudProfileConfig, machineImages []core.MachineImage, capabilitiesDefinitions []core.CapabilityDefinition, fldPath *field.Path) field.ErrorList {
+func ValidateCloudProfileConfig(cpConfig *apisaws.CloudProfileConfig, machineImages []core.MachineImage, capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	machineImagesPath := fldPath.Child("machineImages")
@@ -38,7 +41,7 @@ func ValidateCloudProfileConfig(cpConfig *apisaws.CloudProfileConfig, machineIma
 }
 
 // ValidateProviderMachineImage validates a CloudProfileConfig MachineImages entry.
-func ValidateProviderMachineImage(validationPath *field.Path, providerImage apisaws.MachineImages, capabilitiesDefinitions []core.CapabilityDefinition) field.ErrorList {
+func ValidateProviderMachineImage(validationPath *field.Path, providerImage apisaws.MachineImages, capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition) field.ErrorList {
 	allErrs := field.ErrorList{}
 	hasCloudProfileCapabilities := len(capabilitiesDefinitions) > 0
 
@@ -59,7 +62,7 @@ func ValidateProviderMachineImage(validationPath *field.Path, providerImage apis
 		if hasCloudProfileCapabilities {
 			for k, capabilitySet := range version.CapabilitySets {
 				kdxPath := jdxPath.Child("capabilitySets").Index(k)
-				allErrs = append(allErrs, gutil.ValidateCapabilities(capabilitySet.Capabilities, capabilitiesDefinitions, kdxPath.Child("capabilities"))...)
+				allErrs = append(allErrs, helper.ValidateCapabilities(capabilitySet.Capabilities, capabilitiesDefinitions, kdxPath.Child("capabilities"))...)
 				allErrs = append(allErrs, validateRegions(capabilitySet.Regions, providerImage.Name, version.Version, hasCloudProfileCapabilities, kdxPath)...)
 			}
 			if len(version.Regions) > 0 {
@@ -121,7 +124,7 @@ func NewProviderImagesContext(providerImages []apisaws.MachineImages) *gutil.Ima
 }
 
 // validateMachineImageMapping validates that for each machine image there is a corresponding cpConfig image.
-func validateMachineImageMapping(machineImages []core.MachineImage, cpConfig *apisaws.CloudProfileConfig, capabilitiesDefinitions []core.CapabilityDefinition, fldPath *field.Path) field.ErrorList {
+func validateMachineImageMapping(machineImages []core.MachineImage, cpConfig *apisaws.CloudProfileConfig, capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	providerImages := NewProviderImagesContext(cpConfig.MachineImages)
 
@@ -151,22 +154,23 @@ func validateMachineImageMapping(machineImages []core.MachineImage, cpConfig *ap
 					))
 					continue
 				}
-
-				coreDefaultedCapabilitySets := gardencorehelper.GetCapabilitySetsWithAppliedDefaults(version.CapabilitySets, capabilitiesDefinitions)
-
-				for idxCapability, coreDefaultedCapabilitySet := range coreDefaultedCapabilitySets {
+				var v1beta1Version gardencorev1beta1.MachineImageVersion
+				if err := gardencoreapi.Scheme.Convert(&version, &v1beta1Version, nil); err != nil {
+					return append(allErrs, field.InternalError(machineImageVersionPath, err))
+				}
+				defaultedCapabilitySets := v1beta1helper.GetCapabilitySetsWithAppliedDefaults(v1beta1Version.CapabilitySets, capabilitiesDefinitions)
+				for idxCapability, defaultedCapabilitySet := range defaultedCapabilitySets {
 					isFound := false
 					// search for the corresponding imageVersion.CapabilitySet
 					for _, providerCapabilitySet := range imageVersion.CapabilitySets {
-						providerDefaultedCapabilities := gardencorehelper.GetCapabilitiesWithAppliedDefaults(providerCapabilitySet.Capabilities, capabilitiesDefinitions)
-						if gutil.AreCapabilitiesEqual(coreDefaultedCapabilitySet.Capabilities, providerDefaultedCapabilities) {
+						providerDefaultedCapabilities := v1beta1helper.GetCapabilitiesWithAppliedDefaults(providerCapabilitySet.Capabilities, capabilitiesDefinitions)
+						if helper.AreCapabilitiesEqual(defaultedCapabilitySet.Capabilities, providerDefaultedCapabilities) {
 							isFound = true
 						}
 					}
 					if !isFound {
 						allErrs = append(allErrs, field.Required(machineImageVersionPath.Child("capabilitySets").Index(idxCapability),
-							fmt.Sprintf("missing providerConfig mapping for machine image version %s@%s and capabilitySet %v",
-								machineImage.Name, version.Version, coreDefaultedCapabilitySet.Capabilities)))
+							fmt.Sprintf("missing providerConfig mapping for machine image version %s@%s and capabilitySet %v", machineImage.Name, version.Version, defaultedCapabilitySet.Capabilities)))
 					}
 				}
 				continue
@@ -177,16 +181,12 @@ func validateMachineImageMapping(machineImages []core.MachineImage, cpConfig *ap
 				imageVersion, exists := providerImages.GetImageVersion(machineImage.Name, version.Version)
 				if !exists {
 					allErrs = append(allErrs, field.Required(machineImageVersionPath,
-						fmt.Sprintf("machine image version %s@%s is not defined in the providerConfig",
-							machineImage.Name, version.Version),
-					))
+						fmt.Sprintf("machine image version %s@%s is not defined in the providerConfig", machineImage.Name, version.Version)))
 					continue
 				}
 				// validate machine image version architectures
 				if !slices.Contains(v1beta1constants.ValidArchitectures, expectedArchitecture) {
-					allErrs = append(allErrs, field.NotSupported(
-						machineImageVersionPath.Child("architectures"),
-						expectedArchitecture, v1beta1constants.ValidArchitectures))
+					allErrs = append(allErrs, field.NotSupported(machineImageVersionPath.Child("architectures"), expectedArchitecture, v1beta1constants.ValidArchitectures))
 				}
 
 				// validate that machine image version with architecture x exists in cpConfig
@@ -197,9 +197,7 @@ func validateMachineImageMapping(machineImages []core.MachineImage, cpConfig *ap
 				architectures := slices.Collect(maps.Keys(architecturesMap))
 				if !slices.Contains(architectures, expectedArchitecture) {
 					allErrs = append(allErrs, field.Required(machineImageVersionPath,
-						fmt.Sprintf("missing providerConfig mapping for machine image version %s@%s and architecture: %s",
-							machineImage.Name, version.Version, expectedArchitecture),
-					))
+						fmt.Sprintf("missing providerConfig mapping for machine image version %s@%s and architecture: %s", machineImage.Name, version.Version, expectedArchitecture)))
 					continue
 				}
 			}

--- a/pkg/apis/aws/validation/cloudprofile_test.go
+++ b/pkg/apis/aws/validation/cloudprofile_test.go
@@ -6,6 +6,7 @@ package validation_test
 
 import (
 	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -21,7 +22,7 @@ import (
 var _ = Describe("CloudProfileConfig validation", func() {
 	DescribeTableSubtree("#ValidateCloudProfileConfig", func(isCapabilitiesCloudProfile bool) {
 		var (
-			capabilitiesDefinitions []core.CapabilityDefinition
+			capabilitiesDefinitions []v1beta1.CapabilityDefinition
 			cloudProfileConfig      *apisaws.CloudProfileConfig
 			machineImages           []core.MachineImage
 			machineImageName        string
@@ -37,13 +38,13 @@ var _ = Describe("CloudProfileConfig validation", func() {
 			var capabilitySets []apisaws.CapabilitySet
 
 			if isCapabilitiesCloudProfile {
-				capabilitiesDefinitions = []core.CapabilityDefinition{{
+				capabilitiesDefinitions = []v1beta1.CapabilityDefinition{{
 					Name:   v1beta1constants.ArchitectureName,
 					Values: []string{v1beta1constants.ArchitectureAMD64},
 				}}
 				capabilitySets = []apisaws.CapabilitySet{{
 					Regions: regions,
-					Capabilities: core.Capabilities{
+					Capabilities: v1beta1.Capabilities{
 						v1beta1constants.ArchitectureName: []string{v1beta1constants.ArchitectureAMD64},
 					}}}
 				regions = nil
@@ -158,7 +159,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 						Version: "1.2.3",
 						CapabilitySets: []apisaws.CapabilitySet{{
 							Regions:      []apisaws.RegionAMIMapping{{}},
-							Capabilities: core.Capabilities{v1beta1constants.ArchitectureName: {v1beta1constants.ArchitectureAMD64}},
+							Capabilities: v1beta1.Capabilities{v1beta1constants.ArchitectureName: {v1beta1constants.ArchitectureAMD64}},
 						}},
 					}
 				} else {

--- a/pkg/apis/aws/zz_generated.deepcopy.go
+++ b/pkg/apis/aws/zz_generated.deepcopy.go
@@ -594,6 +594,21 @@ func (in *MachineImage) DeepCopyInto(out *MachineImage) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Capabilities != nil {
+		in, out := &in.Capabilities, &out.Capabilities
+		*out = make(core.Capabilities, len(*in))
+		for key, val := range *in {
+			var outVal []string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make(core.CapabilityValues, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
+		}
+	}
 	return
 }
 

--- a/pkg/apis/aws/zz_generated.deepcopy.go
+++ b/pkg/apis/aws/zz_generated.deepcopy.go
@@ -10,7 +10,7 @@
 package aws
 
 import (
-	core "github.com/gardener/gardener/pkg/apis/core"
+	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -57,14 +57,14 @@ func (in *CapabilitySet) DeepCopyInto(out *CapabilitySet) {
 	}
 	if in.Capabilities != nil {
 		in, out := &in.Capabilities, &out.Capabilities
-		*out = make(core.Capabilities, len(*in))
+		*out = make(v1beta1.Capabilities, len(*in))
 		for key, val := range *in {
 			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
 				in, out := &val, &outVal
-				*out = make(core.CapabilityValues, len(*in))
+				*out = make(v1beta1.CapabilityValues, len(*in))
 				copy(*out, *in)
 			}
 			(*out)[key] = outVal
@@ -596,14 +596,14 @@ func (in *MachineImage) DeepCopyInto(out *MachineImage) {
 	}
 	if in.Capabilities != nil {
 		in, out := &in.Capabilities, &out.Capabilities
-		*out = make(core.Capabilities, len(*in))
+		*out = make(v1beta1.Capabilities, len(*in))
 		for key, val := range *in {
 			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
 				in, out := &val, &outVal
-				*out = make(core.CapabilityValues, len(*in))
+				*out = make(v1beta1.CapabilityValues, len(*in))
 				copy(*out, *in)
 			}
 			(*out)[key] = outVal

--- a/pkg/controller/worker/machine_images.go
+++ b/pkg/controller/worker/machine_images.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
@@ -82,10 +82,10 @@ func appendMachineImage(machineImages []api.MachineImage, machineImage api.Machi
 		})
 	}
 
-	defaultedCapabilities := v1beta1helper.GetCapabilitiesWithAppliedDefaults(machineImage.Capabilities, capabilitiesDefinitions)
+	defaultedCapabilities := gardencorev1beta1helper.GetCapabilitiesWithAppliedDefaults(machineImage.Capabilities, capabilitiesDefinitions)
 
 	for _, existingMachineImage := range machineImages {
-		existingDefaultedCapabilities := v1beta1helper.GetCapabilitiesWithAppliedDefaults(existingMachineImage.Capabilities, capabilitiesDefinitions)
+		existingDefaultedCapabilities := gardencorev1beta1helper.GetCapabilitiesWithAppliedDefaults(existingMachineImage.Capabilities, capabilitiesDefinitions)
 		if existingMachineImage.Name == machineImage.Name && existingMachineImage.Version == machineImage.Version && helper.AreCapabilitiesEqual(defaultedCapabilities, existingDefaultedCapabilities) {
 			// If the image already exists with the same capabilities return the existing list.
 			return machineImages

--- a/pkg/controller/worker/machine_images.go
+++ b/pkg/controller/worker/machine_images.go
@@ -9,10 +9,8 @@ import (
 	"fmt"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
-	"github.com/gardener/gardener/pkg/apis/core"
-	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gutil "github.com/gardener/gardener/pkg/utils/gardener"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
@@ -67,7 +65,7 @@ func (w *WorkerDelegate) selectMachineImageForWorkerPool(name, version string, r
 	return nil, worker.ErrorMachineImageNotFound(name, version, *arch, region)
 }
 
-func appendMachineImage(machineImages []api.MachineImage, machineImage api.MachineImage, capabilitiesDefinitions []core.CapabilityDefinition) []api.MachineImage {
+func appendMachineImage(machineImages []api.MachineImage, machineImage api.MachineImage, capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition) []api.MachineImage {
 	// support for cloudprofile machine images without capabilities
 	if len(capabilitiesDefinitions) == 0 {
 		for _, image := range machineImages {
@@ -84,11 +82,11 @@ func appendMachineImage(machineImages []api.MachineImage, machineImage api.Machi
 		})
 	}
 
-	defaultedCapabilities := gardencorehelper.GetCapabilitiesWithAppliedDefaults(machineImage.Capabilities, capabilitiesDefinitions)
+	defaultedCapabilities := v1beta1helper.GetCapabilitiesWithAppliedDefaults(machineImage.Capabilities, capabilitiesDefinitions)
 
 	for _, existingMachineImage := range machineImages {
-		existingDefaultedCapabilities := gardencorehelper.GetCapabilitiesWithAppliedDefaults(existingMachineImage.Capabilities, capabilitiesDefinitions)
-		if existingMachineImage.Name == machineImage.Name && existingMachineImage.Version == machineImage.Version && gutil.AreCapabilitiesEqual(defaultedCapabilities, existingDefaultedCapabilities) {
+		existingDefaultedCapabilities := v1beta1helper.GetCapabilitiesWithAppliedDefaults(existingMachineImage.Capabilities, capabilitiesDefinitions)
+		if existingMachineImage.Name == machineImage.Name && existingMachineImage.Version == machineImage.Version && helper.AreCapabilitiesEqual(defaultedCapabilities, existingDefaultedCapabilities) {
 			// If the image already exists with the same capabilities return the existing list.
 			return machineImages
 		}

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -16,7 +16,6 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
-	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -1495,14 +1494,14 @@ var _ = Describe("Machines", func() {
 
 		})
 	})
-	DescribeTable("EnsureUniformMachineImages", func(capabilitiesDefinitions []core.CapabilityDefinition, expectedImages []api.MachineImage) {
+	DescribeTable("EnsureUniformMachineImages", func(capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition, expectedImages []api.MachineImage) {
 		machineImages := []api.MachineImage{
 			// images with capability sets
 			{
 				Name:    "some-image",
 				Version: "1.2.1",
 				AMI:     "ami-for-arm64",
-				Capabilities: core.Capabilities{
+				Capabilities: gardencorev1beta1.Capabilities{
 					v1beta1constants.ArchitectureName: []string{v1beta1constants.ArchitectureARM64},
 				},
 			},
@@ -1510,7 +1509,7 @@ var _ = Describe("Machines", func() {
 				Name:    "some-image",
 				Version: "1.2.2",
 				AMI:     "ami-for-amd64",
-				Capabilities: core.Capabilities{
+				Capabilities: gardencorev1beta1.Capabilities{
 					v1beta1constants.ArchitectureName: []string{v1beta1constants.ArchitectureAMD64},
 				},
 			},
@@ -1566,7 +1565,7 @@ var _ = Describe("Machines", func() {
 				Architecture: ptr.To(v1beta1constants.ArchitectureAMD64),
 			},
 		}),
-		Entry("should return images with Capabilities", []core.CapabilityDefinition{{
+		Entry("should return images with Capabilities", []gardencorev1beta1.CapabilityDefinition{{
 			Name:   v1beta1constants.ArchitectureName,
 			Values: []string{v1beta1constants.ArchitectureAMD64, v1beta1constants.ArchitectureARM64},
 		}}, []api.MachineImage{
@@ -1575,7 +1574,7 @@ var _ = Describe("Machines", func() {
 				Name:    "some-image",
 				Version: "1.2.1",
 				AMI:     "ami-for-arm64",
-				Capabilities: core.Capabilities{
+				Capabilities: gardencorev1beta1.Capabilities{
 					v1beta1constants.ArchitectureName: []string{v1beta1constants.ArchitectureARM64},
 				},
 			},
@@ -1583,7 +1582,7 @@ var _ = Describe("Machines", func() {
 				Name:    "some-image",
 				Version: "1.2.2",
 				AMI:     "ami-for-amd64",
-				Capabilities: core.Capabilities{
+				Capabilities: gardencorev1beta1.Capabilities{
 					v1beta1constants.ArchitectureName: []string{v1beta1constants.ArchitectureAMD64},
 				},
 			},
@@ -1592,14 +1591,14 @@ var _ = Describe("Machines", func() {
 				Name:    "some-image",
 				Version: "1.2.3",
 				AMI:     "ami-for-amd64",
-				Capabilities: core.Capabilities{
+				Capabilities: gardencorev1beta1.Capabilities{
 					v1beta1constants.ArchitectureName: []string{v1beta1constants.ArchitectureAMD64},
 				}},
 			{
 				Name:    "some-image",
 				Version: "1.2.1",
 				AMI:     "ami-for-amd64",
-				Capabilities: core.Capabilities{
+				Capabilities: gardencorev1beta1.Capabilities{
 					v1beta1constants.ArchitectureName: []string{v1beta1constants.ArchitectureAMD64},
 				},
 			},

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Machines", func() {
 	Context("WorkerDelegate", func() {
 		workerDelegate, _ := NewWorkerDelegate(nil, nil, nil, nil, "", nil, nil)
 
-		Describe("#GenerateMachineDeployments, #DeployMachineClasses", func() {
+		DescribeTableSubtree("#GenerateMachineDeployments, #DeployMachineClasses", func(isCapabilitiesCloudProfile bool) {
 			var (
 				namespace        string
 				cloudProfileName string
@@ -79,14 +79,14 @@ var _ = Describe("Machines", func() {
 				machineImageVersion string
 				machineImageAMI     string
 
-				vpcID                 string
-				machineType           string
-				userData              []byte
-				userDataSecretName    string
-				userDataSecretDataKey string
-				instanceProfileName   string
-				securityGroupID       string
-				keyName               string
+				vpcID                       string
+				machineType, machineTypeArm string
+				userData                    []byte
+				userDataSecretName          string
+				userDataSecretDataKey       string
+				instanceProfileName         string
+				securityGroupID             string
+				keyName                     string
 
 				archAMD  string
 				archARM  string
@@ -147,17 +147,31 @@ var _ = Describe("Machines", func() {
 				workerPoolHash2 string
 				workerPoolHash3 string
 
-				shootVersionMajorMinor       string
-				shootVersion                 string
-				scheme                       *runtime.Scheme
-				decoder                      runtime.Decoder
-				clusterWithoutImages         *extensionscontroller.Cluster
-				cluster                      *extensionscontroller.Cluster
-				infrastructureProviderStatus *api.InfrastructureStatus
-				w                            *extensionsv1alpha1.Worker
+				shootVersionMajorMinor           string
+				shootVersion                     string
+				scheme                           *runtime.Scheme
+				decoder                          runtime.Decoder
+				clusterWithoutImages             *extensionscontroller.Cluster
+				cluster                          *extensionscontroller.Cluster
+				infrastructureProviderStatus     *api.InfrastructureStatus
+				w                                *extensionsv1alpha1.Worker
+				capabilitiesAmd, capabilitiesArm gardencorev1beta1.Capabilities
+				capabilityDefinitions            []gardencorev1beta1.CapabilityDefinition
 			)
 
 			BeforeEach(func() {
+				if isCapabilitiesCloudProfile {
+					capabilityDefinitions = []gardencorev1beta1.CapabilityDefinition{
+						{Name: "some-capability", Values: []string{"a", "b", "c"}},
+						{Name: v1beta1constants.ArchitectureName, Values: []string{v1beta1constants.ArchitectureAMD64, v1beta1constants.ArchitectureARM64}},
+					}
+					capabilitiesAmd = gardencorev1beta1.Capabilities{
+						v1beta1constants.ArchitectureName: []string{v1beta1constants.ArchitectureAMD64},
+					}
+					capabilitiesArm = gardencorev1beta1.Capabilities{
+						v1beta1constants.ArchitectureName: []string{v1beta1constants.ArchitectureARM64},
+					}
+				}
 				namespace = "shoot--foobar--aws"
 				cloudProfileName = "aws"
 
@@ -169,6 +183,7 @@ var _ = Describe("Machines", func() {
 
 				vpcID = "vpc-1234"
 				machineType = "large"
+				machineTypeArm = "large-arm"
 				userData = []byte("some-user-data")
 				userDataSecretName = "userdata-secret-name"
 				userDataSecretDataKey = "userdata-secret-key"
@@ -243,14 +258,14 @@ var _ = Describe("Machines", func() {
 
 				nodeTemplatePool2Zone1 = machinev1alpha1.NodeTemplate{
 					Capacity:     nodeCapacity,
-					InstanceType: machineType,
+					InstanceType: machineTypeArm,
 					Region:       region,
 					Zone:         zone1,
 					Architecture: &archARM,
 				}
 				nodeTemplatePool2Zone2 = machinev1alpha1.NodeTemplate{
 					Capacity:     nodeCapacity,
-					InstanceType: machineType,
+					InstanceType: machineTypeArm,
 					Region:       region,
 					Zone:         zone2,
 					Architecture: &archARM,
@@ -258,14 +273,14 @@ var _ = Describe("Machines", func() {
 
 				nodeTemplatePool3Zone1 = machinev1alpha1.NodeTemplate{
 					Capacity:     nodeCapacity,
-					InstanceType: machineType,
+					InstanceType: machineTypeArm,
 					Region:       region,
 					Zone:         zone1,
 					Architecture: &archARM,
 				}
 				nodeTemplatePool3Zone2 = machinev1alpha1.NodeTemplate{
 					Capacity:     nodeCapacity,
-					InstanceType: machineType,
+					InstanceType: machineTypeArm,
 					Region:       region,
 					Zone:         zone2,
 					Architecture: &archARM,
@@ -286,12 +301,39 @@ var _ = Describe("Machines", func() {
 					},
 				}
 
-				cloudProfileConfig := &apiv1alpha1.CloudProfileConfig{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-						Kind:       "CloudProfileConfig",
+				machineImages := []apiv1alpha1.MachineImages{
+					{
+						Name: machineImageName,
+						Versions: []apiv1alpha1.MachineImageVersion{
+							{
+								Version: machineImageVersion,
+								CapabilitySets: []apiv1alpha1.CapabilitySet{
+									{
+										Capabilities: capabilitiesAmd,
+										Regions: []apiv1alpha1.RegionAMIMapping{
+											{
+												Name: region,
+												AMI:  machineImageAMI,
+											},
+										},
+									},
+									{
+										Capabilities: capabilitiesArm,
+										Regions: []apiv1alpha1.RegionAMIMapping{
+											{
+												Name: region,
+												AMI:  machineImageAMI,
+											},
+										},
+									},
+								},
+							},
+						},
 					},
-					MachineImages: []apiv1alpha1.MachineImages{
+				}
+
+				if !isCapabilitiesCloudProfile {
+					machineImages = []apiv1alpha1.MachineImages{
 						{
 							Name: machineImageName,
 							Versions: []apiv1alpha1.MachineImageVersion{
@@ -306,8 +348,7 @@ var _ = Describe("Machines", func() {
 									},
 								},
 							},
-						},
-						{
+						}, {
 							Name: machineImageName,
 							Versions: []apiv1alpha1.MachineImageVersion{
 								{
@@ -322,7 +363,15 @@ var _ = Describe("Machines", func() {
 								},
 							},
 						},
+					}
+				}
+
+				cloudProfileConfig := &apiv1alpha1.CloudProfileConfig{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "CloudProfileConfig",
 					},
+					MachineImages: machineImages,
 				}
 				cloudProfileConfigJSON, _ := json.Marshal(cloudProfileConfig)
 				cluster = &extensionscontroller.Cluster{
@@ -331,9 +380,16 @@ var _ = Describe("Machines", func() {
 							Name: cloudProfileName,
 						},
 						Spec: gardencorev1beta1.CloudProfileSpec{
+							Capabilities: capabilityDefinitions,
 							MachineTypes: []gardencorev1beta1.MachineType{
 								{
-									Name: machineType,
+									Name:         machineType,
+									Capabilities: capabilitiesAmd,
+								},
+								{
+									Name:         machineTypeArm,
+									Architecture: ptr.To(archARM),
+									Capabilities: capabilitiesArm,
 								},
 							},
 							ProviderConfig: &runtime.RawExtension{
@@ -467,7 +523,7 @@ var _ = Describe("Machines", func() {
 								Priority:       ptr.To(priorityPool2),
 								MaxSurge:       maxSurgePool2,
 								MaxUnavailable: maxUnavailablePool2,
-								MachineType:    machineType,
+								MachineType:    machineTypeArm,
 								NodeTemplate: &extensionsv1alpha1.NodeTemplate{
 									Capacity: nodeCapacity,
 								},
@@ -499,7 +555,7 @@ var _ = Describe("Machines", func() {
 								Priority:       ptr.To(priorityPool2),
 								MaxSurge:       maxSurgePool2,
 								MaxUnavailable: maxUnavailablePool2,
-								MachineType:    machineType,
+								MachineType:    machineTypeArm,
 								NodeTemplate: &extensionsv1alpha1.NodeTemplate{
 									Capacity: nodeCapacity,
 								},
@@ -568,9 +624,8 @@ var _ = Describe("Machines", func() {
 						"secret": map[string]interface{}{
 							"cloudConfig": string(userData),
 						},
-						"ami":         machineImageAMI,
-						"region":      region,
-						"machineType": machineType,
+						"ami":    machineImageAMI,
+						"region": region,
 						"iamInstanceProfile": map[string]interface{}{
 							"name": instanceProfileName,
 						},
@@ -671,11 +726,22 @@ var _ = Describe("Machines", func() {
 					machineClassPool1Zone2["blockDevices"] = machineClassPool1BlockDevices
 
 					machineClassPool1Zone1 = addKeyValueToMap(machineClassPool1Zone1, "labels", map[string]string{corev1.LabelZoneFailureDomain: zone1})
+					machineClassPool1Zone1 = addKeyValueToMap(machineClassPool1Zone1, "machineType", machineType)
+
 					machineClassPool1Zone2 = addKeyValueToMap(machineClassPool1Zone2, "labels", map[string]string{corev1.LabelZoneFailureDomain: zone2})
+					machineClassPool1Zone2 = addKeyValueToMap(machineClassPool1Zone2, "machineType", machineType)
+
 					machineClassPool2Zone1 = addKeyValueToMap(machineClassPool2Zone1, "labels", map[string]string{corev1.LabelZoneFailureDomain: zone1})
+					machineClassPool2Zone1 = addKeyValueToMap(machineClassPool2Zone1, "machineType", machineTypeArm)
+
 					machineClassPool2Zone2 = addKeyValueToMap(machineClassPool2Zone2, "labels", map[string]string{corev1.LabelZoneFailureDomain: zone2})
+					machineClassPool2Zone2 = addKeyValueToMap(machineClassPool2Zone2, "machineType", machineTypeArm)
+
 					machineClassPool3Zone1 = addKeyValueToMap(machineClassPool3Zone1, "labels", map[string]string{corev1.LabelZoneFailureDomain: zone1})
+					machineClassPool3Zone1 = addKeyValueToMap(machineClassPool3Zone1, "machineType", machineTypeArm)
+
 					machineClassPool3Zone2 = addKeyValueToMap(machineClassPool3Zone2, "labels", map[string]string{corev1.LabelZoneFailureDomain: zone2})
+					machineClassPool3Zone2 = addKeyValueToMap(machineClassPool3Zone2, "machineType", machineTypeArm)
 
 					var (
 						machineClassNamePool1Zone1 = fmt.Sprintf("%s-%s-z1", namespace, namePool1)
@@ -903,13 +969,22 @@ var _ = Describe("Machines", func() {
 					err := workerDelegate.DeployMachineClasses(ctx)
 					Expect(err).NotTo(HaveOccurred())
 
-					// Test WorkerDelegate.UpdateMachineDeployments()
-					expectedImages := &apiv1alpha1.WorkerStatus{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-							Kind:       "WorkerStatus",
+					machineImages := []apiv1alpha1.MachineImage{
+						{
+							Name:         machineImageName,
+							Version:      machineImageVersion,
+							AMI:          machineImageAMI,
+							Capabilities: capabilitiesAmd,
 						},
-						MachineImages: []apiv1alpha1.MachineImage{
+						{
+							Name:         machineImageName,
+							Version:      machineImageVersion,
+							AMI:          machineImageAMI,
+							Capabilities: capabilitiesArm,
+						},
+					}
+					if !isCapabilitiesCloudProfile {
+						machineImages = []apiv1alpha1.MachineImage{
 							{
 								Name:         machineImageName,
 								Version:      machineImageVersion,
@@ -922,7 +997,16 @@ var _ = Describe("Machines", func() {
 								AMI:          machineImageAMI,
 								Architecture: ptr.To(archARM),
 							},
+						}
+					}
+
+					// Test WorkerDelegate.UpdateMachineDeployments()
+					expectedImages := &apiv1alpha1.WorkerStatus{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "WorkerStatus",
 						},
+						MachineImages: machineImages,
 					}
 
 					workerWithExpectedImages := w.DeepCopy()
@@ -1146,7 +1230,11 @@ var _ = Describe("Machines", func() {
 			})
 
 			It("should fail because the ami for this architecture cannot be found", func() {
-				w.Spec.Pools[0].Architecture = ptr.To(archFAKE)
+				if isCapabilitiesCloudProfile {
+					cluster.CloudProfile.Spec.MachineTypes[0].Capabilities[v1beta1constants.ArchitectureName] = []string{archFAKE}
+				} else {
+					w.Spec.Pools[0].Architecture = ptr.To(archFAKE)
+				}
 
 				workerDelegate, _ = NewWorkerDelegate(c, decoder, scheme, chartApplier, "", w, cluster)
 
@@ -1356,7 +1444,10 @@ var _ = Describe("Machines", func() {
 					})
 				})
 			})
-		})
+		},
+			Entry("with capabilities", true),
+			Entry("without capabilities", false),
+		)
 
 		Describe("InstanceMetadata", func() {
 			var (

--- a/pkg/webhook/infrastructure/mutate.go
+++ b/pkg/webhook/infrastructure/mutate.go
@@ -13,7 +13,7 @@ import (
 	extensionscontextwebhook "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -102,6 +102,6 @@ func (m *mutator) isInMigrationOrRestorePhase(infra *extensionsv1alpha1.Infrastr
 		return true
 	}
 
-	operationType := v1beta1helper.ComputeOperationType(infra.ObjectMeta, infra.Status.LastOperation)
+	operationType := gardencorev1beta1helper.ComputeOperationType(infra.ObjectMeta, infra.Status.LastOperation)
 	return operationType == v1beta1.LastOperationTypeMigrate || operationType == v1beta1.LastOperationTypeRestore
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR is part of [GEP-33 Machine Image Capabilities](https://github.com/gardener/gardener/blob/master/docs/proposals/33-machine-image-capabilities.md)

To make use of the introduced machine `Capabilities`. This PR implements the AMI selection based on these `Capabilities`. The selection algorithm distinguishes if a shoot is created based on a `CloudProfile` with or without `Capabilities` to select the best matching AMI for an `MachineImageVersion`. It also ensures that the status of `Workers` is consistently using `Capabilities` or not to support switching existing `Workers` to a `Cloudprofile` with `Capabilities` and the other way round.


**Which issue(s) this PR fixes**:
Part of: https://github.com/gardener/gardener/issues/11301

**Special notes for your reviewer**:
Image selection for bastions is not included as it depends on https://github.com/gardener/gardener/pull/12834
@hebelsan 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
AMI selection for workers' `MachineClass` supports `Cloudprofiles` with `Capabilities`.
```
