### PR TITLE
Use pointer for FromPort and ToPort

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -1130,12 +1130,8 @@ func (c *Client) prepareRules(groupId string, rules []*SecurityGroupRule) (ingre
 				Ipv6Ranges:       nil,
 				PrefixListIds:    nil,
 				UserIdGroupPairs: nil,
-			}
-			if rule.FromPort != 0 {
-				ipPerm.FromPort = aws.Int32(rule.FromPort)
-			}
-			if rule.ToPort != 0 {
-				ipPerm.ToPort = aws.Int32(rule.ToPort)
+				FromPort:         rule.FromPort,
+				ToPort:           rule.ToPort,
 			}
 			for _, block := range rule.CidrBlocks {
 				ipPerm.IpRanges = append(ipPerm.IpRanges, ec2types.IpRange{CidrIp: aws.String(block)})
@@ -2478,12 +2474,8 @@ func fromIpPermission(groupId string, ipPerm ec2types.IpPermission, ruleType Sec
 		Type:       ruleType,
 		Protocol:   aws.ToString(ipPerm.IpProtocol),
 		CidrBlocks: blocks,
-	}
-	if ipPerm.FromPort != nil {
-		rule.FromPort = *ipPerm.FromPort
-	}
-	if ipPerm.ToPort != nil {
-		rule.ToPort = *ipPerm.ToPort
+		FromPort:   ipPerm.FromPort,
+		ToPort:     ipPerm.ToPort,
 	}
 	if len(ipPerm.UserIdGroupPairs) == 1 && ipPerm.UserIdGroupPairs[0].GroupId != nil && *ipPerm.UserIdGroupPairs[0].GroupId == groupId {
 		rule.Self = true

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -337,8 +337,8 @@ const (
 // SecurityGroupRule contains the relevant fields of a EC2 security group rule resource.
 type SecurityGroupRule struct {
 	Type         SecurityGroupRuleType
-	FromPort     int32
-	ToPort       int32
+	FromPort     *int32
+	ToPort       *int32
 	Protocol     string
 	CidrBlocks   []string
 	CidrBlocksv6 []string
@@ -390,17 +390,21 @@ func (sgr *SecurityGroupRule) LessThan(other *SecurityGroupRule) bool {
 	if sgr.Protocol > other.Protocol {
 		return false
 	}
-	if sgr.FromPort < other.FromPort {
-		return true
+	if sgr.FromPort != nil && other.FromPort != nil {
+		if *sgr.FromPort < *other.FromPort {
+			return true
+		}
+		if *sgr.FromPort > *other.FromPort {
+			return false
+		}
 	}
-	if sgr.FromPort > other.FromPort {
-		return false
-	}
-	if sgr.ToPort < other.ToPort {
-		return true
-	}
-	if sgr.ToPort > other.ToPort {
-		return false
+	if sgr.ToPort != nil && other.ToPort != nil {
+		if *sgr.ToPort < *other.ToPort {
+			return true
+		}
+		if *sgr.ToPort > *other.ToPort {
+			return false
+		}
 	}
 	if sgr.Self != other.Self {
 		return other.Self

--- a/pkg/aws/client/types_test.go
+++ b/pkg/aws/client/types_test.go
@@ -25,15 +25,15 @@ var _ = Describe("SecurityGroup", func() {
 			},
 			{
 				Type:       SecurityGroupRuleTypeIngress,
-				FromPort:   30000,
-				ToPort:     32767,
+				FromPort:   ptr.To[int32](30000),
+				ToPort:     ptr.To[int32](32767),
 				Protocol:   "tcp",
 				CidrBlocks: []string{"0.0.0.0/0"},
 			},
 			{
 				Type:       SecurityGroupRuleTypeIngress,
-				FromPort:   30000,
-				ToPort:     32767,
+				FromPort:   ptr.To[int32](30000),
+				ToPort:     ptr.To[int32](32767),
 				Protocol:   "udp",
 				CidrBlocks: []string{"0.0.0.0/0"},
 			},
@@ -46,8 +46,8 @@ var _ = Describe("SecurityGroup", func() {
 		rules2 = []*SecurityGroupRule{
 			{
 				Type:       SecurityGroupRuleTypeIngress,
-				FromPort:   30000,
-				ToPort:     32767,
+				FromPort:   ptr.To[int32](30000),
+				ToPort:     ptr.To[int32](32767),
 				Protocol:   "udp",
 				CidrBlocks: []string{"10.0.0.0/8"},
 			},

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -524,8 +524,8 @@ func (c *FlowContext) ensureNodesSecurityGroup(ctx context.Context) error {
 			},
 			{
 				Type:     awsclient.SecurityGroupRuleTypeIngress,
-				FromPort: 30000,
-				ToPort:   32767,
+				FromPort: ptr.To[int32](30000),
+				ToPort:   ptr.To[int32](32767),
 				Protocol: "tcp",
 				CidrBlocks: func() []string {
 					if isIPv4(c.getIpFamilies()) {
@@ -542,8 +542,8 @@ func (c *FlowContext) ensureNodesSecurityGroup(ctx context.Context) error {
 			},
 			{
 				Type:     awsclient.SecurityGroupRuleTypeIngress,
-				FromPort: 30000,
-				ToPort:   32767,
+				FromPort: ptr.To[int32](30000),
+				ToPort:   ptr.To[int32](32767),
 				Protocol: "udp",
 				CidrBlocks: func() []string {
 					if isIPv4(c.getIpFamilies()) {
@@ -587,36 +587,36 @@ func (c *FlowContext) ensureNodesSecurityGroup(ctx context.Context) error {
 
 		ruleNodesInternalTCP := &awsclient.SecurityGroupRule{
 			Type:     awsclient.SecurityGroupRuleTypeIngress,
-			FromPort: 30000,
-			ToPort:   32767,
+			FromPort: ptr.To[int32](30000),
+			ToPort:   ptr.To[int32](32767),
 			Protocol: "tcp",
 		}
 
 		ruleNodesInternalUDP := &awsclient.SecurityGroupRule{
 			Type:     awsclient.SecurityGroupRuleTypeIngress,
-			FromPort: 30000,
-			ToPort:   32767,
+			FromPort: ptr.To[int32](30000),
+			ToPort:   ptr.To[int32](32767),
 			Protocol: "udp",
 		}
 
 		ruleNodesPublicTCP := &awsclient.SecurityGroupRule{
 			Type:     awsclient.SecurityGroupRuleTypeIngress,
-			FromPort: 30000,
-			ToPort:   32767,
+			FromPort: ptr.To[int32](30000),
+			ToPort:   ptr.To[int32](32767),
 			Protocol: "tcp",
 		}
 
 		ruleNodesPublicUDP := &awsclient.SecurityGroupRule{
 			Type:     awsclient.SecurityGroupRuleTypeIngress,
-			FromPort: 30000,
-			ToPort:   32767,
+			FromPort: ptr.To[int32](30000),
+			ToPort:   ptr.To[int32](32767),
 			Protocol: "udp",
 		}
 
 		ruleEfsInboundNFS := &awsclient.SecurityGroupRule{
 			Type:     awsclient.SecurityGroupRuleTypeIngress,
-			FromPort: 2049,
-			ToPort:   2049,
+			FromPort: ptr.To[int32](2049),
+			ToPort:   ptr.To[int32](2049),
 			Protocol: "tcp",
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
Use pointer for FromPort and ToPort in SecurityGroupRule wrapper.
This fixes a bug where a user provided security group port with value 0 would lead to a reconcile error

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-aws/issues/1547

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix a bug where security group port with value 0 leads to a reconcile error
```
