### PR TITLE
fix gatewayEndpoint validation

### DIFF
--- a/pkg/apis/aws/validation/filter.go
+++ b/pkg/apis/aws/validation/filter.go
@@ -31,7 +31,7 @@ var (
 	// TagKeyRegex matches Letters (a–z, A–Z), numbers (0–9), spaces, and the following symbols: + - = . _ : / @
 	TagKeyRegex = `^[\w +\-=\.:/@]+$`
 	// GatewayEndpointRegex matches one or more word characters, optionally followed by dot-separated word segments
-	GatewayEndpointRegex = `^\w+(\.\w+)*$`
+	GatewayEndpointRegex = `^[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)*$`
 
 	validateK8sResourceName        = combineValidationFuncs(regex(k8sResourceNameRegex), notEmpty, maxLength(253))
 	validateVpcID                  = combineValidationFuncs(regex(VpcIDRegex), notEmpty, maxLength(255))

--- a/pkg/apis/aws/validation/infrastructure_test.go
+++ b/pkg/apis/aws/validation/infrastructure_test.go
@@ -221,12 +221,12 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				})
 
 				It("should reject non-alphanumeric endpoints", func() {
-					infrastructureConfig.Networks.VPC.GatewayEndpoints = []string{"s3", "my-endpoint"}
+					infrastructureConfig.Networks.VPC.GatewayEndpoints = []string{"s3", "my_endpoint", "guardduty-data"}
 					errorList := ValidateInfrastructureConfig(infrastructureConfig, familyIPv4, &nodes, &pods, &services)
 					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":     Equal(field.ErrorTypeInvalid),
 						"Field":    Equal("networks.vpc.gatewayEndpoints[1]"),
-						"BadValue": Equal("my-endpoint"),
+						"BadValue": Equal("my_endpoint"),
 						"Detail":   Equal(fmt.Sprintf("does not match expected regex %s", GatewayEndpointRegex)),
 					}))
 				})


### PR DESCRIPTION
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:
gatewayEndpoints naming follows domain naming. current code allowed for A-Za-z0-9\_ (which is wrong and misses \- char)

**Which issue(s) this PR fixes**:
Fixes #1533 

**Special notes for your reviewer**: