### PR TITLE
[release-v1.66] Automated cherry pick of #1629: [GEP-26] Fix Route53 client rate limiter key for Workload Identity credentials

### DIFF
--- a/pkg/aws/client/types_route53.go
+++ b/pkg/aws/client/types_route53.go
@@ -58,7 +58,7 @@ func (f *route53Factory) NewClient(authConfig AuthConfig) (Interface, error) {
 	if authConfig.AccessKey != nil {
 		rateLimiterKey = authConfig.AccessKey.ID
 	} else {
-		// In practice singel AWS Role (the same roleARN) can be assumed by multiple Workload Identities.
+		// In practice single AWS Role (the same roleARN) can be assumed by multiple Workload Identities.
 		// A side effect of rate limiter using the roleARN as key is that all Workload Identities assuming the same
 		// RoleARN will be throttled at the same time.
 		// However, most probably on the server side(AWS STS) they would be throttled also on the roleARN


### PR DESCRIPTION
/area security
/kind bug
/area ipcei

Cherry pick of #1629 on release-v1.66.

#1629: [GEP-26] Fix Route53 client rate limiter key for Workload Identity credentials

**Release Notes:**
```bugfix operator
A bug leading to nil pointer exception in the Route53 client when Workload Identity credentials are used has been fixed.
```