### PR TITLE
migrate cc-utils actions/workflows from @master to @v1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   prepare:
-    uses: gardener/cc-utils/.github/workflows/prepare.yaml@master
+    uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1
     permissions:
       id-token: write
       pull-requests: write # required until https://github.com/gardener/cc-utils/pull/1529 is merged
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25'
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
         with:
           remove-trusted-label: false
       - name: run-verify
@@ -42,7 +42,7 @@ jobs:
           mkdir /tmp/blobs.d
           tar czf /tmp/blobs.d/gosec-report.tar.gz gosec-report.sarif
       - name: add-sast-report-to-component-descriptor
-        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1
         with:
           blobs-directory: /tmp/blobs.d
           ocm-resources: |
@@ -70,7 +70,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@master
+    uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@v1
     strategy:
       matrix:
         args:
@@ -117,7 +117,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    uses: gardener/cc-utils/.github/workflows/helmchart-ocm.yaml@master
+    uses: gardener/cc-utils/.github/workflows/helmchart-ocm.yaml@v1
     strategy:
       matrix:
         args:

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -30,7 +30,7 @@ jobs:
 
   component-descriptor:
     if: ${{ github.event_name != 'pull_request_target' || (github.event_name == 'pull_request_target' && github.event.label.name == vars.DEFAULT_LABEL_OK_TO_TEST && vars.DEFAULT_LABEL_OK_TO_TEST != '') }}
-    uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
+    uses: gardener/cc-utils/.github/workflows/post-build.yaml@v1
     needs:
       - build
     permissions:

--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate-release-notes:
-    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@master
+    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1
     permissions:
       pull-requests: read
     with:

--- a/.github/workflows/pullrequest-trust-helper.yaml
+++ b/.github/workflows/pullrequest-trust-helper.yaml
@@ -10,6 +10,6 @@ jobs:
   pullrequest-trusted-helper:
     permissions:
       id-token: write
-    uses: gardener/cc-utils/.github/workflows/pullrequest-trust-helper.yaml@master
+    uses: gardener/cc-utils/.github/workflows/pullrequest-trust-helper.yaml@v1
     with:
       trusted-teams: 'core,gardener-extension-provider-aws-maintainers'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
       skip-integration-tests: ${{ inputs.skip-integration-tests }}
 
   release-to-github-and-bump:
-    uses: gardener/cc-utils/.github/workflows/release.yaml@master
+    uses: gardener/cc-utils/.github/workflows/release.yaml@v1
     needs:
       - build
       - integration-tests

--- a/.github/workflows/run-integrationtests.yaml
+++ b/.github/workflows/run-integrationtests.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   run-tests:
     if: ${{ !inputs.skip-integration-tests }}
-    uses: gardener/cc-utils/.github/workflows/run-testmachinery-tests.yaml@master
+    uses: gardener/cc-utils/.github/workflows/run-testmachinery-tests.yaml@v1
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   update-images:
-    uses: gardener/cc-utils/.github/workflows/update-extension-provider-images.yaml@master
+    uses: gardener/cc-utils/.github/workflows/update-extension-provider-images.yaml@v1
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Switch references to [cc-utils](https://github.com/gardener/cc-utils)
actions and reusable workflows from `@master` to `@v1`.

## Motivation

`v1` is the intended stable branch for downstream users. All internal cross-references
are pinned by commit digest, ensuring a consistent, self-contained snapshot. Coverage
(e.g. pre-qualification) will increase over time.

`master` remains the development branch and continues to work, but is not intended for
downstream consumption.

See the [Reuse and Branching Model](https://gardener.github.io/cc-utils) for details.
