### PR TITLE
Use the correct API version for MutatingAdmissionPolicy

### DIFF
--- a/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/templates/mutating-admission-policy.yaml
+++ b/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/templates/mutating-admission-policy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.enabled }}
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/{{ .Values.apiVersion }}
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: block-calico-network-unavailable-binding
@@ -10,7 +10,7 @@ spec:
 # MutatingAdmissionPolicy to block Calico from setting the NetworkUnavailable condition on nodes.
 # This policy intercepts node/status updates from the calico-node service account and removes
 # any changes to the NetworkUnavailable condition, effectively preserving the existing condition.
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/{{ .Values.apiVersion }}
 kind: MutatingAdmissionPolicy
 metadata:
   name: block-calico-network-unavailable

--- a/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/values.yaml
+++ b/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/values.yaml
@@ -1,1 +1,2 @@
 enabled: false
+apiVersion: v1alpha1

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -29,6 +29,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -306,8 +307,12 @@ var (
 			{
 				Name: "calico-mutating-admission-policy",
 				Objects: []*chart.Object{
-					{Type: &admissionregistrationv1alpha1.MutatingAdmissionPolicy{}, Name: "calico-mutating-admission-policy"},
+					{Type: &admissionregistrationv1alpha1.MutatingAdmissionPolicy{}, Name: "block-calico-network-unavailable"},
 					{Type: &admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{}, Name: "block-calico-network-unavailable-binding"},
+					{Type: &admissionregistrationv1beta1.MutatingAdmissionPolicy{}, Name: "block-calico-network-unavailable"},
+					{Type: &admissionregistrationv1beta1.MutatingAdmissionPolicyBinding{}, Name: "block-calico-network-unavailable-binding"},
+					// TODO(@DockToFuture): Add admissionregistrationv1.MutatingAdmissionPolicy and admissionregistrationv1.MutatingAdmissionPolicyBinding
+					// cleanup entries once k8s.io/api v0.36.x is available (MutatingAdmissionPolicy graduates to v1 in K8s 1.36).
 				},
 			},
 		},
