### PR TITLE
CustomRouteController Healthcheck does not properly inject k8s clients

### DIFF
--- a/pkg/controller/healthcheck/customroutecontrollerhealth.go
+++ b/pkg/controller/healthcheck/customroutecontrollerhealth.go
@@ -92,15 +92,15 @@ func (hc *CustomRouteControllerHealthCheck) SetLoggerSuffix(provider, extension 
 	hc.deploymentCheck.SetLoggerSuffix(provider, extension)
 }
 
-// InjectSeedClient injects the seed client
-func (hc *CustomRouteControllerHealthCheck) InjectSeedClient(seedClient client.Client) {
+// InjectSourceClient injects the seed client into the health check and also into the underlying deployment health check.
+func (hc *CustomRouteControllerHealthCheck) InjectSourceClient(seedClient client.Client) {
 	if itf, ok := hc.deploymentCheck.(healthcheck.SourceClient); ok {
 		itf.InjectSourceClient(seedClient)
 	}
 }
 
-// InjectShootClient injects the shoot client
-func (hc *CustomRouteControllerHealthCheck) InjectShootClient(shootClient client.Client) {
+// InjectTargetClient injects the shoot client into the health check and also into the underlying deployment health check.
+func (hc *CustomRouteControllerHealthCheck) InjectTargetClient(shootClient client.Client) {
 	if itf, ok := hc.deploymentCheck.(healthcheck.TargetClient); ok {
 		itf.InjectTargetClient(shootClient)
 	}

--- a/pkg/controller/healthcheck/customroutecontrollerhealth_test.go
+++ b/pkg/controller/healthcheck/customroutecontrollerhealth_test.go
@@ -143,7 +143,7 @@ func runHealthCheckWithEvent(event *corev1.Event, scheme *runtime.Scheme) (*heal
 	}
 
 	hc := chealthcheck.NewCustomRouteControllerHealthCheck(deploymentCheck)
-	hc.InjectShootClient(shootClient)
+	hc.InjectTargetClient(shootClient)
 	hc.Logger = logr.Discard()
 
 	return hc.Check(context.Background(), types.NamespacedName{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Introduced with https://github.com/gardener/gardener-extension-provider-aws/pull/1677

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
