### PR TITLE
Downgrade `cloud-controller-manager` for kubernetes `1.31` to `v1.31.8`

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -59,7 +59,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-aws
   repository: registry.k8s.io/provider-aws/cloud-controller-manager
-  tag: v1.31.9
+  tag: v1.31.8
   labels:
   - name: gardener.cloud/cve-categorisation
     value:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:
[cloud-provider-aws](https://github.com/kubernetes/cloud-provider-aws) `v1.31.9`  has an issue when services of type LoadBalancer are reconciled, after they have been created, due to which it tries to re-add already existing `ipPermissions` to the security groups created for the LoadBalancers. This leads to the following error:
```
E0128 11:53:01.803364       1 controller.go:302] "Unhandled Error" err="error processing service istio-system/istio-ingressgateway (retrying with exponential backoff): failed to ensure load balancer: error authorizing security group ingress: \"operation error EC2: AuthorizeSecurityGroupIngress, https response error StatusCode: 400, RequestID: d545ac47-ae41-4cf0-a3b9-36460b06ab4f, api error InvalidPermission.Duplicate: the specified rule \\\"peer: 0.0.0.0/0, ICMP, type: 3, code: 4, ALLOW\\\" already exists\"" logger="UnhandledError"
```

This can happen if the service's spec or annotations are modified, or if [cloud-provider-aws](https://github.com/kubernetes/cloud-provider-aws) is restarted.

This issue was fixed with https://github.com/kubernetes/cloud-provider-aws/pull/1207, however the fix was not cherry-picked to the `v1.31` releases. Additionally, it seems that the error first appeared after the AWS SDK was migrated from V1 to V2, which was included in `v1.31.9`

`v1.31.8` still uses the V1 AWS SDK and this error does not happen there. I was able to successfully create a shoot cluster, and then reconcile a LoadBalancer service multiple times with the downgraded version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The cloud-controller-manager image used for `Shoot` clusters running on kubernetes `1.31` was downgraded from `v1.31.9` to `v1.31.8`. This was done to resolve an issue that caused reconciliations of `Service`s of type LoadBalancer to fail because of attempts to add already existing `IpPermission` rules to the security groups created for the LoadBalancers.
```
