### PR TITLE
Fix efs daemonset

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-efs/templates/node-daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-efs/templates/node-daemonset.yaml
@@ -69,7 +69,7 @@ spec:
                   containerName: driver-efs-node
                   resource: limits.memory
             - name: PORT_RANGE_UPPER_BOUND
-              value: {{ .Values.resources.portRangeUpperBound }}
+              value: {{ .Values.resources.portRangeUpperBound | quote }}
           volumeMounts:
             - name: kubelet-dir
               mountPath: {{ .Values.node.kubeletPath }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-provider-aws/pull/1717 introduced a bug in the efs daemonset.yaml.
The port range upper bound must be specified as string.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
