### PR TITLE
Clean up unused constant

### DIFF
--- a/pkg/aws/types.go
+++ b/pkg/aws/types.go
@@ -137,10 +137,6 @@ const (
 	// RoleARN is a constant for the key in a cloud provider secret that points to the role which should be assumed.
 	RoleARN = "roleARN"
 
-	// CSISnapshotValidationName is the constant for the name of the csi-snapshot-validation-webhook component.
-	// TODO(AndreasBurger): Clean up once SnapshotValidation is removed everywhere
-	CSISnapshotValidationName = "csi-snapshot-validation"
-
 	// CSIEfsNodeName is the constant for the name of the efs csi node deployment.
 	CSIEfsNodeName = "csi-driver-efs-node"
 	// CSIEfsControllerName is the constant for the name of the efs csi controller deployment.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform aws

**What this PR does / why we need it**:
No longer used after https://github.com/gardener/gardener-extension-provider-aws/pull/1506.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-provider-aws/pull/1506

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
