### PR TITLE
Add annotation to disable patching of load balancer services.

### DIFF
--- a/docs/usage/ipv6.md
+++ b/docs/usage/ipv6.md
@@ -85,6 +85,7 @@ When creating a load balancer, the corresponding annotations need to be configur
 
 The AWS Load Balancer Controller allows dual-stack ingress so that an IPv6-only shoot cluster can serve IPv4 and IPv6 clients.
 You can find an example [here](dual-stack-ingress.md#creating-an-ipv4ipv6-dual-stack-ingress).
+A mutating webhook will automatically add the required annotations. To disable this automated behavior, use the annotation `extensions.gardener.cloud/ignore-load-balancer: "true"`.
 
 > [!WARNING]
 > When accessing Network Load Balancers (NLB) from within the same IPv6-only cluster, it is crucial to add the annotation `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=false`.
@@ -176,19 +177,3 @@ You can find more information about the process and the steps required [here](ht
 > [!WARNING]
 > Please note that the dual-stack migration requires the IPv4-only cluster to run in native routing mode, i.e. pod overlay network needs to be disabled.
 > The default quota of routes per route table in AWS is 50. This restricts the cluster size to about 50 nodes. Therefore, please adapt (if necessary) the routes per route table limit in the Amazon Virtual Private Cloud quotas accordingly before switching to native routing. The maximum setting is currently 1000.
-
-### Load Balancer Configuration
-
-The AWS Load Balancer Controller is automatically deployed when using a dual-stack shoot cluster.
-When creating a load balancer, the corresponding annotations need to be configured, see [AWS Load Balancer Documentation - Network Load Balancer](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/service/nlb/) for details.
-
-> [!WARNING]
-> Please note that load balancer services without any special annotations will default to IPv4-only regardless how `.spec.ipFamilies` is set.
-
-The AWS Load Balancer Controller allows dual-stack ingress so that a dual-stack shoot cluster can serve IPv4 and IPv6 clients.
-You can find an example [here](dual-stack-ingress.md#creating-an-ipv4ipv6-dual-stack-ingress).
-
-> [!WARNING]
-> When accessing external Network Load Balancers (NLB) from within the same cluster via IPv6 or internal NLBs via IPv4, it is crucial to add the annotation `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=false`.
-> Without this annotation, if a request is routed by the NLB to the same target instance from which it originated, the client IP and destination IP will be identical.
-> This situation, known as the hair-pinning effect, will prevent the request from being processed.

--- a/pkg/webhook/shootservice/mutator.go
+++ b/pkg/webhook/shootservice/mutator.go
@@ -63,7 +63,9 @@ func (m *mutator) Mutate(ctx context.Context, newObj, _ client.Object) error {
 	if metav1.HasAnnotation(service.ObjectMeta, "service.beta.kubernetes.io/aws-load-balancer-scheme") &&
 		service.Annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"] == "internal" ||
 		metav1.HasAnnotation(service.ObjectMeta, "service.beta.kubernetes.io/aws-load-balancer-internal") &&
-			service.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] == "true" {
+			service.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] == "true" ||
+		metav1.HasAnnotation(service.ObjectMeta, "extensions.gardener.cloud/ignore-load-balancer") &&
+			service.Annotations["extensions.gardener.cloud/ignore-load-balancer"] == "true" {
 		return nil
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
In IPv6 and dual-stack clusters, LoadBalancer services are automatically annotated to deploy dual-stack network load balancers.

Users can opt out of this automatic behavior by setting the annotation `extensions.gardener.cloud/ignore-load-balancer: "true"`. This allows users to:
- Configure custom load balancer annotations
- Avoid issues during service migration
- Maintain full control over load balancer configuration when needed

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
LoadBalancer services in IPv6 and dual-stack clusters can now opt out of automatic dual-stack annotations using `extensions.gardener.cloud/ignore-load-balancer: "true"`.
```
