### PR TITLE
Add support for (local) multiplatform container images build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.26.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.0 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-aws
 
@@ -11,8 +11,10 @@ RUN go mod download
 COPY . .
 
 ARG EFFECTIVE_VERSION
+ARG TARGETOS
+ARG TARGETARCH
 
-RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
+RUN make build GOOS=$TARGETOS GOARCH=$TARGETARCH EFFECTIVE_VERSION=$EFFECTIVE_VERSION BUILD_OUTPUT_FILE="/output/bin/"
 
 ############# base
 FROM gcr.io/distroless/static-debian12:nonroot AS base
@@ -21,12 +23,12 @@ FROM gcr.io/distroless/static-debian12:nonroot AS base
 FROM base AS gardener-extension-provider-aws
 WORKDIR /
 
-COPY --from=builder /go/bin/gardener-extension-provider-aws /gardener-extension-provider-aws
+COPY --from=builder /output/bin/gardener-extension-provider-aws /gardener-extension-provider-aws
 ENTRYPOINT ["/gardener-extension-provider-aws"]
 
 ############# gardener-extension-admission-aws
 FROM base AS gardener-extension-admission-aws
 WORKDIR /
 
-COPY --from=builder /go/bin/gardener-extension-admission-aws /gardener-extension-admission-aws
+COPY --from=builder /output/bin/gardener-extension-admission-aws /gardener-extension-admission-aws
 ENTRYPOINT ["/gardener-extension-admission-aws"]

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ WEBHOOK_CONFIG_URL	:= host.docker.internal:$(WEBHOOK_CONFIG_PORT)
 EXTENSION_NAMESPACE	:= garden
 GARDEN_KUBECONFIG 	?=
 
-PLATFORM := linux/amd64
+TARGET_PLATFORMS    ?= linux/$(shell go env GOARCH)
 
 WEBHOOK_PARAM := --webhook-config-url=$(WEBHOOK_CONFIG_URL)
 ifeq ($(WEBHOOK_CONFIG_MODE), service)
@@ -97,17 +97,25 @@ install:
 	@LD_FLAGS=$(LD_FLAGS) EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) \
 	bash $(GARDENER_HACK_DIR)/install.sh ./...
 
+BUILD_OUTPUT_FILE ?= .
+BUILD_PACKAGES ?= ./...
+
+.PHONY: build
+build:
+	@LD_FLAGS=$(LD_FLAGS) EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) \
+	bash $(GARDENER_HACK_DIR)/build.sh -o $(BUILD_OUTPUT_FILE) $(BUILD_PACKAGES)
+
 .PHONY: docker-login
 docker-login:
 	@gcloud auth activate-service-account --key-file .kube-secrets/gcr/gcr-readwrite.json
 
 .PHONY: docker-image-provider
 docker-image-provider:
-	@docker buildx build --load --platform=$(PLATFORM) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(NAME):$(VERSION)           -t $(IMAGE_PREFIX)/$(NAME):latest           -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME)           .
+	@docker buildx build --load --platform=$(TARGET_PLATFORMS) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME) .
 
 .PHONY: docker-image-admission
 docker-image-admission:
-	@docker buildx build --load --platform=$(PLATFORM) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(ADMISSION_NAME) .
+	@docker buildx build --load --platform=$(TARGET_PLATFORMS) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(ADMISSION_NAME) .
 
 .PHONY: docker-images
 docker-images: docker-image-provider docker-image-admission


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Add support for (local) multiplatform container images build.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Same as https://github.com/gardener/gardener-extension-provider-gcp/pull/1322

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Gardener extension provider-aws container images now can be built for multiple platforms locally via the variable `TARGET_PLATFORMS`, e.g. `make docker-images TARGET_PLATFORMS=linux/amd64,linux/arm64`. If the variable is unset, the container images are built for the platform `linux/<host-arch>` only.
```

```breaking developer
The `PLATFORM` makefile variable has been replaced by `TARGET_PLATFORM`. 
```
