### PR TITLE
GetFileSystem: return no error if not found

### DIFF
--- a/pkg/aws/client/mock/mocks.go
+++ b/pkg/aws/client/mock/mocks.go
@@ -1137,19 +1137,19 @@ func (mr *MockInterfaceMockRecorder) GetElasticIPsAssociationIDForAllocationIDs(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetElasticIPsAssociationIDForAllocationIDs", reflect.TypeOf((*MockInterface)(nil).GetElasticIPsAssociationIDForAllocationIDs), ctx, allocationIDs)
 }
 
-// GetFileSystems mocks base method.
-func (m *MockInterface) GetFileSystems(ctx context.Context, fileSystemID string) (*types0.FileSystemDescription, error) {
+// GetFileSystem mocks base method.
+func (m *MockInterface) GetFileSystem(ctx context.Context, fileSystemID string) (*types0.FileSystemDescription, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFileSystems", ctx, fileSystemID)
+	ret := m.ctrl.Call(m, "GetFileSystem", ctx, fileSystemID)
 	ret0, _ := ret[0].(*types0.FileSystemDescription)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetFileSystems indicates an expected call of GetFileSystems.
-func (mr *MockInterfaceMockRecorder) GetFileSystems(ctx, fileSystemID any) *gomock.Call {
+// GetFileSystem indicates an expected call of GetFileSystem.
+func (mr *MockInterfaceMockRecorder) GetFileSystem(ctx, fileSystemID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileSystems", reflect.TypeOf((*MockInterface)(nil).GetFileSystems), ctx, fileSystemID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileSystem", reflect.TypeOf((*MockInterface)(nil).GetFileSystem), ctx, fileSystemID)
 }
 
 // GetIAMInstanceProfile mocks base method.

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -195,7 +195,7 @@ type Interface interface {
 	DeleteEC2Tags(ctx context.Context, resources []string, tags Tags) error
 
 	// Efs
-	GetFileSystems(ctx context.Context, fileSystemID string) (*efstypes.FileSystemDescription, error)
+	GetFileSystem(ctx context.Context, fileSystemID string) (*efstypes.FileSystemDescription, error)
 	FindFileSystemsByTags(ctx context.Context, tags Tags) ([]*efstypes.FileSystemDescription, error)
 	CreateFileSystem(ctx context.Context, input *efs.CreateFileSystemInput) (*efstypes.FileSystemDescription, error)
 	DeleteFileSystem(ctx context.Context, input *efs.DeleteFileSystemInput) error

--- a/pkg/controller/infrastructure/infraflow/delete.go
+++ b/pkg/controller/infrastructure/infraflow/delete.go
@@ -387,7 +387,7 @@ func (c *FlowContext) deleteEfs(ctx context.Context) error {
 	log := LogFromContext(ctx)
 
 	managedEfs, err := FindExisting(ctx, c.state.Get(IdentifierManagedEfsID), c.commonTags.AddManagedTag(),
-		c.client.GetFileSystems, c.client.FindFileSystemsByTags)
+		c.client.GetFileSystem, c.client.FindFileSystemsByTags)
 	if err != nil {
 		return fmt.Errorf("failed to find managed EFS file system: %w", err)
 	}

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -1829,7 +1829,7 @@ func (c *FlowContext) ensureEfsCreateFileSystem(ctx context.Context) error {
 	log := LogFromContext(ctx)
 
 	current, err := FindExisting(ctx, c.state.Get(IdentifierManagedEfsID), c.commonTags.AddManagedTag(),
-		c.client.GetFileSystems, c.client.FindFileSystemsByTags)
+		c.client.GetFileSystem, c.client.FindFileSystemsByTags)
 	if err != nil {
 		return fmt.Errorf("failed to find managed EFS file system: %w", err)
 	}


### PR DESCRIPTION
…alls

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This renames GetFileSystems to GetFileSystem and changes behaviour if no fileSystem is found.

**Which issue(s) this PR fixes**:
Shoot cluster deletion should go through even if the file system is already gone.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix cluster deletion if EFS can not be found
```
