### PR TITLE
Add health check condition `RouteControllerActive` to control plane

### DIFF
--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -69,6 +69,11 @@ func RegisterHealthChecks(_ context.Context, mgr manager.Manager, opts healthche
 				HealthCheck:   newCustomRouteControllerHealthCheck(general.NewSeedDeploymentHealthChecker(aws.AWSCustomRouteControllerName)),
 				// no precheck needed, as the deployment is always created (with replicas=0 if not enabled, see valuesprovider.go)
 			},
+			{
+				ConditionType: string("RouteControllerActive"),
+				HealthCheck:   routeControllerActiveHealthCheck(general.NewSeedDeploymentHealthChecker(aws.AWSCustomRouteControllerName)),
+				// no precheck needed, as the deployment is always created (with replicas=0 if not enabled, see valuesprovider.go)
+			},
 		},
 		sets.New[gardencorev1beta1.ConditionType](),
 	); err != nil {

--- a/pkg/controller/healthcheck/routecontrolleractive.go
+++ b/pkg/controller/healthcheck/routecontrolleractive.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/extensions/pkg/controller/healthcheck"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
+)
+
+// routeControllerActiveHealthCheck creates a health check that verifies if the route controller is actively running
+func routeControllerActiveHealthCheck(deploymentCheck healthcheck.HealthCheck) healthcheck.HealthCheck {
+	return &routeControllerActiveCheck{
+		deploymentCheck: deploymentCheck,
+	}
+}
+
+type routeControllerActiveCheck struct {
+	seedClient      client.Client
+	logger          logr.Logger
+	deploymentCheck healthcheck.HealthCheck
+}
+
+var _ healthcheck.HealthCheck = &routeControllerActiveCheck{}
+
+// Check verifies if the route controller is actively running (replicas > 0)
+func (hc *routeControllerActiveCheck) Check(ctx context.Context, request types.NamespacedName) (*healthcheck.SingleCheckResult, error) {
+	deployment := &appsv1.Deployment{}
+	deploymentName := types.NamespacedName{
+		Name:      aws.AWSCustomRouteControllerName,
+		Namespace: request.Namespace,
+	}
+	if err := hc.seedClient.Get(ctx, deploymentName, deployment); err != nil {
+		err := fmt.Errorf("failed to get deployment %s: %w", aws.AWSCustomRouteControllerName, err)
+		hc.logger.Error(err, "Failed to check if route controller is active")
+		return nil, err
+	}
+
+	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas == 0 {
+		return &healthcheck.SingleCheckResult{
+			Status: gardencorev1beta1.ConditionFalse,
+			Detail: "Route controller is not active (replicas=0)",
+		}, nil
+	}
+
+	result, err := hc.deploymentCheck.Check(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Status == gardencorev1beta1.ConditionTrue {
+		return &healthcheck.SingleCheckResult{
+			Status: gardencorev1beta1.ConditionTrue,
+			Detail: "Route controller is active and healthy",
+		}, nil
+	}
+
+	return result, nil
+}
+
+// SetLoggerSuffix sets the logger suffix
+func (hc *routeControllerActiveCheck) SetLoggerSuffix(provider, extension string) {
+	hc.logger = log.Log.WithName(fmt.Sprintf("%s-healthcheck-route-controller-active", provider))
+	hc.deploymentCheck.SetLoggerSuffix(provider, extension)
+}
+
+// InjectSeedClient injects the seed client
+func (hc *routeControllerActiveCheck) InjectSeedClient(seedClient client.Client) {
+	hc.seedClient = seedClient
+	if itf, ok := hc.deploymentCheck.(healthcheck.SeedClient); ok {
+		itf.InjectSeedClient(seedClient)
+	}
+}
+
+// InjectShootClient injects the shoot client
+func (hc *routeControllerActiveCheck) InjectShootClient(shootClient client.Client) {
+	if itf, ok := hc.deploymentCheck.(healthcheck.ShootClient); ok {
+		itf.InjectShootClient(shootClient)
+	}
+}
+
+// DeepCopy creates a deep copy of the health check
+func (hc *routeControllerActiveCheck) DeepCopy() healthcheck.HealthCheck {
+	return &routeControllerActiveCheck{
+		seedClient:      hc.seedClient,
+		logger:          hc.logger,
+		deploymentCheck: hc.deploymentCheck,
+	}
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:

This PR adds a new health check condition `RouteControllerActive` that monitors whether the AWS custom route controller is actively running in the control plane. RouteControllerActive (new): Returns `False` when the route controller is disabled (replicas=0) and `True` only when it's actively running with replicas > 0. 

The health check condition looks like:

```
  {
    "lastTransitionTime": "2026-01-09T14:10:08Z",
    "lastUpdateTime": "2026-01-09T14:10:08Z",
    "message": "All health checks successful",
    "reason": "HealthCheckSuccessful",
    "status": "True",
    "type": "RouteControllerActive"
  }
```

The `RouteControllerActive` condition is required by the [calico extension](https://github.com/gardener/gardener-extension-networking-calico) to know when a transition from overlay network to native routing can happen seamlessly.
For more information see: https://github.com/gardener/gardener-extension-networking-calico/pull/765
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add a new health check condition `RouteControllerActive` that monitors whether the AWS custom route controller is actively running in the control plane.
```
