### PR TITLE
Support reconciling duplicated zones in flow

### DIFF
--- a/pkg/apis/aws/helper/zone.go
+++ b/pkg/apis/aws/helper/zone.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package helper
 
 import (

--- a/pkg/apis/aws/helper/zone.go
+++ b/pkg/apis/aws/helper/zone.go
@@ -19,13 +19,12 @@ type ZoneInternal struct {
 
 // HasDuplicatedZoneNames returns true if there are duplicated zone names in the given zones.
 func HasDuplicatedZoneNames(zones []aws.Zone) bool {
-	zoneNameCount := make(map[string]int)
+	seenZoneNames := make(map[string]bool)
 	for _, zone := range zones {
-		count := zoneNameCount[zone.Name]
-		if count > 0 {
+		if seenZoneNames[zone.Name] {
 			return true
 		}
-		zoneNameCount[zone.Name] = count + 1
+		seenZoneNames[zone.Name] = true
 	}
 	return false
 }

--- a/pkg/apis/aws/helper/zone.go
+++ b/pkg/apis/aws/helper/zone.go
@@ -1,0 +1,57 @@
+package helper
+
+import (
+	"fmt"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
+)
+
+// ZoneInternal is like aws.Zone but with an additional NameInternal field.
+// this is needed to disambiguate duplicated zones with the same.
+type ZoneInternal struct {
+	aws.Zone
+	NameInternal string
+}
+
+// HasDuplicatedZoneNames returns true if there are duplicated zone names in the given zones.
+func HasDuplicatedZoneNames(zones []aws.Zone) bool {
+	zoneNameCount := make(map[string]int)
+	for _, zone := range zones {
+		count := zoneNameCount[zone.Name]
+		if count > 0 {
+			return true
+		}
+		zoneNameCount[zone.Name] = count + 1
+	}
+	return false
+}
+
+// AddInternalZoneName adds the internal zone name to the given tags map under the given key,
+// if the internal name is different from the public name.
+func AddInternalZoneName(tags map[string]string, key string, zone ZoneInternal) {
+	if zone.Name != zone.NameInternal && tags != nil {
+		tags[key] = zone.NameInternal
+	}
+}
+
+// CreateInternalZones creates internal zones from the given zones.
+// If there are multiple zones with the same name, the internal name will be suffixed with -<index>.
+// For example, if there are two zones with the name "us-west-1a", the internal names will be "us-west-1a" and "us-west-1a-2".
+func CreateInternalZones(zones []aws.Zone) []ZoneInternal {
+	var zonesInternal []ZoneInternal
+	zoneNameCount := make(map[string]int)
+	for _, zone := range zones {
+		count := zoneNameCount[zone.Name]
+		internalName := zone.Name
+		if count > 0 {
+			// TODO maybe use a hash overs CIDRs as suffix instead of a counter
+			internalName = fmt.Sprintf("%s-%d", zone.Name, count+1)
+		}
+		zoneNameCount[zone.Name] = count + 1
+		zonesInternal = append(zonesInternal, ZoneInternal{
+			Zone:         zone,
+			NameInternal: internalName,
+		})
+	}
+	return zonesInternal
+}

--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -34,6 +34,9 @@ const (
 	TagKeyRolePublicELB = "kubernetes.io/role/elb"
 	// TagKeyRolePrivateELB is the tag key for the internal ELB
 	TagKeyRolePrivateELB = "kubernetes.io/role/internal-elb"
+	// TagKeyInternalZoneName is the internal zone name, only used if one zone has multiple entries
+	// if a zone has multiple entries, we need to distinguish between them
+	TagKeyInternalZoneName = "NameInternal"
 	// TagValueCluster is the tag value for the cluster tag
 	TagValueCluster = "1"
 	// TagValueELB is the tag value for the ELB tag keys

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -1422,12 +1422,12 @@ func (c *FlowContext) ensurePrivateRoutingTable(zoneName, zoneNameInternal strin
 
 func findInRouteTableByWorkerSubnetAssoc(routeTables []*awsclient.RouteTable, subnetWorkersID *string) (*awsclient.RouteTable, error) {
 	if subnetWorkersID == nil {
-		return nil, fmt.Errorf("subnetWorkersID is nil")
+		return nil, fmt.Errorf("failed finding matching route table because subnetWorkersID is nil")
 	}
 
 	for _, rt := range routeTables {
 		for _, associations := range rt.Associations {
-			if associations.SubnetId != nil && *associations.SubnetId == *subnetWorkersID {
+			if associations != nil && associations.SubnetId != nil && *associations.SubnetId == *subnetWorkersID {
 				return rt, nil
 			}
 		}

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
 	. "github.com/gardener/gardener-extension-provider-aws/pkg/controller/infrastructure/infraflow/shared"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Support duplicated zones in the flow reconciler.
This is needed to migrated 2 shoots from terraformer to flow.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Support reconciling duplicated zones in flow
```
