### PR TITLE
Improve developer experience in remote setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ WORKDIR /go/src/github.com/gardener/gardener-extension-provider-aws
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 
 COPY . .
 
@@ -14,7 +16,9 @@ ARG EFFECTIVE_VERSION
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN make build GOOS=$TARGETOS GOARCH=$TARGETARCH EFFECTIVE_VERSION=$EFFECTIVE_VERSION BUILD_OUTPUT_FILE="/output/bin/"
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make build GOOS=$TARGETOS GOARCH=$TARGETARCH EFFECTIVE_VERSION=$EFFECTIVE_VERSION BUILD_OUTPUT_FILE="/output/bin/"
 
 ############# base
 FROM gcr.io/distroless/static-debian12:nonroot AS base

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ IT_LOGLEVEL := info
 IT_USE_EXISTING_CLUSTER := false # set to true if you want to use an existing cluster for backupbucket integration tests
 
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
-	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
+	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-$(shell date +%s)-dirty
 endif
 
 #########################################
@@ -123,14 +123,14 @@ docker-images: docker-image-provider docker-image-admission
 .PHONY: docker-push-provider
 docker-push-provider: $(KUBECTL)
 	$(eval REGISTRY_URL := $(shell $(KUBECTL) cluster-info | head -1 | grep -oP 'https://\K[^:]+' | sed 's/^api\./reg./'))
-	@docker tag $(IMAGE_PREFIX)/$(NAME):$(VERSION) $(REGISTRY_URL)/$(NAME):$(VERSION)
-	@docker push $(REGISTRY_URL)/$(NAME):$(VERSION)
+	@docker tag $(IMAGE_PREFIX)/$(NAME):$(VERSION) $(REGISTRY_URL)/$(NAME):$(EFFECTIVE_VERSION)
+	@docker push $(REGISTRY_URL)/$(NAME):$(EFFECTIVE_VERSION)
 
 .PHONY: docker-push-admission
 docker-push-admission: $(KUBECTL)
 	$(eval REGISTRY_URL := $(shell $(KUBECTL) cluster-info | head -1 | grep -oP 'https://\K[^:]+' | sed 's/^api\./reg./'))
-	@docker tag $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) $(REGISTRY_URL)/$(ADMISSION_NAME):$(VERSION)
-	@docker push $(REGISTRY_URL)/$(ADMISSION_NAME):$(VERSION)
+	@docker tag $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) $(REGISTRY_URL)/$(ADMISSION_NAME):$(EFFECTIVE_VERSION)
+	@docker push $(REGISTRY_URL)/$(ADMISSION_NAME):$(EFFECTIVE_VERSION)
 
 .PHONY: docker-push
 docker-push: docker-push-provider docker-push-admission
@@ -138,13 +138,13 @@ docker-push: docker-push-provider docker-push-admission
 .PHONY: helm-chart-provider
 helm-chart-provider: $(HELM)
 	@mkdir -p remote
-	@$(HELM) package ./charts/$(EXTENSION_PREFIX)-$(NAME) --version $(VERSION) --app-version $(VERSION) --destination remote
+	@$(HELM) package ./charts/$(EXTENSION_PREFIX)-$(NAME) --version $(EFFECTIVE_VERSION) --app-version $(EFFECTIVE_VERSION) --destination remote
 
 .PHONY: helm-chart-admission
 helm-chart-admission: $(HELM)
 	@mkdir -p remote
-	@$(HELM) package ./charts/$(EXTENSION_PREFIX)-$(ADMISSION_NAME)/charts/application --version $(VERSION) --app-version $(VERSION) --destination remote
-	@$(HELM) package ./charts/$(EXTENSION_PREFIX)-$(ADMISSION_NAME)/charts/runtime --version $(VERSION) --app-version $(VERSION) --destination remote
+	@$(HELM) package ./charts/$(EXTENSION_PREFIX)-$(ADMISSION_NAME)/charts/application --version $(EFFECTIVE_VERSION) --app-version $(EFFECTIVE_VERSION) --destination remote
+	@$(HELM) package ./charts/$(EXTENSION_PREFIX)-$(ADMISSION_NAME)/charts/runtime --version $(EFFECTIVE_VERSION) --app-version $(EFFECTIVE_VERSION) --destination remote
 
 .PHONY: helm-charts
 helm-charts: helm-chart-provider helm-chart-admission
@@ -152,13 +152,13 @@ helm-charts: helm-chart-provider helm-chart-admission
 .PHONY: helm-push-provider
 helm-push-provider: $(HELM) $(KUBECTL)
 	$(eval REGISTRY_URL := $(shell $(KUBECTL) cluster-info | head -1 | grep -oP 'https://\K[^:]+' | sed 's/^api\./reg./'))
