### PR TITLE
`cherry-pick:` Improve GW  endpoint validation (#1536)

### DIFF
--- a/pkg/apis/aws/validation/filter.go
+++ b/pkg/apis/aws/validation/filter.go
@@ -30,8 +30,6 @@ var (
 	ZoneNameRegex = `^[a-z0-9-]+$`
 	// TagKeyRegex matches Letters (a–z, A–Z), numbers (0–9), spaces, and the following symbols: + - = . _ : / @
 	TagKeyRegex = `^[\w +\-=\.:/@]+$`
-	// GatewayEndpointRegex matches one or more word characters, optionally followed by dot-separated word segments
-	GatewayEndpointRegex = `^\w+(\.\w+)*$`
 
 	validateK8sResourceName        = combineValidationFuncs(regex(k8sResourceNameRegex), notEmpty, maxLength(253))
 	validateVpcID                  = combineValidationFuncs(regex(VpcIDRegex), notEmpty, maxLength(255))
@@ -41,7 +39,6 @@ var (
 	validateIamInstanceProfileArn  = combineValidationFuncs(regex(IamInstanceProfileArnRegex), maxLength(255))
 	validateZoneName               = combineValidationFuncs(regex(ZoneNameRegex), maxLength(255))
 	validateTagKey                 = combineValidationFuncs(regex(TagKeyRegex), notEmpty, maxLength(128))
-	validateGatewayEndpointName    = combineValidationFuncs(regex(GatewayEndpointRegex), maxLength(255))
 )
 
 type validateFunc[T any] func(T, *field.Path) field.ErrorList

--- a/pkg/apis/aws/validation/infrastructure_test.go
+++ b/pkg/apis/aws/validation/infrastructure_test.go
@@ -221,13 +221,13 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				})
 
 				It("should reject non-alphanumeric endpoints", func() {
-					infrastructureConfig.Networks.VPC.GatewayEndpoints = []string{"s3", "my-endpoint"}
+					infrastructureConfig.Networks.VPC.GatewayEndpoints = []string{"com.amazonaws.eu-west-1.s3", "my_endpoint", "com.amazonaws.eu-west-1.guardduty", "aws.sagemaker.eu-west-1.partner-app"}
 					errorList := ValidateInfrastructureConfig(infrastructureConfig, familyIPv4, &nodes, &pods, &services)
 					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":     Equal(field.ErrorTypeInvalid),
 						"Field":    Equal("networks.vpc.gatewayEndpoints[1]"),
-						"BadValue": Equal("my-endpoint"),
-						"Detail":   Equal(fmt.Sprintf("does not match expected regex %s", GatewayEndpointRegex)),
+						"BadValue": Equal("my_endpoint"),
+						"Detail":   Equal("must be a valid DNS subdomain"),
 					}))
 				})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:
The changes focus on modifying the validation logic for AWS infrastructure configurations. Specifically, it replaces the custom regex validation for gateway endpoint names with the IsDNS1123Subdomain validation function from the k8s.io/apimachinery package. This change aligns the validation of gateway endpoint names with DNS subdomain requirements, ensuring the endpoints conform to established standards.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-aws/issues/1533

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix an issue with gateway endpoint validation not accepting valid DNS subdomains.
```