### PR TITLE
Wait until NATGateway is available after update

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -1265,6 +1265,12 @@ func (c *FlowContext) ensureNATGateway(zone *aws.Zone) flow.TaskFn {
 			if _, err := c.updater.UpdateEC2Tags(ctx, current.NATGatewayId, desired.Tags, current.Tags); err != nil {
 				return err
 			}
+			waiter := informOnWaiting(log, 10*time.Second, "waiting for NATGateway to become available...")
+			err = c.client.WaitForNATGatewayAvailable(ctx, current.NATGatewayId)
+			waiter.Done(err)
+			if err != nil {
+				return err
+			}
 		} else {
 			child.Set(IdentifierZoneNATGateway, "")
 			log.Info("creating...")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform aws

**What this PR does / why we need it**:
We sometimes miss the egress CIDRs in the infra state, probably because we skip to expose them if the nat is not in state available:
https://github.com/gardener/gardener-extension-provider-aws/blob/10240070d3343d4e7687cc7f6dd9e443b45c3e9b/pkg/controller/infrastructure/infraflow/reconcile.go#L689-L691
With this PR the controller waits until the NATGate has become available also after updating it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Wait until NATGateway is available after update
```
