### PR TITLE
[release-v1.65] Update github.com/gardener/gardener to v1.129.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/gardener/etcd-druid/api v0.32.0
 	github.com/gardener/external-dns-management v0.28.0
-	github.com/gardener/gardener v1.129.1
+	github.com/gardener/gardener v1.129.4
 	github.com/gardener/machine-controller-manager v0.60.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -960,8 +960,8 @@ github.com/gardener/etcd-druid/api v0.32.0 h1:B3MEBe9q3+Q0jjFb/BhMigde05mYkVjWzV
 github.com/gardener/etcd-druid/api v0.32.0/go.mod h1:Qpl1PDJ+bKa6OPWk4o7WBzvjPqZc/CxIXbiTkdRhCrg=
 github.com/gardener/external-dns-management v0.28.0 h1:zAU5wW7aGkg2Syb/QqN56v/uUWL1BOMvUIE8XPFo87w=
 github.com/gardener/external-dns-management v0.28.0/go.mod h1:ruNKzI+peCHaTJHr14aq9iogiMfwxyOziMv6QFNyx6Y=
-github.com/gardener/gardener v1.129.1 h1:w1WLmEo/1IqLV5vyWI+X+ZbfgX7vkloJf3Rv5Vud8QU=
-github.com/gardener/gardener v1.129.1/go.mod h1:ok40pupWZBJ9nr21WTB5zpuTTt7cw0Al6y0q9cCGYuY=
+github.com/gardener/gardener v1.129.4 h1:A5KPAMIxrpB9b1+VC9VsNNBrtKOUKxaGSglAwxEi5lU=
+github.com/gardener/gardener v1.129.4/go.mod h1:ok40pupWZBJ9nr21WTB5zpuTTt7cw0Al6y0q9cCGYuY=
 github.com/gardener/machine-controller-manager v0.60.0 h1:aaSE85Yu0hcHYsP5/x1rxWa5o2zhmsmXlKQ+xefHY/Q=
 github.com/gardener/machine-controller-manager v0.60.0/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
**How to categorize this PR?**
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
Update github.com/gardener/gardener to v1.129.4

**Which issue(s) this PR fixes**:
This is mainly to fix https://github.com/gardener/gardener/issues/13245 in the provider extension, tl;dr - fixing bug occurring when switching from Workload Identity to static credentials for etcd backups.

**Special notes for your reviewer**:
Can be treated as cherry pick of https://github.com/gardener/gardener-extension-provider-aws/pull/1563

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
The following third party dependencies have been updated:
- github.com/gardener/gardener v1.129.1 -> v1.129.4
```
