### PR TITLE
[GEP-26] Fix Route53 client rate limiter key for Workload Identity credentials

### DIFF
--- a/pkg/aws/client/types_route53.go
+++ b/pkg/aws/client/types_route53.go
@@ -58,7 +58,7 @@ func (f *route53Factory) NewClient(authConfig AuthConfig) (Interface, error) {
 	if authConfig.AccessKey != nil {
 		rateLimiterKey = authConfig.AccessKey.ID
 	} else {
-		// In practice singel AWS Role (the same roleARN) can be assumed by multiple Workload Identities.
+		// In practice single AWS Role (the same roleARN) can be assumed by multiple Workload Identities.
 		// A side effect of rate limiter using the roleARN as key is that all Workload Identities assuming the same
 		// RoleARN will be throttled at the same time.
 		// However, most probably on the server side(AWS STS) they would be throttled also on the roleARN


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind bug
/label ipcei/workload-identity
/platform aws

**What this PR does / why we need it**:
Fix Route53 client rate limiter key for Workload Identity credentials

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
/cc @dimityrmirchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug leading to nil pointer exception in the Route53 client when Workload Identity credentials are used has been fixed.
```
