### PR TITLE
Treat infra and dns secrets the same in validation

### DIFF
--- a/pkg/admission/validator/credentialsbinding.go
+++ b/pkg/admission/validator/credentialsbinding.go
@@ -59,7 +59,7 @@ func (cb *credentialsBinding) Validate(ctx context.Context, newObj, oldObj clien
 			return err
 		}
 
-		return awsvalidation.ValidateCloudProviderSecret(secret, field.NewPath("secret"), awsvalidation.SecretKindInfrastructure).ToAggregate()
+		return awsvalidation.ValidateCloudProviderSecret(secret, field.NewPath("secret")).ToAggregate()
 	case credentialsBinding.CredentialsRef.APIVersion == securityv1alpha1.SchemeGroupVersion.String() && credentialsBinding.CredentialsRef.Kind == "WorkloadIdentity":
 		workloadIdentity := &securityv1alpha1.WorkloadIdentity{}
 		if err := cb.apiReader.Get(ctx, credentialsKey, workloadIdentity); err != nil {

--- a/pkg/admission/validator/secretbinding.go
+++ b/pkg/admission/validator/secretbinding.go
@@ -59,5 +59,5 @@ func (sb *secretBinding) Validate(ctx context.Context, newObj, oldObj client.Obj
 		return err
 	}
 
-	return awsvalidation.ValidateCloudProviderSecret(secret, field.NewPath("secret"), awsvalidation.SecretKindInfrastructure).ToAggregate()
+	return awsvalidation.ValidateCloudProviderSecret(secret, field.NewPath("secret")).ToAggregate()
 }

--- a/pkg/admission/validator/secrets.go
+++ b/pkg/admission/validator/secrets.go
@@ -42,5 +42,5 @@ func (s *secret) Validate(_ context.Context, newObj, oldObj client.Object) error
 		}
 	}
 
-	return awsvalidation.ValidateCloudProviderSecret(secret, field.NewPath("secret"), awsvalidation.SecretKindInfrastructure).ToAggregate()
+	return awsvalidation.ValidateCloudProviderSecret(secret, field.NewPath("secret")).ToAggregate()
 }

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -259,7 +259,7 @@ func (s *shoot) validateDNS(ctx context.Context, shoot *core.Shoot) field.ErrorL
 			continue
 		}
 
-		allErrs = append(allErrs, awsvalidation.ValidateCloudProviderSecret(secret, providerFldPath, awsvalidation.SecretKindDns)...)
+		allErrs = append(allErrs, awsvalidation.ValidateCloudProviderSecret(secret, providerFldPath)...)
 	}
 
 	return allErrs


### PR DESCRIPTION
* Remove SecretKind parameter
* Allow region key in both infra and dns secrets
* refactor by introducing helper functions
* adapt tests

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind regression
/platform aws

**What this PR does / why we need it**:
This PR removes the different validation logic for infrastructure and dns secrets in the input validation. This is required because some stakeholders use one secret for both.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow to use one secret as an infrastructure secret as well as a dns secret.
```
