### PR TITLE
fix: Add (currently) still required `pull-requests: write` permission

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,7 @@ jobs:
     uses: gardener/cc-utils/.github/workflows/prepare.yaml@master
     permissions:
       id-token: write
+      pull-requests: write # required until https://github.com/gardener/cc-utils/pull/1529 is merged
     with:
       mode: ${{ inputs.mode }}
       version-operation: ${{ inputs.release-version }}

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -26,6 +26,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      pull-requests: write
 
   component-descriptor:
     if: ${{ github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && github.event.label.name == vars.DEFAULT_LABEL_OK_TO_TEST && vars.DEFAULT_LABEL_OK_TO_TEST != '') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      pull-requests: write
     with:
       mode: release
       release-version: ${{ inputs.release-version }}


### PR DESCRIPTION
Required to remove `ok-to-test` labels from PRs until https://github.com/gardener/cc-utils/pull/1529 is merged.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