@@ -898,6 +903,11 @@ func getControlPlaneShootChartValues(
 
 	isIPv6SingleStack := networkingConfig != nil && v1beta1.IsIPv6SingleStack(networkingConfig.IPFamilies)
 
+	calicoMutatingAdmissionPolicyValues := map[string]interface{}{"enabled": mutatingAdmissionPolicyEnabled}
+	if mutatingAdmissionPolicyEnabled {
+		calicoMutatingAdmissionPolicyValues["apiVersion"] = mutatingAdmissionPolicyAPIVersion(cluster)
+	}
+
 	return map[string]interface{}{
 		aws.CloudControllerManagerName:     map[string]interface{}{"enabled": true},
 		aws.AWSCustomRouteControllerName:   map[string]interface{}{"enabled": customRouteControllerEnabled},
@@ -905,7 +915,7 @@ func getControlPlaneShootChartValues(
 		aws.AWSLoadBalancerControllerName:  albValues,
 		aws.CSINodeName:                    csiDriverNodeValues,
 		aws.CSIEfsNodeName:                 getControlPlaneShootChartCSIEfsValues(infraConfig, infraStatus, isIPv6SingleStack),
-		"calico-mutating-admission-policy": map[string]interface{}{"enabled": mutatingAdmissionPolicyEnabled},
+		"calico-mutating-admission-policy": calicoMutatingAdmissionPolicyValues,
 	}, nil
 }
 
@@ -952,7 +962,32 @@ func isUsingCalico(cluster *extensionscontroller.Cluster) bool {
 		*cluster.Shoot.Spec.Networking.Type == "calico"
 }
 
+// constraintK8sGreaterEqual136 is a version constraint for Kubernetes versions >= 1.36.
+var constraintK8sGreaterEqual136 = versionutils.MustNewConstraint(">= 1.36-0")
+
 func isMutatingAdmissionPolicyEnabled(cluster *extensionscontroller.Cluster) bool {
+	k8sVersion, err := semver.NewVersion(cluster.Shoot.Spec.Kubernetes.Version)
+	if err != nil {
+		return false
+	}
+
+	// For K8s >= 1.34, MutatingAdmissionPolicy is beta (enabled by default) or GA (>= 1.36).
+	// For beta (>= 1.34 and < 1.36), users can explicitly disable the feature gate.
+	// For GA (>= 1.36), the feature gate is locked on and cannot be disabled.
+	if versionutils.ConstraintK8sGreaterEqual134.Check(k8sVersion) {
+		if constraintK8sGreaterEqual136.Check(k8sVersion) {
+			return true
+		}
+		// Beta: check if user explicitly disabled the feature gate
+		if cluster.Shoot.Spec.Kubernetes.KubeAPIServer != nil &&
+			cluster.Shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates != nil {
+			if enabled, ok := cluster.Shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates["MutatingAdmissionPolicy"]; ok && !enabled {
+				return false
+			}
+		}
+		return true
+	}
+
 	if cluster.Shoot.Spec.Kubernetes.KubeAPIServer == nil {
 		return false
 	}
@@ -969,9 +1004,36 @@ func isMutatingAdmissionPolicyEnabled(cluster *extensionscontroller.Cluster) boo
 		return false
 	}
 
-	if enabled, ok := cluster.Shoot.Spec.Kubernetes.KubeAPIServer.RuntimeConfig["admissionregistration.k8s.io/v1alpha1"]; !ok || !enabled {
+	rc := cluster.Shoot.Spec.Kubernetes.KubeAPIServer.RuntimeConfig
+	if !rc["admissionregistration.k8s.io/v1alpha1"] && !rc["admissionregistration.k8s.io/v1beta1"] {
 		return false
 	}
 
 	return true
+}
+
+func mutatingAdmissionPolicyAPIVersion(cluster *extensionscontroller.Cluster) string {
+	k8sVersion, err := semver.NewVersion(cluster.Shoot.Spec.Kubernetes.Version)
+	if err != nil {
+		return "v1alpha1"
+	}
+
+	// For K8s >= 1.36, MutatingAdmissionPolicy is GA
+	if constraintK8sGreaterEqual136.Check(k8sVersion) {
+		return "v1"
+	}
+
+	// For K8s >= 1.34, MutatingAdmissionPolicy is beta
+	if versionutils.ConstraintK8sGreaterEqual134.Check(k8sVersion) {
+		return "v1beta1"
+	}
+
+	// For older versions, prefer v1beta1 over v1alpha1 when explicitly enabled
+	if cluster.Shoot.Spec.Kubernetes.KubeAPIServer != nil &&
+		cluster.Shoot.Spec.Kubernetes.KubeAPIServer.RuntimeConfig != nil &&
+		cluster.Shoot.Spec.Kubernetes.KubeAPIServer.RuntimeConfig["admissionregistration.k8s.io/v1beta1"] {
+		return "v1beta1"
+	}
+
+	return "v1alpha1"
 }

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -722,4 +722,235 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(values).NotTo(HaveKey("controller"))
 		})
 	})
