### PR TITLE
Allow migration from dual-stack [IPv4, IPv6]  to single stack [IPv4] networking

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -45,6 +45,7 @@ import (
 	apisaws "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/utils"
 )
 
 const (
@@ -720,7 +721,7 @@ func getIPAMChartValues(
 		"nodeCIDRMaskSizeIPv6": nodeCidrMaskSizeIPv6,
 		"useWorkloadIdentity":  useWorkloadIdentity,
 	}
-	enabled := mode != "ipv4"
+	enabled := mode != "ipv4" || utils.HasIPv6NodeCIDR(cluster.Shoot.Status.Networking.Nodes)
 	if !enabled {
 		values["replicas"] = 0
 	}
@@ -856,7 +857,9 @@ func getControlPlaneShootChartValues(
 		*cpConfig.CloudControllerManager.UseCustomRouteController
 
 	ipamControllerEnabled := false
-	if networkingConfig := cluster.Shoot.Spec.Networking; networkingConfig != nil && slices.Contains(networkingConfig.IPFamilies, v1beta1.IPFamilyIPv6) {
+	if networkingConfig := cluster.Shoot.Spec.Networking; networkingConfig != nil &&
+		(slices.Contains(networkingConfig.IPFamilies, v1beta1.IPFamilyIPv6) ||
+			utils.HasIPv6NodeCIDR(cluster.Shoot.Status.Networking.Nodes)) {
 		ipamControllerEnabled = true
 	}
 

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -198,6 +198,11 @@ var _ = Describe("ValuesProvider", func() {
 						Version: "1.29.0",
 					},
 				},
+				Status: gardencorev1beta1.ShootStatus{
+					Networking: &gardencorev1beta1.NetworkingStatus{
+						Nodes: []string{"1.2.3.4/24"},
+					},
+				},
 			},
 		}
 

--- a/pkg/utils/iputil.go
+++ b/pkg/utils/iputil.go
@@ -1,0 +1,22 @@
+package utils
+
+import "net"
+
+// IsIPv6CIDR checks if a CIDR string represents an IPv6 network
+func IsIPv6CIDR(cidr string) bool {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false
+	}
+	return ipNet.IP.To4() == nil
+}
+
+// HasIPv6NodeCIDR checks if any of the node CIDRs is IPv6
+func HasIPv6NodeCIDR(nodeCIDRs []string) bool {
+	for _, cidr := range nodeCIDRs {
+		if IsIPv6CIDR(cidr) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gardener/gardener-extension-provider-aws/imagevector"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
+	"github.com/gardener/gardener-extension-provider-aws/pkg/utils"
 )
 
 const (
@@ -174,7 +175,10 @@ func (e *ensurer) EnsureKubeControllerManagerDeployment(ctx context.Context, gct
 	}
 
 	allocateNodeCIDRs := true
-	if networkingConfig := cluster.Shoot.Spec.Networking; networkingConfig != nil && slices.Contains(networkingConfig.IPFamilies, v1beta1.IPFamilyIPv6) {
+	// Check if IPv6 is configured in IPFamilies or if any node CIDR is IPv6
+	if networkingConfig := cluster.Shoot.Spec.Networking; networkingConfig != nil &&
+		(slices.Contains(networkingConfig.IPFamilies, v1beta1.IPFamilyIPv6) ||
+			utils.HasIPv6NodeCIDR(cluster.Shoot.Status.Networking.Nodes)) {
 		allocateNodeCIDRs = false
 	}
 	if c := extensionswebhook.ContainerWithName(ps.Containers, "kube-controller-manager"); c != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
PR is needed for https://github.com/gardener/gardener/pull/12967

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Migration from dual-stack [IPv4, IPv6] to [IPv4] networking is now allowed.
```
