### PR TITLE
Fix BackupBucket validation when ProviderConfig is nil

### DIFF
--- a/pkg/admission/validator/backupbucket.go
+++ b/pkg/admission/validator/backupbucket.go
@@ -64,7 +64,10 @@ func (b *backupBucketValidator) validateCreate(backupBucket *core.BackupBucket) 
 		providerConfigPath = field.NewPath("spec", "providerConfig")
 	)
 
-	allErrs = append(allErrs, awsvalidation.ValidateBackupBucketProviderConfigCreate(b.lenientDecoder, backupBucket.Spec.ProviderConfig, providerConfigPath)...)
+	if backupBucket.Spec.ProviderConfig != nil {
+		allErrs = append(allErrs, awsvalidation.ValidateBackupBucketProviderConfigCreate(b.lenientDecoder, backupBucket.Spec.ProviderConfig, providerConfigPath)...)
+	}
+
 	allErrs = append(allErrs, awsvalidation.ValidateBackupBucketCredentialsRef(backupBucket.Spec.CredentialsRef, credentialsRefPath)...)
 	return allErrs
 }
@@ -79,7 +82,10 @@ func (b *backupBucketValidator) validateUpdate(oldBackupBucket, backupBucket *co
 		providerConfigPath = field.NewPath("spec", "providerConfig")
 	)
 
-	allErrs = append(allErrs, awsvalidation.ValidateBackupBucketProviderConfigUpdate(b.decoder, b.lenientDecoder, oldBackupBucket.Spec.ProviderConfig, backupBucket.Spec.ProviderConfig, providerConfigPath)...)
+	if backupBucket.Spec.ProviderConfig != nil {
+		allErrs = append(allErrs, awsvalidation.ValidateBackupBucketProviderConfigUpdate(b.decoder, b.lenientDecoder, oldBackupBucket.Spec.ProviderConfig, backupBucket.Spec.ProviderConfig, providerConfigPath)...)
+	}
+
 	allErrs = append(allErrs, awsvalidation.ValidateBackupBucketCredentialsRef(backupBucket.Spec.CredentialsRef, credentialsRefPath)...)
 	return allErrs
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/platform aws

**What this PR does / why we need it**:
Fixes nil-pointer dereference during backupBucket validation when providerConfig is nil.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed issue when validating a backupBucket without providerConfig.
```
