### PR TITLE
Fix tf subnets status

### DIFF
--- a/pkg/controller/infrastructure/tf_reconciler.go
+++ b/pkg/controller/infrastructure/tf_reconciler.go
@@ -587,7 +587,7 @@ func computeProviderStatusSubnets(logger logr.Logger, infrastructure *api.Infras
 			return s.Zone == zone && s.Purpose == purpose
 		})
 		if zoneExists {
-			logger.Info("Skipping subnet addition to status as zones is already present", "zone", zone, "purpose", purpose)
+			logger.Info("Skipping subnet addition to status as zone is already present", "zone", zone, "purpose", purpose)
 			continue
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform aws

**What this PR does / why we need it**:
In case of duplicated zones multiple subnets with the same zone are written into the status.
This can lead to situations where after a reconcile a different subnet is used for the nodes because only one subnet per zone can be used in the machineclass.
With this PR we always use the the first zone entry as subnet in the status.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Always use the same node subnet in case of duplicated zones
```
