### PR TITLE
Group gardener dependencies in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,8 @@ updates:
     gardener-dependencies:
       applies-to: "version-updates"
       patterns:
-        - "github.com/gardener/gardener"
-        - "github.com/gardener/gardener/*"
+      - "github.com/gardener/gardener"
+      - "github.com/gardener/gardener/*"
   ignore:
   - dependency-name: "k8s.io/*"
   - dependency-name: "sigs.k8s.io/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
       applies-to: "version-updates"
       patterns:
       - "github.com/aws/*"
+    gardener-dependencies:
+      applies-to: "version-updates"
+      patterns:
+        - "github.com/gardener/gardener"
+        - "github.com/gardener/gardener/*"
   ignore:
   - dependency-name: "k8s.io/*"
   - dependency-name: "sigs.k8s.io/*"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Gardener is now split in api lib and core.
We also want `github.com/gardener/gardener/pkg/apis` to be on the same version as `github.com/gardener/gardener`.
Therefore we should group gardener dependabot update PRs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
