### PR TITLE
Upgrade `ebs-csi-driver` to v1.50.3

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -136,8 +136,7 @@ images:
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/aws-ebs-csi-driver
   repository: registry.k8s.io/provider-aws/aws-ebs-csi-driver
-#  do not upgrade until https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2748 is resolved
-  tag: v1.47.1
+  tag: v1.50.3
   labels:
   - name: gardener.cloud/cve-categorisation
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2748 is now fixed

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
xRef https://github.com/gardener/gardener-extension-provider-aws/pull/1548

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Upgrade `ebs-csi-driver` to `v1.50.3`.
```