+
+	Describe("#isMutatingAdmissionPolicyEnabled", func() {
+		var testCluster *extensionscontroller.Cluster
+
+		BeforeEach(func() {
+			calico := "calico"
+			testCluster = &extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Networking: &gardencorev1beta1.Networking{
+							Type: &calico,
+						},
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.33.0",
+						},
+					},
+				},
+			}
+		})
+
+		It("should return false if KubeAPIServer is nil", func() {
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false if feature gates are nil", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false if MutatingAdmissionPolicy feature gate is not set", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"SomeOtherGate": true},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false if MutatingAdmissionPolicy feature gate is disabled", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": false},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false if RuntimeConfig is nil", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false if neither v1alpha1 nor v1beta1 is enabled in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{"some.other/v1": true},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return true if feature gate is enabled and v1alpha1 is in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1alpha1": true},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return true if feature gate is enabled and v1beta1 is in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1beta1": true},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return true if feature gate is enabled and both v1alpha1 and v1beta1 are in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{
+					"admissionregistration.k8s.io/v1alpha1": true,
+					"admissionregistration.k8s.io/v1beta1":  true,
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return true for K8s >= 1.34 without any feature gate or RuntimeConfig (beta)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return true for K8s >= 1.34 even without KubeAPIServer config (beta)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.35.0"
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return false for K8s >= 1.34 and < 1.36 if feature gate is explicitly disabled (beta)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": false},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false for K8s 1.35 if feature gate is explicitly disabled (beta)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.35.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": false},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return true for K8s >= 1.36 even if feature gate is explicitly disabled (GA, locked on)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.36.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": false},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return true for K8s >= 1.36 without any feature gate or RuntimeConfig (GA)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.36.0"
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return true for K8s >= 1.36 even without KubeAPIServer config (GA)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.37.1"
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+	})
+
+	Describe("#mutatingAdmissionPolicyAPIVersion", func() {
+		var testCluster *extensionscontroller.Cluster
+
+		BeforeEach(func() {
+			testCluster = &extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.33.0",
+						},
+					},
+				},
+			}
+		})
+
+		It("should return v1alpha1 if no RuntimeConfig is set (< 1.34)", func() {
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1alpha1"))
+		})
+
+		It("should return v1alpha1 if only v1alpha1 is in RuntimeConfig (< 1.34)", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1alpha1": true},
+			}
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1alpha1"))
+		})
+
+		It("should return v1beta1 if v1beta1 is in RuntimeConfig (< 1.34)", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1beta1": true},
+			}
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1beta1"))
+		})
+
+		It("should return v1beta1 if both v1alpha1 and v1beta1 are in RuntimeConfig (< 1.34)", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				RuntimeConfig: map[string]bool{
+					"admissionregistration.k8s.io/v1alpha1": true,
+					"admissionregistration.k8s.io/v1beta1":  true,
+				},
+			}
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1beta1"))
+		})
+
+		It("should return v1alpha1 if v1beta1 is explicitly disabled in RuntimeConfig (< 1.34)", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				RuntimeConfig: map[string]bool{
+					"admissionregistration.k8s.io/v1alpha1": true,
+					"admissionregistration.k8s.io/v1beta1":  false,
+				},
+			}
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1alpha1"))
+		})
+
+		It("should return v1beta1 for K8s >= 1.34 (beta)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1beta1"))
+		})
+
+		It("should return v1beta1 for K8s 1.35 (beta)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.35.0"
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1beta1"))
+		})
+
+		It("should return v1 for K8s >= 1.36 (GA)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.36.0"
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1"))
+		})
+
+		It("should return v1 for K8s 1.36 even if v1beta1 is in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.36.2"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1beta1": true},
+			}
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1"))
+		})
+
+		It("should return v1 for K8s versions higher than 1.36", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.38.0"
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1"))
+		})
+	})
 })


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind enhancement
/platform aws

**What this PR does / why we need it**:
MutatingAdmissionPolicy graduates from v1alpha1 → v1beta1 in Kubernetes 1.34 and to v1 (GA) in 1.36. This PR makes the Calico mutating admission policy chart use the correct API version based on the shoot's Kubernetes version, and aligns the enable/disable logic accordingly:

  - `< 1.34`: v1alpha1, requires explicit feature gate + RuntimeConfig opt-in
  - `>= 1.34`: v1beta1, enabled by default (can be opted out)
  - `>= 1.36`: v1, always enabled (feature gate locked on)
  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Calico mutating admission policy chart uses the correct API version based on the shoot's Kubernetes version, and aligns the enable/disable logic accordingly.
```
