### PR TITLE
Update github.com/gardener/gardener to v1.131.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/gardener/etcd-druid/api v0.33.0
 	github.com/gardener/external-dns-management v0.30.0
-	github.com/gardener/gardener v1.131.0
+	github.com/gardener/gardener v1.131.2
 	github.com/gardener/machine-controller-manager v0.60.2
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -960,8 +960,8 @@ github.com/gardener/etcd-druid/api v0.33.0 h1:YwgsYYldaLig2laJMAAMX/dg9/XsQx/LPz
 github.com/gardener/etcd-druid/api v0.33.0/go.mod h1:Qpl1PDJ+bKa6OPWk4o7WBzvjPqZc/CxIXbiTkdRhCrg=
 github.com/gardener/external-dns-management v0.30.0 h1:WqKzai5uidFOMIFvEM57dX8rwlKSAvSSFoj69dPvtTM=
 github.com/gardener/external-dns-management v0.30.0/go.mod h1:56DcKMYG5aaENj5kz9oyfr5ckqawfTW14p2eSkLiwRg=
-github.com/gardener/gardener v1.131.0 h1:6Az0KcZXf78+Ml6tEK+iS9XY4N2VR9Y/3Ltl1rj6mUI=
-github.com/gardener/gardener v1.131.0/go.mod h1:SAUHqtQtT/PDUKClTwbH9/pyEUc2sB1VBl6ko3EC2p4=
+github.com/gardener/gardener v1.131.2 h1:xMCTgErhHA5b6TMKKG82It7WcvdeM0tkY2qDogAIj5Q=
+github.com/gardener/gardener v1.131.2/go.mod h1:SAUHqtQtT/PDUKClTwbH9/pyEUc2sB1VBl6ko3EC2p4=
 github.com/gardener/machine-controller-manager v0.60.2 h1:lY6z67lDlwl9dQUEmlJbrmpxWK10o/rVRUu4JB7xK4U=
 github.com/gardener/machine-controller-manager v0.60.2/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
**How to categorize this PR?**
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
Update github.com/gardener/gardener to v1.131.2

**Which issue(s) this PR fixes**:
This is mainly to fix https://github.com/gardener/gardener/issues/13245 in the provider extension, tl;dr - fixing bug occurring when switching from Workload Identity to static credentials for etcd backups.


**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
The following third party dependencies have been updated:
- github.com/gardener/gardener v1.131.0 -> v1.131.2
```
