### PR TITLE
Increase client-side QPS/burst for CSI-* components

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-deployment.yaml
@@ -132,8 +132,8 @@ spec:
         - --default-fstype=ext4
         - --leader-election=true
         - --leader-election-namespace=kube-system
-        - --kube-api-qps=20
-        - --kube-api-burst=100
+        - --kube-api-qps=100
+        - --kube-api-burst=200
         - --worker-threads=100
         - --retry-interval-max=10m
         - --v=5
@@ -168,8 +168,8 @@ spec:
         - --v=5
         - --timeout=60s
         - --retry-interval-max=3m
-        - --kube-api-qps=20
-        - --kube-api-burst=100
+        - --kube-api-qps=100
+        - --kube-api-burst=200
         - --worker-threads=100
         env:
         - name: ADDRESS
@@ -198,8 +198,8 @@ spec:
         - --leader-election-namespace=kube-system
         - --snapshot-name-prefix={{ .Release.Namespace }}
         - --extra-create-metadata
-        - --kube-api-qps=20
-        - --kube-api-burst=100
+        - --kube-api-qps=100
+        - --kube-api-burst=200
         - --worker-threads=100
         - --retry-interval-max=30m
         env:
@@ -231,8 +231,8 @@ spec:
         - --v=5
         - --extra-modify-metadata
         - --timeout=60s
-        - --kube-api-qps=20
-        - --kube-api-burst=100
+        - --kube-api-qps=100
+        - --kube-api-burst=200
         - --workers=100
         - --retry-interval-max=10m
         {{- if ((.Values.csiResizer).featureGates) }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area performance
/kind ehnhancement
/platform aws

**What this PR does / why we need it**:

To avoid client-side throttling in clusters with a high amount of disk operations, the `kube-api-qps` and `kube-api-burst` parameters are increased. As these are global controllers per cluster, increasing the throughput to the kube-apiserver improves scalability. There is still API priority & fairness on the server-side to balance incoming requests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We had similar changes in the past - e.g. for MCM - https://github.com/gardener/gardener/pull/11879. 

/invite @kon-angelo @hebelsan 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increase client-side QPS/burst for CSI-* components
```
