### PR TITLE
Document route table entries limit

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -926,3 +926,14 @@ The "flow" implementation is a newer implementation that is trying to solve issu
 For most users there will be no noticeable difference. However for certain use-cases, users may notice a slight deviation from the previous behavior. For example, with flow-based infrastructure users may be able to perform certain modifications to infrastructure resources without having them reconciled back by terraform. Operations that would degrade the shoot infrastructure are still expected to be reverted back.
 
 For the time-being, to take advantage of the flow reconciler users have to "opt-in" by annotating the shoot manifest with: `aws.provider.extensions.gardener.cloud/use-flow="true"`. For existing shoots with this annotation, the migration will take place on the next infrastructure reconciliation (on maintenance window or if other infrastructure changes are requested). The migration is not revertible.
+
+## Route table entries limit
+
+Gardener can be used with or without the overlay network.
+In case of calico, overlay network is disabled by default.
+This means that the routing is done directly through the VPC routing table.
+The [aws-custom-route-controller](https://github.com/gardener/aws-custom-route-controller) performs this if required.
+You can find more information on how to enable/disable calico overlay in the gardener [calico documentation](https://github.com/gardener/gardener-extension-networking-calico/blob/master/docs/usage/shoot_overlay_network.md).
+The default quota for route table entries per route table is 500 entries.
+This means that a cluster with more than 500 nodes will run into the default limit resulting in a partially unusable pod network.
+Apart from the default limit (500), it is also important to mention the hard limit of 1000 route table entries resulting in a hard stop regarding the amount of cluster nodes that can be used in an overlay free pod network.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Document route table entries limit if network overlay is disabled.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-aws/issues/691

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Document route table entries limit if network overlay is disabled
```
