### PR TITLE
Revert CIDR validation enhancement for now

### DIFF
--- a/pkg/controller/infrastructure/configvalidator.go
+++ b/pkg/controller/infrastructure/configvalidator.go
@@ -11,14 +11,12 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	apiaws "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/helper"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
 	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
@@ -69,8 +67,7 @@ func (c *configValidator) Validate(ctx context.Context, infra *extensionsv1alpha
 	// Validate infrastructure config
 	if config.Networks.VPC.ID != nil {
 		logger.Info("Validating infrastructure networks.vpc.id")
-		allErrs = append(allErrs, c.validateVPC(ctx, field.NewPath("networks", "vpc", "id"),
-			awsClient, *config, *config.Networks.VPC.ID, infra.Spec.Region)...)
+		allErrs = append(allErrs, c.validateVPC(ctx, awsClient, *config.Networks.VPC.ID, infra.Spec.Region, field.NewPath("networks", "vpc", "id"), config.DualStack != nil && config.DualStack.Enabled)...)
 	}
 
 	var (
@@ -92,8 +89,7 @@ func (c *configValidator) Validate(ctx context.Context, infra *extensionsv1alpha
 	return allErrs
 }
 
-func (c *configValidator) validateVPC(ctx context.Context, fldPath *field.Path, awsClient awsclient.Interface,
-	infraConfig apiaws.InfrastructureConfig, vpcID, region string) field.ErrorList {
+func (c *configValidator) validateVPC(ctx context.Context, awsClient awsclient.Interface, vpcID, region string, fldPath *field.Path, dualStack bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Verify that the VPC exists and the enableDnsSupport and enableDnsHostnames VPC attributes are both true
@@ -112,7 +108,6 @@ func (c *configValidator) validateVPC(ctx context.Context, fldPath *field.Path, 
 		}
 	}
 
-	dualStack := infraConfig.DualStack != nil && infraConfig.DualStack.Enabled
 	if dualStack {
 		_, err := awsClient.GetIPv6Cidr(ctx, vpcID)
 		if err != nil {
@@ -142,23 +137,6 @@ func (c *configValidator) validateVPC(ctx context.Context, fldPath *field.Path, 
 		allErrs = append(allErrs, field.Invalid(fldPath, vpcID, "missing domain-name value in DHCP options used by the VPC"))
 	} else if (region == "us-east-1" && domainName != "ec2.internal") || (region != "us-east-1" && domainName != region+".compute.internal") {
 		allErrs = append(allErrs, field.Invalid(fldPath, vpcID, fmt.Sprintf("invalid domain-name specified in DHCP options used by VPC: %s", domainName)))
-	}
-
-	// crosscheck subnet CIDRs are subset of VPC CIDR
-	vpc, err := awsClient.GetVpc(ctx, vpcID)
-	if err != nil {
-		allErrs = append(allErrs, field.InternalError(fldPath, fmt.Errorf("could not get CIDR block for VPC %s: %w", vpcID, err)))
-		return allErrs
-	}
-	networkingPath := field.NewPath("networking")
-	vpcCIDR := cidrvalidation.NewCIDR(vpc.CidrBlock, fldPath)
-	for _, zones := range infraConfig.Networks.Zones {
-		zoneSubnetCIDRs := []cidrvalidation.CIDR{
-			cidrvalidation.NewCIDR(zones.Workers, networkingPath.Child("nodes")),
-			cidrvalidation.NewCIDR(zones.Public, networkingPath.Child("public")),
-			cidrvalidation.NewCIDR(zones.Internal, networkingPath.Child("internal")),
-		}
-		allErrs = append(allErrs, vpcCIDR.ValidateSubset(zoneSubnetCIDRs...)...)
 	}
 
 	return allErrs

--- a/pkg/controller/infrastructure/configvalidator_test.go
+++ b/pkg/controller/infrastructure/configvalidator_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
 	"github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -39,10 +40,11 @@ import (
 )
 
 const (
-	name            = "infrastructure"
-	namespace       = "shoot--foobar--aws"
-	region          = "eu-west-1"
-	vpcID           = "vpc-123456"
+	name      = "infrastructure"
+	namespace = "shoot--foobar--aws"
+	region    = "eu-west-1"
+	vpcID     = "vpc-123456"
+
 	accessKeyID     = "accessKeyID"
 	secretAccessKey = "secretAccessKey"
 )
@@ -59,50 +61,100 @@ var _ = Describe("ConfigValidator", func() {
 		infra            *extensionsv1alpha1.Infrastructure
 		secret           *corev1.Secret
 		authConfig       awsclient.AuthConfig
+
+		mgr *mockmanager.MockManager
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
+
 		c = mockclient.NewMockClient(ctrl)
 		awsClientFactory = mockawsclient.NewMockFactory(ctrl)
 		awsClient = mockawsclient.NewMockInterface(ctrl)
+
 		ctx = context.TODO()
 		logger = log.Log.WithName("test")
 
-		mgr := mockmanager.NewMockManager(ctrl)
+		mgr = mockmanager.NewMockManager(ctrl)
 		mgr.EXPECT().GetClient().Return(c)
+
 		cv = NewConfigValidator(mgr, awsClientFactory, logger)
 
-		// shared infra + secret setup
-		infra = baseInfra(region, ptr.To(vpcID))
-		secret, authConfig = baseSecretAuth(accessKeyID, secretAccessKey, region)
-
-		c.EXPECT().Get(ctx, client.ObjectKey{Namespace: infra.Namespace, Name: infra.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-			DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-				*obj = *secret
-				return nil
-			})
-		awsClientFactory.EXPECT().NewClient(authConfig).Return(awsClient, nil)
+		infra = &extensionsv1alpha1.Infrastructure{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: extensionsv1alpha1.InfrastructureSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type: aws.Type,
+					ProviderConfig: &runtime.RawExtension{
+						Raw: encode(&apisaws.InfrastructureConfig{
+							Networks: apisaws.Networks{
+								VPC: apisaws.VPC{
+									ID: ptr.To(vpcID),
+								},
+							},
+						}),
+					},
+				},
+				Region: region,
+				SecretRef: corev1.SecretReference{
+					Name:      name,
+					Namespace: namespace,
+				},
+			},
+		}
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				aws.AccessKeyID:     []byte(accessKeyID),
+				aws.SecretAccessKey: []byte(secretAccessKey),
+			},
+		}
+		authConfig = awsclient.AuthConfig{
+			AccessKey: &awsclient.AccessKey{
+				ID:     accessKeyID,
+				Secret: secretAccessKey,
+			},
+			Region: region,
+		}
 	})
 
