### PR TITLE
Remove deprecated flow annotation constants

### DIFF
--- a/pkg/apis/aws/const.go
+++ b/pkg/apis/aws/const.go
@@ -5,20 +5,6 @@
 package aws
 
 const (
-	// AnnotationKeyUseFlow is the annotation key used to enable reconciliation with flow instead of terraformer.
-	AnnotationKeyUseFlow = "aws.provider.extensions.gardener.cloud/use-flow"
-	// GlobalAnnotationKeyUseFlow is the annotation key used to enable reconciliation with flow instead of terraformer.
-	GlobalAnnotationKeyUseFlow = "provider.extensions.gardener.cloud/use-flow"
-	// SeedAnnotationKeyUseFlow is the label for seeds to enable flow reconciliation for all of its shoots if value is `true`
-	// or for new shoots only with value `new`
-	SeedAnnotationKeyUseFlow = AnnotationKeyUseFlow
-	// SeedAnnotationUseFlowValueNew is the value to restrict flow reconciliation to new shoot clusters
-	SeedAnnotationUseFlowValueNew = "new"
 	// AnnotationKeyIPStack is the annotation key to set the IP stack for a DNSRecord.
 	AnnotationKeyIPStack = "dns.gardener.cloud/ip-stack"
-)
-
-var (
-	// ValidFlowAnnotations is a list of all the available annotations to indicate the use of the flow reconciler.
-	ValidFlowAnnotations = []string{AnnotationKeyUseFlow, GlobalAnnotationKeyUseFlow}
 )


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/platform aws

**What this PR does / why we need it**:
This is a cleanup of constants that are no longer used anywhere after we merged: https://github.com/gardener/gardener-extension-provider-aws/pull/1617

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
