### PR TITLE
Automatically close release milestones

### DIFF
--- a/.github/workflows/close-milestone.yaml
+++ b/.github/workflows/close-milestone.yaml
@@ -7,11 +7,11 @@ on:
         description: "The milestone name to close"
         required: true
         type: string
-    strip_patch:
-      description: "Whether to strip the patch version (last .X) from the name"
-      required: false
-      type: boolean
-      default: false
+      strip_patch:
+        description: "Whether to strip the patch version (last .X) from the name"
+        required: false
+        type: boolean
+        default: false
     secrets:
       token:
         description: "GitHub token"

--- a/.github/workflows/close-milestone.yaml
+++ b/.github/workflows/close-milestone.yaml
@@ -1,0 +1,40 @@
+name: Reusable - Close Milestone
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: "The milestone name to close"
+        required: true
+        type: string
+    secrets:
+      token:
+        description: "GitHub token"
+        required: true
+
+jobs:
+  close-milestone:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check milestone exists
+      id: check
+      env:
+        GH_TOKEN: ${{ secrets.token }}
+      run: |
+        set -e
+        milestone_id=$(gh api repos/${{ github.repository }}/milestones \
+          --jq '.[] | select(.title=="${{ inputs.name }}") | .number')
+        if [ -n "$milestone_id" ]; then
+          echo "id=$milestone_id" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Close milestone if found
+      if: steps.check.outputs.id != ''
+      env:
+        GH_TOKEN: ${{ secrets.token }}
+      run: |
+        gh api \
+          -X PATCH \
+          -F state=closed \
+          repos/${{ github.repository }}/milestones/${{ steps.check.outputs.id }}
+        echo "Closed milestone '${{ inputs.name }}'."

--- a/.github/workflows/close-milestone.yaml
+++ b/.github/workflows/close-milestone.yaml
@@ -7,6 +7,11 @@ on:
         description: "The milestone name to close"
         required: true
         type: string
+    strip_patch:
+      description: "Whether to strip the patch version (last .X) from the name"
+      required: false
+      type: boolean
+      default: false
     secrets:
       token:
         description: "GitHub token"
@@ -16,6 +21,18 @@ jobs:
   close-milestone:
     runs-on: ubuntu-latest
     steps:
+    - name: Prepare milestone name
+      id: prepare_name
+      run: |
+        MILESTONE="${{ inputs.name }}"
+        
+        if [ "${{ inputs.strip_patch }}" = "true" ]; then
+          # Remove last .X (patch) from the version
+          MILESTONE="${MILESTONE%.*}"
+        fi
+        
+        echo "milestone_name=$MILESTONE" >> $GITHUB_OUTPUT
+
     - name: Check milestone exists
       id: check
       env:
@@ -23,7 +40,7 @@ jobs:
       run: |
         set -e
         milestone_id=$(gh api repos/${{ github.repository }}/milestones \
-          --jq '.[] | select(.title=="${{ inputs.name }}") | .number')
+          --jq '.[] | select(.title=="'${{ steps.prepare_name.outputs.milestone_name }}'") | .number')
         if [ -n "$milestone_id" ]; then
           echo "id=$milestone_id" >> $GITHUB_OUTPUT
         fi
@@ -37,4 +54,4 @@ jobs:
           -X PATCH \
           -F state=closed \
           repos/${{ github.repository }}/milestones/${{ steps.check.outputs.id }}
-        echo "Closed milestone '${{ inputs.name }}'."
+        echo "Closed milestone '${{ steps.prepare_name.outputs.milestone_name }}'."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,3 +49,14 @@ jobs:
       packages: write
       id-token: write
       pull-requests: write
+
+  close-release-milestone:
+    if: ${{ inputs.next-version == 'bump-minor' && inputs.release-version == 'set-prerelease' }}
+    needs:
+      - build
+      - release-to-github-and-bump
+    uses: .github/workflows/close-milestone.yaml@master
+    with:
+      name: ${{ replace(needs.release-to-github-and-bump.outputs.component-descriptor.version, '\.[0-9]+$', '') }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,8 +55,19 @@ jobs:
     needs:
       - build
       - release-to-github-and-bump
-    uses: .github/workflows/close-milestone.yaml@master
-    with:
-      name: ${{ replace(needs.release-to-github-and-bump.outputs.component-descriptor.version, '\.[0-9]+$', '') }}
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Compute major.minor version
+      id: compute_version
+      run: |
+        VERSION="${{ needs.release-to-github-and-bump.outputs.component-descriptor.version }}"
+        MAJOR_MINOR="${VERSION%.*}"
+        echo "major_minor=$MAJOR_MINOR" >> $GITHUB_OUTPUT
+    - name: Close release milestone
+      uses: ./.github/workflows/close-milestone.yaml
+      with:
+        name: ${{ steps.compute_version.outputs.major_minor }}
+      secrets:
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,19 +55,9 @@ jobs:
     needs:
       - build
       - release-to-github-and-bump
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Compute major.minor version
-      id: compute_version
-      run: |
-        VERSION="${{ needs.release-to-github-and-bump.outputs.component-descriptor.version }}"
-        MAJOR_MINOR="${VERSION%.*}"
-        echo "major_minor=$MAJOR_MINOR" >> $GITHUB_OUTPUT
-    - name: Close release milestone
-      uses: ./.github/workflows/close-milestone.yaml
-      with:
-        name: ${{ steps.compute_version.outputs.major_minor }}
-      secrets:
-        token: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/close-milestone.yaml
+    with:
+      name: ${{ needs.release-to-github-and-bump.outputs.component-descriptor.version }}
+      strip_patch: true
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR adds a close-milestone GitHub action workflow that's called at the end of a release action.
With that release milestones are closed automatically after a release.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
