### PR TITLE
Fix CSI resizer RecoverVolumeExpansionFailure feature gate

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package features
+
+const (
+	// VolumeAttributesClass is the feature gate for VolumeAttributesClass support.
+	// alpha: v1.29
+	// beta: v1.31
+	// GA: v1.34
+	VolumeAttributesClass = "VolumeAttributesClass"
+
+	// RecoverVolumeExpansionFailure is the feature gate for recovering from volume expansion failures.
+	// alpha: v1.23
+	// beta: v1.32
+	//
+	RecoverVolumeExpansionFailure = "RecoverVolumeExpansionFailure"
+)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area bug
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR disables the `RecoverVolumeExpansionFailure` feature gate in the csi-resizer if not all workerpools are on v1.32 and above.

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/gardener-extension-provider-aws/issues/1518

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Disable the `RecoverVolumeExpansionFailure` feature gate in the csi-resizer if not all workerpools are on v1.32 and above
```
