### PR TITLE
Add netpol to allow access to metadata service

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-efs/templates/node-daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-efs/templates/node-daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         app: csi
         role: driver-efs-node
         node.gardener.cloud/critical-component: "true"
-        network-policy.aws-metadata-access: "true"
+        aws.extension.gardener.cloud/allow-metadata-access: "true"
     spec:
       priorityClassName: system-node-critical
       hostNetwork: false

--- a/charts/internal/shoot-system-components/charts/csi-driver-efs/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-efs/values.yaml
@@ -39,9 +39,6 @@ sidecars:
 
 ## Node daemonset variables
 
-# allowMetadataAccess defines whether to create a NetworkPolicy that allows access to the AWS metadata service.
-allowMetadataAccess: false
-
 node:
   # Number for the log level verbosity
   logLevel: 5

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -19,10 +19,11 @@ spec:
         app: csi
         role: disk-driver
         node.gardener.cloud/critical-component: "true"
+        aws.extension.gardener.cloud/allow-metadata-access: "true"
       annotations:
         node.gardener.cloud/wait-for-csi-node-aws: {{ include "csi-driver-node.provisioner" . }}
     spec:
-      hostNetwork: true
+      hostNetwork: false
       priorityClassName: system-node-critical
       serviceAccountName: csi-driver-node
       tolerations:

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/netpol.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/netpol.yaml
@@ -1,14 +1,13 @@
 # with kubernetes >= 1.33 a deny all rule for the kube-system namespace is applied by default
-{{- if .Values.allowMetadataAccess }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-metadata-access
+  name: aws.extensions.gardener.cloud--allow-metadata-access
   namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:
-      network-policy.aws-metadata-access: "true"
+      aws.extension.gardener.cloud/allow-metadata-access: "true"
   policyTypes:
     - Egress
   egress:
@@ -18,4 +17,3 @@ spec:
       ports:
         - protocol: TCP
           port: 80
-{{- end }}

--- a/pkg/aws/types.go
+++ b/pkg/aws/types.go
@@ -126,6 +126,8 @@ const (
 	CSILivenessProbeName = "csi-liveness-probe"
 	// CSIVolumeModifierName is the constant for the name of the csi-volume-modifier.
 	CSIVolumeModifierName = "csi-volume-modifier"
+	// CSINetworkPolicyIMDSName is the constant for the name of the csi network policy allowing access to the IMDS.
+	CSINetworkPolicyIMDSName = "aws.extensions.gardener.cloud--allow-metadata-access"
 
 	// AnnotationEnableVolumeAttributesClass is the annotation to use on shoots to enable VolumeAttributesClasses
 	AnnotationEnableVolumeAttributesClass = "aws.provider.extensions.gardener.cloud/enable-volume-attributes-class"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
With kubernetes >= 1.33 a deny all rule for the kube-system namespace is applied by default.
The efs node csi driver need to talk to the AWS metadata service and fails if he can not.
This PR creates a netpol if efs-csi-driver is enabled and the kubernetes version is >= 1.33.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Add netpol to allow access to metadata service if EFS is enabled
```
