### PR TITLE
add s3 eusc policy partition

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -417,11 +417,14 @@ func (c *Client) CreateBucket(ctx context.Context, bucket, region string, object
 	// Handle bucket policy IAM ARN for different partitions (AWS region groups)
 	// Different available partitions in AWS are defined at
 	// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html
+	// https://github.com/aws/aws-sdk-go-v2/blob/main/internal/endpoints/awsrulesfn/partitions.json
 	arnPartition := "aws"
 	if strings.HasPrefix(region, "cn-") {
 		arnPartition = "aws-cn" // China regions
 	} else if strings.HasPrefix(region, "us-gov-") {
 		arnPartition = "aws-us-gov" // AWS GovCloud (US) regions
+	} else if strings.HasPrefix(region, "eusc-") { // e.g. "eusc-de-east-1"
+		arnPartition = "aws-eusc" // AWS EUSC region
 	}
 
 	// Set bucket policy to deny non-HTTPS requests


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Relies on release of https://github.com/gardener/etcd-backup-restore v0.41.x to be tested along.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add missing s3 policy partition for EUSC region
```
