### PR TITLE
Support flow migration of shoots with duplicated zone

### DIFF
--- a/pkg/controller/infrastructure/flow_reconciler.go
+++ b/pkg/controller/infrastructure/flow_reconciler.go
@@ -333,7 +333,14 @@ func migrateTerraformStateToFlowState(rawExtension *runtime.RawExtension, zones 
 
 	tfNamePrefixes := []string{"nodes_", "private_utility_", "public_utility_"}
 	flowNames := []string{infraflow.IdentifierZoneSubnetWorkers, infraflow.IdentifierZoneSubnetPrivate, infraflow.IdentifierZoneSubnetPublic}
+
+	processedZones := make(map[string]bool)
 	for i, zone := range zones {
+		if processedZones[zone.Name] {
+			continue
+		}
+		processedZones[zone.Name] = true
+
 		keyPrefix := infraflow.ChildIdZones + shared.Separator + zone.Name + shared.Separator
 		suffix := fmt.Sprintf("z%d", i)
 		setFlowStateData(flowState, keyPrefix+infraflow.IdentifierZoneSuffix, &suffix)

--- a/pkg/controller/infrastructure/flow_reconciler.go
+++ b/pkg/controller/infrastructure/flow_reconciler.go
@@ -334,6 +334,7 @@ func migrateTerraformStateToFlowState(rawExtension *runtime.RawExtension, zones 
 	tfNamePrefixes := []string{"nodes_", "private_utility_", "public_utility_"}
 	flowNames := []string{infraflow.IdentifierZoneSubnetWorkers, infraflow.IdentifierZoneSubnetPrivate, infraflow.IdentifierZoneSubnetPublic}
 
+	// TODO: @hebelsan - remove processedZones after migration of shoots with duplicated zone name entries
 	processedZones := make(map[string]bool)
 	for i, zone := range zones {
 		if processedZones[zone.Name] {

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -781,13 +781,6 @@ func (c *FlowContext) ensureZones(ctx context.Context) error {
 		return item.AvailabilityZone + "-" + item.CidrBlock
 	})
 
-	log.Info("Tobe deleted", "subnetIDs", mmap(toBeDeleted, func(t *awsclient.Subnet) string {
-		return t.SubnetId
-	}))
-	log.Info("Tobe created", "subnetIDs", mmap(toBeCreated, func(t *awsclient.Subnet) string {
-		return t.SubnetId
-	}))
-
 	g := flow.NewGraph("AWS infrastructure reconciliation: zones")
 
 	if err := c.addZoneDeletionTasksBySubnets(g, toBeDeleted); err != nil {

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -571,6 +571,7 @@ func (c *FlowContext) ensureNodesSecurityGroup(ctx context.Context) error {
 		},
 	}
 
+	// TODO: @hebelsan - remove processedZones after migration of shoots with duplicated zone name entries
 	processedZones := make(map[string]bool)
 	for index, zone := range c.config.Networks.Zones {
 		if processedZones[zone.Name] {
@@ -698,6 +699,7 @@ func (c *FlowContext) ensureZones(ctx context.Context) error {
 	log := LogFromContext(ctx)
 	var desired []*awsclient.Subnet
 
+	// TODO: @hebelsan - remove processedZones after migration of shoots with duplicated zone name entries
 	processedZones := make(map[string]bool)
 	for index, zone := range c.config.Networks.Zones {
 		if processedZones[zone.Name] {
@@ -802,6 +804,8 @@ func (c *FlowContext) ensureZones(ctx context.Context) error {
 		}
 		dependencies.Append(pair.desired.AvailabilityZone, taskID)
 	}
+
+	// TODO: @hebelsan - remove processedZones after migration of shoots with duplicated zone name entries
 	processedZones = make(map[string]bool)
 	for _, item := range c.config.Networks.Zones {
 		if processedZones[item.Name] {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR enables the migration of shoots with duplicated availability zone entries from Terraform to Flow. For each availability zone, only the first entry will be migrated and managed by the Flow reconciler.

Duplicated zone entries are not supported because the Cloud Controller Manager does not allow multiple subnets for a single zone.

Before migrating these shoots, the shoot tag must be removed from all duplicated subnets and private route tables to prevent the Flow reconciler from crashing.

After the migration, ELBv2 load balancers can be moved into the correct subnets, and all unused AWS resources associated with the duplicated subnets can be safely deleted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Support migration of shoots with duplicated zone entries from terraform to flow
```
