### PR TITLE
Add missing keys to AWS secret validation's expected keys

### DIFF
--- a/pkg/apis/aws/validation/secrets.go
+++ b/pkg/apis/aws/validation/secrets.go
@@ -7,6 +7,7 @@ package validation
 import (
 	"fmt"
 
+	securityv1alpha1constants "github.com/gardener/gardener/pkg/apis/security/v1alpha1/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -48,7 +49,9 @@ func ValidateCloudProviderSecret(secret *corev1.Secret, fldPath *field.Path, kin
 
 		// Validate no unexpected keys exist
 		allErrs = append(allErrs, validateNoUnexpectedKeys(secret.Data, dataPath, secretRef,
-			aws.AccessKeyID, aws.SecretAccessKey)...)
+			aws.AccessKeyID, aws.SecretAccessKey, aws.Region,
+			aws.SharedCredentialsFile, securityv1alpha1constants.DataKeyConfig,
+			aws.RoleARN, aws.WorkloadIdentityTokenFileKey)...)
 
 	case SecretKindDns:
 		// For DNS secrets, check for DNS-specific key aliases first, then fall back to
@@ -77,10 +80,10 @@ func ValidateCloudProviderSecret(secret *corev1.Secret, fldPath *field.Path, kin
 
 		if hasStandardAccessKey || hasStandardSecretKey {
 			allErrs = append(allErrs, validateNoUnexpectedKeys(secret.Data, dataPath, secretRef,
-				aws.AccessKeyID, aws.SecretAccessKey)...)
+				aws.AccessKeyID, aws.SecretAccessKey, aws.Region)...)
 		} else {
 			allErrs = append(allErrs, validateNoUnexpectedKeys(secret.Data, dataPath, secretRef,
-				aws.DNSAccessKeyID, aws.DNSSecretAccessKey)...)
+				aws.DNSAccessKeyID, aws.DNSSecretAccessKey, aws.DNSRegion)...)
 		}
 
 	default:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/platform aws

**What this PR does / why we need it**:
This PR adds missing keys to the list of expected keys for the validation of infrastructure and dns secrets.
The complete list of possible keys is:
1. for infra secrets:
  a. without workload identity: accessKeyID, secretAccessKey, region (optional), SharedCredentialsFile (optional)
  b. with workload identity: config, SharedCredentialsFile (optional), roleARN (optional), webIdentityTokenFile (optional)
2. for dns secrets: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION (optional)

The keys 
1. for infra secrets:
  a. without workload identity: SharedCredentialsFile (optional)
  b. with workload identity: SharedCredentialsFile (optional), roleARN (optional), webIdentityTokenFile (optional)

are added by https://github.com/gardener/gardener-extension-provider-aws/blob/master/pkg/webhook/cloudprovider/ensurer.go#L35 and may then be present in update operations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The validation of the values for the keys SharedCredentialsFile, roleARN, webIdentityTokenFile is not required since it's no user input. In contrast to that, validation for region and config is missing so far. Since it may require a refactoring of the existing code I'll create a separate PR for that.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
