### PR TITLE
fix cleanup logic when shoot is going to hibernation or waking up

### DIFF
--- a/pkg/controller/controlplane/actuator.go
+++ b/pkg/controller/controlplane/actuator.go
@@ -68,8 +68,9 @@ func (a *actuator) Reconcile(
 
 	// Clean up NetworkUnavailable conditions set by Calico only when overlay is disabled
 	// Only run cleanup if it hasn't been completed yet (annotation not present)
-	if !overlayEnabled && cp.Annotations[AnnotationCalicoCleanupCompleted] != "true" {
-		if err := a.cleanupCalicoNetworkUnavailableConditions(ctx, log, cp.Namespace, cluster); err != nil {
+	// Skip if cluster is hibernated or transitioning (hibernating/waking up)
+	if !overlayEnabled && !extensionscontroller.IsHibernated(cluster) && !extensionscontroller.IsHibernatingOrWakingUp(cluster) && cp.Annotations[AnnotationCalicoCleanupCompleted] != "true" {
+		if err := a.cleanupCalicoNetworkUnavailableConditions(ctx, log, cp.Namespace); err != nil {
 			log.Error(err, "Failed to cleanup Calico NetworkUnavailable conditions")
 			return ok, err
 		} else {
@@ -98,12 +99,7 @@ func (a *actuator) cleanupCalicoNetworkUnavailableConditions(
 	ctx context.Context,
 	log logr.Logger,
 	namespace string,
-	cluster *extensionscontroller.Cluster,
 ) error {
-	if extensionscontroller.IsHibernated(cluster) {
-		return nil
-	}
-
 	_, shootClient, err := util.NewClientForShoot(ctx, a.client, namespace, client.Options{}, extensionsconfigv1alpha1.RESTOptions{})
 	if err != nil {
 		return fmt.Errorf("could not create shoot client: %w", err)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform aws

**What this PR does / why we need it**:
Fix cleanup logic when shoot is going to hibernation or waking up.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix cleanup logic when shoot is going to hibernation or waking up.
```
