### PR TITLE
move back to public.ecr.aws registry

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -27,12 +27,9 @@ images:
       integrity_requirement: high
       availability_requirement: low
     signing: false
-# We cannot use the upstream repository here as it is not reachable using IPv6.
-# NOTE: Please make sure to copy new image versions when updating the version by adding them to
-#       https://github.com/gardener/ci-infra/blob/master/config/images/images.yaml.
 - name: aws-load-balancer-controller
   sourceRepository: github.com/kubernetes-sigs/aws-load-balancer-controller
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/eks/aws-load-balancer-controller
+  repository: public.ecr.aws/eks/aws-load-balancer-controller
   tag: v2.13.4
   labels:
   - name: gardener.cloud/cve-categorisation
@@ -245,14 +242,11 @@ images:
       integrity_requirement: high
       availability_requirement: low
     signing: false
-# We cannot use the upstream repository here as it is not reachable using IPv6.
-# NOTE: Please make sure to copy new image versions when updating the version by adding them to
-#       https://github.com/gardener/ci-infra/blob/master/config/images/images.yaml.
 # NOTE: volume-modifier-for-k8s has been deprecated in favor of the native Kubernetes VolumeAttributesClass API.
 #       we can get rid of this image once we remove K8s v1.31 support (VolumeAttributesClass graduated to beta).
 - name: csi-volume-modifier
   sourceRepository: github.com/awslabs/volume-modifier-for-k8s
-  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/ebs-csi-driver/volume-modifier-for-k8s
+  repository: public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s
   tag: v0.7.0
   labels:
   - name: gardener.cloud/cve-categorisation


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Move back to `public.ecr.aws` registry for `aws-load-balancer-controller` and `volume-modifier-for-k8s` as it is now reachable via AAAA record.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
https://github.com/gardener/ci-infra/pull/4991
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Move back to `public.ecr.aws` registry for `aws-load-balancer-controller` and `volume-modifier-for-k8s` as it is now reachable via AAAA record.
```
