### PR TITLE
fix(Bastion): correct parameter usage in FindImageInCloudProfile func…

### DIFF
--- a/pkg/controller/bastion/options.go
+++ b/pkg/controller/bastion/options.go
@@ -104,7 +104,7 @@ func NewOpts(ctx context.Context, bastion *extensionsv1alpha1.Bastion, cluster *
 	machineTypeCapabilities := helper.NormalizeMachineTypeCapabilities(vmDetails.MachineTypeCapabilities, &vmDetails.Architecture, capabilityDefinitions)
 
 	var ami string
-	imageFlavor, err := helper.FindImageInCloudProfile(cloudProfileConfig, vmDetails.ImageBaseName, vmDetails.ImageVersion, region, machineTypeCapabilities, cluster.CloudProfile.Spec.MachineCapabilities)
+	imageFlavor, err := helper.FindImageInCloudProfile(cloudProfileConfig, vmDetails.ImageBaseName, vmDetails.ImageVersion, region, machineTypeCapabilities, capabilityDefinitions)
 	if err != nil {
 		return Options{}, fmt.Errorf("failed to find machine image in CloudProfileConfig: %w", err)
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security
/kind bug
/platform aws

**What this PR does / why we need it**:


Fixes incorrect parameter passed to `helper.FindImageInCloudProfile` in the bastion controller's `NewOpts` function.

The 6th argument was `cluster.CloudProfile.Spec.MachineCapabilities` (the raw capability definitions from the CloudProfile spec) instead of the already-normalized `capabilityDefinitions` local variable. The `FindImageInCloudProfile` function expects normalized capability definitions (as documented in its contract), so passing the unnormalized value leads to failed image lookups when creating bastion instances.

**Which issue(s) this PR fixes**:
Fixes `gardenctl ssh`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix bastion creation by passing normalized capability definitions to `FindImageInCloudProfile` instead of raw CloudProfile spec values.
```
