### PR TITLE
Improve ec2 filter query in bastion test

### DIFF
--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -643,6 +643,10 @@ func verifyCreation(
 	instances, err := awsClient.EC2.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
 		Filters: []ec2types.Filter{
 			{
+				Name:   awssdk.String(awsclient.FilterVpcID),
+				Values: []string{options.VpcID},
+			},
+			{
 				Name:   awssdk.String("tag:Name"),
 				Values: []string{options.InstanceName},
 			},
@@ -687,6 +691,10 @@ func verifyDeletion(
 	// instance should be terminated
 	instances, err := awsClient.EC2.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
 		Filters: []ec2types.Filter{
+			{
+				Name:   awssdk.String(awsclient.FilterVpcID),
+				Values: []string{options.VpcID},
+			},
 			{
 				Name:   awssdk.String("tag:Name"),
 				Values: []string{options.InstanceName},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/platform aws

**What this PR does / why we need it**:
The integration tests sometimes fail because two bastion instances are found by name.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