-	AfterEach(func() { ctrl.Finish() })
+	AfterEach(func() {
+		ctrl.Finish()
+	})
 
-	Context("VPC validation", func() {
-		It("allows existing VPC with correct attributes and IGW", func() {
-			expectValidVPCAttributes(ctx, awsClient, vpcID)
-			expectValidDHCPOptions(ctx, awsClient, vpcID, region)
-			expectGetVpc(ctx, awsClient, vpcID, "")
+	Describe("#Validate", func() {
+		var (
+			validDHCPOptions map[string]string
+		)
 
-			Expect(cv.Validate(ctx, infra)).To(BeEmpty())
+		BeforeEach(func() {
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+				func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+					*obj = *secret
+					return nil
+				},
+			)
+			awsClientFactory.EXPECT().NewClient(authConfig).Return(awsClient, nil)
+
+			validDHCPOptions = map[string]string{
+				"domain-name": region + ".compute.internal",
+			}
 		})
 
-		It("fails when VPC attribute retrieval errors", func() {
-			awsClient.EXPECT().GetVPCAttribute(ctx, vpcID, ec2types.VpcAttributeNameEnableDnsSupport).
-				Return(false, errors.New("test"))
-			Expect(cv.Validate(ctx, infra)).To(ConsistOfFields(Fields{
-				"Type":   Equal(field.ErrorTypeInternal),
-				"Field":  Equal("networks.vpc.id"),
-				"Detail": Equal(fmt.Sprintf("could not get VPC attribute enableDnsSupport for VPC %s: test", vpcID)),
+		It("should forbid VPC that doesn't exist", func() {
+			awsClient.EXPECT().GetVPCAttribute(ctx, vpcID, ec2types.VpcAttributeNameEnableDnsSupport).Return(false, &smithy.GenericAPIError{Code: "InvalidVpcID.NotFound"})
+
+			errorList := cv.Validate(ctx, infra)
+			Expect(errorList).To(ConsistOfFields(Fields{
+				"Type":  Equal(field.ErrorTypeNotFound),
+				"Field": Equal("networks.vpc.id"),
 			}))
 		})
 
@@ -110,8 +162,7 @@ var _ = Describe("ConfigValidator", func() {
 			awsClient.EXPECT().GetVPCAttribute(ctx, vpcID, ec2types.VpcAttributeNameEnableDnsSupport).Return(false, nil)
 			awsClient.EXPECT().GetVPCAttribute(ctx, vpcID, ec2types.VpcAttributeNameEnableDnsHostnames).Return(false, nil)
 			awsClient.EXPECT().GetVPCInternetGateway(ctx, vpcID).Return("", nil)
-			expectValidDHCPOptions(ctx, awsClient, vpcID, region)
-			expectGetVpc(ctx, awsClient, vpcID, "")
+			awsClient.EXPECT().GetDHCPOptions(ctx, vpcID).Return(validDHCPOptions, nil)
 
 			errorList := cv.Validate(ctx, infra)
 			Expect(errorList).To(ConsistOfFields(Fields{
@@ -129,8 +180,28 @@ var _ = Describe("ConfigValidator", func() {
 			}))
 		})
 
-		DescribeTable("validate DHCP options", func(newRegion string, mapping map[string]string,
-			err error, matcher gomegatypes.GomegaMatcher) {
+		It("should allow VPC that exists and has correct attribute values and an attached internet gateway", func() {
+			awsClient.EXPECT().GetVPCAttribute(ctx, vpcID, ec2types.VpcAttributeNameEnableDnsSupport).Return(true, nil)
+			awsClient.EXPECT().GetVPCAttribute(ctx, vpcID, ec2types.VpcAttributeNameEnableDnsHostnames).Return(true, nil)
+			awsClient.EXPECT().GetVPCInternetGateway(ctx, vpcID).Return(vpcID, nil)
+			awsClient.EXPECT().GetDHCPOptions(ctx, vpcID).Return(validDHCPOptions, nil)
+
+			errorList := cv.Validate(ctx, infra)
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should fail with InternalError if getting VPC attributes failed", func() {
+			awsClient.EXPECT().GetVPCAttribute(ctx, vpcID, ec2types.VpcAttributeNameEnableDnsSupport).Return(false, errors.New("test"))
+
+			errorList := cv.Validate(ctx, infra)
+			Expect(errorList).To(ConsistOfFields(Fields{
+				"Type":   Equal(field.ErrorTypeInternal),
+				"Field":  Equal("networks.vpc.id"),
+				"Detail": Equal(fmt.Sprintf("could not get VPC attribute enableDnsSupport for VPC %s: test", vpcID)),
+			}))
+		})
+
+		DescribeTable("validate DHCP options", func(newRegion string, mapping map[string]string, err error, matcher gomegatypes.GomegaMatcher) {
 			if newRegion != "" {
 				infra.Spec.Region = newRegion
 				awsClientFactory.NewClient(authConfig) //nolint:errcheck
@@ -148,17 +219,14 @@ var _ = Describe("ConfigValidator", func() {
 			awsClient.EXPECT().GetVPCAttribute(ctx, vpcID, ec2types.VpcAttributeNameEnableDnsHostnames).Return(true, nil)
 			awsClient.EXPECT().GetVPCInternetGateway(ctx, vpcID).Return(vpcID, nil)
 			awsClient.EXPECT().GetDHCPOptions(ctx, vpcID).Return(mapping, err)
-			if err == nil {
-				awsClient.EXPECT().GetVpc(ctx, vpcID).Return(&awsclient.VPC{}, nil)
-			}
 
 			errorList := cv.Validate(ctx, infra)
 			Expect(errorList).To(matcher)
 		},
-			Entry("should allow VPC with correctly configured DHCP options", "", map[string]string{
+			Entry("should allow VPC with correctly configurated DHCP options", "", map[string]string{
 				"domain-name": region + ".compute.internal",
 			}, nil, BeEmpty()),
-			Entry("should allow VPC with correctly configured DHCP options and domain-name 'us-east-1'", "us-east-1", map[string]string{
+			Entry("should allow VPC with correctly configurated DHCP options and domain-name 'us-east-1`", "us-east-1", map[string]string{
 				"domain-name": "ec2.internal",
 			}, nil, BeEmpty()),
 			Entry("should fail with InternalError if getting DHCP options failed", "", nil, fmt.Errorf("test"), ConsistOfFields(Fields{
@@ -180,288 +248,122 @@ var _ = Describe("ConfigValidator", func() {
 			})),
 		)
 
-		Context("Validate subnet CIDRs are subset of VPC CIDR", func() {
-			It("should succeed - all subnet CIDRs are subset of the VPC CIDR", func() {
+		Describe("validate Elastic IP addresses", func() {
+			BeforeEach(func() {
 				infra.Spec.ProviderConfig.Raw = encode(&apisaws.InfrastructureConfig{
 					Networks: apisaws.Networks{
-						VPC: apisaws.VPC{
-							ID: ptr.To(vpcID),
-						},
+						VPC: apisaws.VPC{},
 						Zones: []apisaws.Zone{
 							{
-								Workers:  "10.251.127.0/26",
-								Public:   "10.251.125.0/26",
-								Internal: "10.251.126.0/26",
+								ElasticIPAllocationID: ptr.To("eipalloc-0e2669d4b46150ee4"),
+							},
+							{
+								ElasticIPAllocationID: ptr.To("eipalloc-0e2669d4b46150ee5"),
+							},
+							{
+								ElasticIPAllocationID: ptr.To("eipalloc-0e2669d4b46150ee6"),
 							},
 						},
 					},
 				})
-				expectValidVPCAttributes(ctx, awsClient, vpcID)
-				expectValidDHCPOptions(ctx, awsClient, vpcID, region)
-				awsClient.EXPECT().GetVpc(ctx, vpcID).Return(&awsclient.VPC{
-					CidrBlock: "10.251.0.0/16",
-				}, nil)
+			})
+
+			It("should succeed - no EIPs configured", func() {
+				infra.Spec.ProviderConfig.Raw = encode(&apisaws.InfrastructureConfig{
+					Networks: apisaws.Networks{
+						VPC: apisaws.VPC{},
+					},
+				})
+				errorList := cv.Validate(ctx, infra)
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should succeed - all EIPs exist and are already associated to the Shoot's NAT Gateways", func() {
+				mapping := map[string]*string{
+					"eipalloc-0e2669d4b46150ee4": ptr.To("eipassoc-0f8ff66536587824b"),
+					"eipalloc-0e2669d4b46150ee5": ptr.To("eipassoc-0f8ff66536587824c"),
+					"eipalloc-0e2669d4b46150ee6": ptr.To("eipassoc-0f8ff66536587824d"),
+				}
+				awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, gomock.Any()).Return(mapping, nil)
+				awsClient.EXPECT().GetNATGatewayAddressAllocations(ctx, infra.Namespace).Return(sets.New[string]("eipalloc-0e2669d4b46150ee4", "eipalloc-0e2669d4b46150ee5", "eipalloc-0e2669d4b46150ee6"), nil)
 
 				errorList := cv.Validate(ctx, infra)
 				Expect(errorList).To(BeEmpty())
 			})
 
-			It("should fail - a subnet CIDR is not a subset of the VPC cidr", func() {
-				infra.Spec.ProviderConfig.Raw = encode(&apisaws.InfrastructureConfig{
-					Networks: apisaws.Networks{
-						VPC: apisaws.VPC{
-							ID: ptr.To(vpcID),
-						},
-						Zones: []apisaws.Zone{
-							{
-								// outside the VPC CIDR on purpose
-								Workers:  "192.168.0.0/24",
-								Public:   "10.252.125.0/26",
-								Internal: "10.250.126.0/26",
-							},
-						},
-					},
-				})
-				expectValidVPCAttributes(ctx, awsClient, vpcID)
-				expectValidDHCPOptions(ctx, awsClient, vpcID, region)
-				awsClient.EXPECT().GetVpc(ctx, vpcID).Return(&awsclient.VPC{CidrBlock: "10.251.0.0/16"}, nil)
-
-				errorList := cv.Validate(ctx, infra)
-				Expect(errorList).To(ConsistOfFields(Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("networking.nodes"), // workers -> nodes in validator
-				}, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("networking.public"),
-				}, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("networking.internal"),
-				}))
-			})
-
-			It("should succeed - in a multi-zone scenario", func() {
-				infra.Spec.ProviderConfig.Raw = encode(&apisaws.InfrastructureConfig{
-					Networks: apisaws.Networks{
-						VPC: apisaws.VPC{
-							ID: ptr.To(vpcID),
-						},
-						Zones: []apisaws.Zone{
-							{
-								Workers:  "10.251.125.0/26",
-								Public:   "10.251.126.0/26",
-								Internal: "10.251.127.0/26",
-							},
-							{
-								Workers:  "10.251.128.0/26",
-								Public:   "10.251.129.0/26",
-								Internal: "10.251.130.0/26",
-							},
-						},
-					},
-				})
-				expectValidVPCAttributes(ctx, awsClient, vpcID)
-				expectValidDHCPOptions(ctx, awsClient, vpcID, region)
-				awsClient.EXPECT().GetVpc(ctx, vpcID).Return(&awsclient.VPC{CidrBlock: "10.251.0.0/16"}, nil)
+			It("should succeed - all EIPs exist, but are not associated to any resource yet", func() {
+				mapping := map[string]*string{
+					"eipalloc-0e2669d4b46150ee4": nil,
+					"eipalloc-0e2669d4b46150ee5": nil,
+					"eipalloc-0e2669d4b46150ee6": nil,
+				}
+				awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, gomock.Any()).Return(mapping, nil)
 
 				errorList := cv.Validate(ctx, infra)
 				Expect(errorList).To(BeEmpty())
 			})
 
-			It("should fail - in a multi-zone scenario", func() {
-				infra.Spec.ProviderConfig.Raw = encode(&apisaws.InfrastructureConfig{
-					Networks: apisaws.Networks{
-						VPC: apisaws.VPC{
-							ID: ptr.To(vpcID),
-						},
-						Zones: []apisaws.Zone{
-							{
-								Workers:  "10.251.125.0/26",
-								Public:   "10.251.126.0/26",
-								Internal: "10.251.127.0/26",
-							},
-							{
-								Workers:  "192.168.0.0/24", // outside the VPC CIDR
-								Public:   "10.251.129.0/26",
-								Internal: "10.251.130.0/26",
-							},
-						},
-					},
-				})
-				expectValidVPCAttributes(ctx, awsClient, vpcID)
-				expectValidDHCPOptions(ctx, awsClient, vpcID, region)
-				awsClient.EXPECT().GetVpc(ctx, vpcID).Return(&awsclient.VPC{CidrBlock: "10.251.0.0/16"}, nil)
+			It("should fail - the Elastic IP Address for the given allocation ID does not exist", func() {
+				empty := make(map[string]*string)
+				awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, []string{"eipalloc-0e2669d4b46150ee4", "eipalloc-0e2669d4b46150ee5", "eipalloc-0e2669d4b46150ee6"}).Return(empty, nil)
 
 				errorList := cv.Validate(ctx, infra)
 				Expect(errorList).To(ConsistOfFields(Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("networking.nodes"),
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("networks.zones[].elasticIPAllocationID"),
+					"BadValue": Equal("eipalloc-0e2669d4b46150ee4"),
+					"Detail":   ContainSubstring("cannot be used as it does not exist"),
+				}, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("networks.zones[].elasticIPAllocationID"),
+					"BadValue": Equal("eipalloc-0e2669d4b46150ee5"),
+					"Detail":   ContainSubstring("cannot be used as it does not exist"),
+				}, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("networks.zones[].elasticIPAllocationID"),
+					"BadValue": Equal("eipalloc-0e2669d4b46150ee6"),
+					"Detail":   ContainSubstring("cannot be used as it does not exist"),
+				},
+				))
+			})
+
+			It("should fail - some of the Elastic IP Addresses exist, some do not", func() {
+				mapping := map[string]*string{
+					"eipalloc-0e2669d4b46150ee4": ptr.To("eipassoc-0f8ff66536587824b"),
+					"eipalloc-0e2669d4b46150ee5": ptr.To("eipassoc-0f8ff66536587824c"),
+				}
+				awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, gomock.Any()).Return(mapping, nil)
+				awsClient.EXPECT().GetNATGatewayAddressAllocations(ctx, infra.Namespace).Return(sets.New[string]("eipalloc-0e2669d4b46150ee4", "eipalloc-0e2669d4b46150ee5"), nil)
+
+				errorList := cv.Validate(ctx, infra)
+				Expect(errorList).To(ConsistOfFields(Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("networks.zones[].elasticIPAllocationID"),
+					"BadValue": Equal("eipalloc-0e2669d4b46150ee6"),
+					"Detail":   ContainSubstring("cannot be used as it does not exist"),
 				}))
 			})
-		})
-	})
 
-	Context("Elastic IPs", func() {
-		BeforeEach(func() {
-			infra.Spec.ProviderConfig.Raw = encode(&apisaws.InfrastructureConfig{
-				Networks: apisaws.Networks{
-					VPC: apisaws.VPC{},
-					Zones: []apisaws.Zone{
-						{ElasticIPAllocationID: ptr.To("eipalloc-0e2669d4b46150ee4")},
-						{ElasticIPAllocationID: ptr.To("eipalloc-0e2669d4b46150ee5")},
-						{ElasticIPAllocationID: ptr.To("eipalloc-0e2669d4b46150ee6")},
-					},
-				},
+			It("should fail - Elastic IP Addresses exist are already associated with another resource", func() {
+				mapping := map[string]*string{
+					"eipalloc-0e2669d4b46150ee4": ptr.To("eipassoc-0f8ff66536587824b"),
+					"eipalloc-0e2669d4b46150ee5": ptr.To("eipassoc-0f8ff66536587824c"),
+					"eipalloc-0e2669d4b46150ee6": ptr.To("eipassoc-0f8ff66536587824d"),
+				}
+				awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, gomock.Any()).Return(mapping, nil)
+				awsClient.EXPECT().GetNATGatewayAddressAllocations(ctx, infra.Namespace).Return(sets.New[string]("eipalloc-0e2669d4b46150ee4", "eipalloc-0e2669d4b46150ee5"), nil)
+
+				errorList := cv.Validate(ctx, infra)
+				Expect(errorList).To(ConsistOfFields(Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("networks.zones[].elasticIPAllocationID"),
+					"BadValue": Equal("eipalloc-0e2669d4b46150ee6"),
+					"Detail":   ContainSubstring("cannot be attached to the clusters NAT Gateway(s) as it is already associated"),
+				}))
 			})
-		})
-
-		It("should succeed - no EIPs configured", func() {
-			infra.Spec.ProviderConfig.Raw = encode(&apisaws.InfrastructureConfig{
-				Networks: apisaws.Networks{
-					VPC: apisaws.VPC{},
-				},
-			})
-			errorList := cv.Validate(ctx, infra)
-			Expect(errorList).To(BeEmpty())
-		})
-
-		It("should succeed - all EIPs exist and are already associated to the Shoot's NAT Gateways", func() {
-			mapping := map[string]*string{
-				"eipalloc-0e2669d4b46150ee4": ptr.To("eipassoc-0f8ff66536587824b"),
-				"eipalloc-0e2669d4b46150ee5": ptr.To("eipassoc-0f8ff66536587824c"),
-				"eipalloc-0e2669d4b46150ee6": ptr.To("eipassoc-0f8ff66536587824d"),
-			}
-			awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, gomock.Any()).Return(mapping, nil)
-			awsClient.EXPECT().GetNATGatewayAddressAllocations(ctx, infra.Namespace).
-				Return(sets.New[string](
-					"eipalloc-0e2669d4b46150ee4",
-					"eipalloc-0e2669d4b46150ee5",
-					"eipalloc-0e2669d4b46150ee6"), nil)
-
-			errorList := cv.Validate(ctx, infra)
-			Expect(errorList).To(BeEmpty())
-		})
-
-		It("should succeed - all EIPs exist, but are not associated to any resource yet", func() {
-			mapping := map[string]*string{
-				"eipalloc-0e2669d4b46150ee4": nil,
-				"eipalloc-0e2669d4b46150ee5": nil,
-				"eipalloc-0e2669d4b46150ee6": nil,
-			}
-			awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, gomock.Any()).Return(mapping, nil)
-
-			errorList := cv.Validate(ctx, infra)
-			Expect(errorList).To(BeEmpty())
-		})
-
-		It("should fail - the Elastic IP Address for the given allocation ID does not exist", func() {
-			empty := make(map[string]*string)
-			awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, []string{
-				"eipalloc-0e2669d4b46150ee4",
-				"eipalloc-0e2669d4b46150ee5",
-				"eipalloc-0e2669d4b46150ee6"}).Return(empty, nil)
-
-			errorList := cv.Validate(ctx, infra)
-			Expect(errorList).To(ConsistOfFields(Fields{
-				"Type":     Equal(field.ErrorTypeInvalid),
-				"Field":    Equal("networks.zones[].elasticIPAllocationID"),
-				"BadValue": Equal("eipalloc-0e2669d4b46150ee4"),
-				"Detail":   ContainSubstring("cannot be used as it does not exist"),
-			}, Fields{
-				"Type":     Equal(field.ErrorTypeInvalid),
-				"Field":    Equal("networks.zones[].elasticIPAllocationID"),
-				"BadValue": Equal("eipalloc-0e2669d4b46150ee5"),
-				"Detail":   ContainSubstring("cannot be used as it does not exist"),
-			}, Fields{
-				"Type":     Equal(field.ErrorTypeInvalid),
-				"Field":    Equal("networks.zones[].elasticIPAllocationID"),
-				"BadValue": Equal("eipalloc-0e2669d4b46150ee6"),
-				"Detail":   ContainSubstring("cannot be used as it does not exist"),
-			},
-			))
-		})
-
-		It("should fail - some of the Elastic IP Addresses exist, some do not", func() {
-			mapping := map[string]*string{
-				"eipalloc-0e2669d4b46150ee4": ptr.To("eipassoc-0f8ff66536587824b"),
-				"eipalloc-0e2669d4b46150ee5": ptr.To("eipassoc-0f8ff66536587824c"),
-			}
-			awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, gomock.Any()).Return(mapping, nil)
-			awsClient.EXPECT().GetNATGatewayAddressAllocations(ctx, infra.Namespace).Return(sets.New[string](
-				"eipalloc-0e2669d4b46150ee4", "eipalloc-0e2669d4b46150ee5"), nil)
-
-			errorList := cv.Validate(ctx, infra)
-			Expect(errorList).To(ConsistOfFields(Fields{
-				"Type":     Equal(field.ErrorTypeInvalid),
-				"Field":    Equal("networks.zones[].elasticIPAllocationID"),
-				"BadValue": Equal("eipalloc-0e2669d4b46150ee6"),
-				"Detail":   ContainSubstring("cannot be used as it does not exist"),
-			}))
-		})
-
-		It("should fail - Elastic IP Addresses exist are already associated with another resource", func() {
-			mapping := map[string]*string{
-				"eipalloc-0e2669d4b46150ee4": ptr.To("eipassoc-0f8ff66536587824b"),
-				"eipalloc-0e2669d4b46150ee5": ptr.To("eipassoc-0f8ff66536587824c"),
-				"eipalloc-0e2669d4b46150ee6": ptr.To("eipassoc-0f8ff66536587824d"),
-			}
-			awsClient.EXPECT().GetElasticIPsAssociationIDForAllocationIDs(ctx, gomock.Any()).Return(mapping, nil)
-			awsClient.EXPECT().GetNATGatewayAddressAllocations(ctx, infra.Namespace).Return(sets.New[string](
-				"eipalloc-0e2669d4b46150ee4", "eipalloc-0e2669d4b46150ee5"), nil)
-
-			errorList := cv.Validate(ctx, infra)
-			Expect(errorList).To(ConsistOfFields(Fields{
-				"Type":     Equal(field.ErrorTypeInvalid),
-				"Field":    Equal("networks.zones[].elasticIPAllocationID"),
-				"BadValue": Equal("eipalloc-0e2669d4b46150ee6"),
-				"Detail":   ContainSubstring("cannot be attached to the clusters NAT Gateway(s) as it is already associated"),
-			}))
 		})
 	})
 })
-
-// helpers
-func baseInfra(region string, vpcID *string) *extensionsv1alpha1.Infrastructure {
-	return &extensionsv1alpha1.Infrastructure{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec: extensionsv1alpha1.InfrastructureSpec{
-			DefaultSpec: extensionsv1alpha1.DefaultSpec{
-				Type: aws.Type,
-				ProviderConfig: &runtime.RawExtension{Raw: encode(&apisaws.InfrastructureConfig{
-					Networks: apisaws.Networks{VPC: apisaws.VPC{ID: vpcID}},
-				})},
-			},
-			Region:    region,
-			SecretRef: corev1.SecretReference{Name: name, Namespace: namespace},
-		},
-	}
-}
-
-func baseSecretAuth(id, secret, region string) (*corev1.Secret, awsclient.AuthConfig) {
-	s := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Type:       corev1.SecretTypeOpaque,
-		Data:       map[string][]byte{aws.AccessKeyID: []byte(id), aws.SecretAccessKey: []byte(secret)},
-	}
-	return s, awsclient.AuthConfig{AccessKey: &awsclient.AccessKey{ID: id, Secret: secret}, Region: region}
-}
-
-// nolint:unparam
-func expectValidVPCAttributes(ctx context.Context, m *mockawsclient.MockInterface, vpcID string) {
-	m.EXPECT().GetVPCAttribute(ctx, vpcID, ec2types.VpcAttributeNameEnableDnsSupport).Return(true, nil)
-	m.EXPECT().GetVPCAttribute(ctx, vpcID, ec2types.VpcAttributeNameEnableDnsHostnames).Return(true, nil)
-	m.EXPECT().GetVPCInternetGateway(ctx, vpcID).Return(vpcID, nil)
-}
-
-// nolint:unparam
-func expectValidDHCPOptions(ctx context.Context, m *mockawsclient.MockInterface, vpcID, region string) {
-	m.EXPECT().GetDHCPOptions(ctx, vpcID).Return(map[string]string{
-		"domain-name": region + ".compute.internal",
-	}, nil)
-}
-
-func expectGetVpc(ctx context.Context, m *mockawsclient.MockInterface, vpcID, cidr string) {
-	m.EXPECT().GetVpc(ctx, vpcID).Return(&awsclient.VPC{CidrBlock: cidr}, nil)
-}
 
 func encode(obj runtime.Object) []byte {
 	data, _ := json.Marshal(obj)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind task
/platform aws

**What this PR does / why we need it**:
Previous validation did not take into consideration additional CIDR blocks of the provided VPC.
A fixed version will be provided for the next minor release

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
