### PR TITLE
Allow `aws-custom-route-controller` to write events of group `events.k8s.io`

### DIFF
--- a/charts/internal/shoot-system-components/charts/aws-custom-route-controller/templates/clusterrole.yaml
+++ b/charts/internal/shoot-system-components/charts/aws-custom-route-controller/templates/clusterrole.yaml
@@ -36,5 +36,8 @@ rules:
     - events
     verbs:
     - create
+    - get
+    - list
     - patch
     - update
+    - watch


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind task
/platform aws

**What this PR does / why we need it**:
Future versions of the aws-custom-route-controllers will write events of group `events.k8s.io`. Permissions need to be adjusted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
See https://github.com/gardener/aws-custom-route-controller/pull/404

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow `aws-custom-route-controller` to write events of group `events.k8s.io`
```
