### PR TITLE
Add check for non-empty IPv6 CIDR block before updating state

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -232,7 +232,9 @@ func (c *FlowContext) ensureManagedVpc(ctx context.Context) error {
 
 	if current != nil {
 		c.state.Set(IdentifierVPC, current.VpcId)
-		c.state.Set(IdentifierVpcIPv6CidrBlock, current.IPv6CidrBlock)
+		if current.IPv6CidrBlock != "" {
+			c.state.Set(IdentifierVpcIPv6CidrBlock, current.IPv6CidrBlock)
+		}
 		_, err := c.updater.UpdateVpc(ctx, desired, current)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/platform aws

**What this PR does / why we need it**:
While testing k8s 1.35 I ended up having a VPC with an IPv6 CIDR although my shoot was IPv4 only.
This PR adds a check for non-empty IPv6 CIDR block before updating the state.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Add check for non-empty IPv6 CIDR block before updating state
```
