### PR TITLE
Fix infraStatus subnets order in edge case of duplicated zones

### DIFF
--- a/pkg/apis/aws/helper/helper.go
+++ b/pkg/apis/aws/helper/helper.go
@@ -73,6 +73,7 @@ func FindSubnetForPurpose(subnets []api.Subnet, purpose string) (*api.Subnet, er
 // an error will be returned.
 func FindSubnetForPurposeAndZone(subnets []api.Subnet, purpose, zone string) (*api.Subnet, error) {
 	// sort subnets to guarantee returning the same subnet for the edge case of duplicated zones
+	// TODO @hebelsan: remove after duplicated zones are fixed
 	subnetsCopy := append([]api.Subnet(nil), subnets...)
 	sort.Slice(subnetsCopy, func(i, j int) bool {
 		return subnetsCopy[i].ID < subnetsCopy[j].ID


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/platform aws

**What this PR does / why we need it**:
In case of multiple zones we should always use the same subnet for the nodes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Always use the same nodes subnet in case of duplicated zones
```