-	@$(HELM) push remote/$(EXTENSION_PREFIX)-$(NAME)-$(VERSION).tgz oci://$(REGISTRY_URL)
+	@$(HELM) push remote/$(EXTENSION_PREFIX)-$(NAME)-$(EFFECTIVE_VERSION).tgz oci://$(REGISTRY_URL)
 
 .PHONY: helm-push-admission
 helm-push-admission: $(HELM) $(KUBECTL)
 	$(eval REGISTRY_URL := $(shell $(KUBECTL) cluster-info | head -1 | grep -oP 'https://\K[^:]+' | sed 's/^api\./reg./'))
-	@$(HELM) push remote/$(ADMISSION_NAME)-application-$(VERSION).tgz oci://$(REGISTRY_URL)
-	@$(HELM) push remote/$(ADMISSION_NAME)-runtime-$(VERSION).tgz oci://$(REGISTRY_URL)
+	@$(HELM) push remote/$(ADMISSION_NAME)-application-$(EFFECTIVE_VERSION).tgz oci://$(REGISTRY_URL)
+	@$(HELM) push remote/$(ADMISSION_NAME)-runtime-$(EFFECTIVE_VERSION).tgz oci://$(REGISTRY_URL)
 
 .PHONY: helm-push
 helm-push: helm-push-provider helm-push-admission
@@ -167,20 +167,20 @@ helm-push: helm-push-provider helm-push-admission
 extension-manifest: $(KUBECTL) $(YQ)
 	$(eval REGISTRY_URL := $(shell $(KUBECTL) cluster-info | head -1 | grep -oP 'https://\K[^:]+' | sed 's/^api\./reg./'))
 	@mkdir -p remote
-	@$(YQ) eval ".spec.deployment.admission.runtimeCluster.helm.ociRepository.ref = \"$(REGISTRY_URL)/$(ADMISSION_NAME)-runtime:$(VERSION)\" | \
+	@$(YQ) eval ".spec.deployment.admission.runtimeCluster.helm.ociRepository.ref = \"$(REGISTRY_URL)/$(ADMISSION_NAME)-runtime:$(EFFECTIVE_VERSION)\" | \
 	          .spec.deployment.admission.runtimeCluster.helm.ociRepository.pullSecretRef.name = \"gardener-images\" | \
-	          .spec.deployment.admission.virtualCluster.helm.ociRepository.ref = \"$(REGISTRY_URL)/$(ADMISSION_NAME)-application:$(VERSION)\" | \
+	          .spec.deployment.admission.virtualCluster.helm.ociRepository.ref = \"$(REGISTRY_URL)/$(ADMISSION_NAME)-application:$(EFFECTIVE_VERSION)\" | \
 	          .spec.deployment.admission.virtualCluster.helm.ociRepository.pullSecretRef.name = \"gardener-images\" | \
-	          .spec.deployment.extension.helm.ociRepository.ref = \"$(REGISTRY_URL)/$(EXTENSION_PREFIX)-$(NAME):$(VERSION)\" | \
+	          .spec.deployment.extension.helm.ociRepository.ref = \"$(REGISTRY_URL)/$(EXTENSION_PREFIX)-$(NAME):$(EFFECTIVE_VERSION)\" | \
 	          .spec.deployment.extension.helm.ociRepository.pullSecretRef.name = \"gardener-images\" | \
 	          .spec.deployment.admission.values.image.repository = \"$(REGISTRY_URL)/$(ADMISSION_NAME)\" | \
-	          .spec.deployment.admission.values.image.tag = \"$(VERSION)\" | \
+	          .spec.deployment.admission.values.image.tag = \"$(EFFECTIVE_VERSION)\" | \
 	          .spec.deployment.admission.values.image.pullPolicy = \"Always\" | \
 	          .spec.deployment.extension.values.image.repository = \"$(REGISTRY_URL)/$(NAME)\" | \
-	          .spec.deployment.extension.values.image.tag = \"$(VERSION)\" | \
+	          .spec.deployment.extension.values.image.tag = \"$(EFFECTIVE_VERSION)\" | \
 	          .spec.deployment.extension.values.image.pullPolicy = \"Always\" | \
 	          .spec.deployment.extension.runtimeClusterValues.image.repository = \"$(REGISTRY_URL)/$(NAME)\" | \
-	          .spec.deployment.extension.runtimeClusterValues.image.tag = \"$(VERSION)\" | \
+	          .spec.deployment.extension.runtimeClusterValues.image.tag = \"$(EFFECTIVE_VERSION)\" | \
 	          .spec.deployment.extension.runtimeClusterValues.image.pullPolicy = \"Always\"" \
 	          example/extension.yaml > remote/extension.yaml
 	@echo "Created remote/extension.yaml with registry $(REGISTRY_URL)"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement
/platform aws

**What this PR does / why we need it**:

This PR introduces two improvements to developer productivity:
- Make the `EFFECTIVE_VERSION` always unique even if the git hash does not change by including a timestamp. This ensures that the latest changes will always be deployed correctly.
- Make use of caches in the `Dockerfile` to improve image build times. Especially `amd64` images build significantly faster on ARM Macs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
