### PR TITLE
Switch VPAs to control memory only

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-vpa.yaml
@@ -9,18 +9,25 @@ spec:
     containerPolicies:
     - containerName: aws-csi-driver
       controlledValues: RequestsOnly
+      controlledResources: ["memory"]
     - containerName: aws-csi-provisioner
       controlledValues: RequestsOnly
+      controlledResources: ["memory"]
     - containerName: aws-csi-attacher
       controlledValues: RequestsOnly
+      controlledResources: ["memory"]
     - containerName: aws-csi-snapshotter
       controlledValues: RequestsOnly
+      controlledResources: ["memory"]
     - containerName: aws-csi-resizer
       controlledValues: RequestsOnly
+      controlledResources: ["memory"]
     - containerName: aws-csi-liveness-probe
       controlledValues: RequestsOnly
+      controlledResources: ["memory"]
     - containerName: aws-csi-volume-modifier
       controlledValues: RequestsOnly
+      controlledResources: ["memory"]
   targetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-controller-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-controller-vpa.yaml
@@ -9,6 +9,7 @@ spec:
     containerPolicies:
     - containerName: aws-csi-snapshot-controller
       controlledValues: RequestsOnly
+      controlledResources: ["memory"]
   targetRef:
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Switch VPAs to control memory only, such that we don't get any recommendations and evictions for CPU changes. VPA can only recommend values > =10m Cores, so we're not really interested in changes for these low-load components.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Seems like this was missed in https://github.com/gardener/gardener-extension-provider-aws/pull/1448

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Switch VPAs to control memory only
```
