### PR TITLE
Ensure NATGateway contains a public IP

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -1929,11 +1929,17 @@ func (c *Client) CreateNATGateway(ctx context.Context, gateway *NATGateway) (*NA
 
 // WaitForNATGatewayAvailable waits until the NAT gateway has state "available" or the context is cancelled.
 func (c *Client) WaitForNATGatewayAvailable(ctx context.Context, id string) error {
+	isNATGatewayReady := func(item *NATGateway) bool {
+		return item != nil &&
+			strings.EqualFold(item.State, string(ec2types.NatGatewayStateAvailable)) &&
+			item.PublicIP != ""
+	}
+
 	return c.PollImmediateUntil(ctx, func(ctx context.Context) (done bool, err error) {
 		if item, err := c.GetNATGateway(ctx, id); err != nil {
 			return false, err
 		} else {
-			return strings.EqualFold(item.State, string(ec2types.NatGatewayStateAvailable)), nil
+			return isNATGatewayReady(item), nil
 		}
 	})
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/platform aws

**What this PR does / why we need it**:
The intent of this PR is to fix our infra tests that are sometimes failing because the NATGateway IP is not yet published in our infra status.
Although we already wait for the NAT to become available we should also wait for it to have a valid public IP.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Ensure NATGateway contains a public IP in the creation step
```
