### PR TITLE
Set EFS daemonset hostnetwork field true

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-efs/templates/node-daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-efs/templates/node-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
         node.gardener.cloud/critical-component: "true"
     spec:
       priorityClassName: system-node-critical
-      hostNetwork: false
+      hostNetwork: true
       dnsPolicy: {{ .Values.node.dnsPolicy }}
       serviceAccountName: {{ .Values.node.serviceAccount.name }}
       tolerations:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
With kubernetes >= 1.33 a deny all rule for the kube-system namespace is applied by default.
The efs node csi driver need to talk to the AWS metadata service and fails if he can not.
This PR sets the hostnetwork field of the efs daemonset true.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Set EFS daemonset hostnetwork field true
```
