### PR TITLE
Add NamespacedCloudProfile spec capabilityFlavors mutation and fix expirationDate-only override validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,8 @@ require (
 	github.com/elastic/crd-ref-docs v0.3.0
 	github.com/gardener/etcd-druid/api v0.36.3
 	github.com/gardener/external-dns-management v0.40.0
-	github.com/gardener/gardener v1.141.0
-	github.com/gardener/gardener/pkg/apis v1.141.0
+	github.com/gardener/gardener v1.141.1
+	github.com/gardener/gardener/pkg/apis v1.141.1
 	github.com/gardener/machine-controller-manager v0.62.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -923,10 +923,10 @@ github.com/gardener/etcd-druid/api v0.36.3 h1:mBhDE/TJmcn2BY8Fscd5SfBSeWvtK4ZBPE
 github.com/gardener/etcd-druid/api v0.36.3/go.mod h1:RwZzKp8K415AS0zg8VoODjBxYepCAUYyLgXnZc1bmbo=
 github.com/gardener/external-dns-management v0.40.0 h1:2pgi/GD0VYWVoVDLsW7Hd9qqv0vzoHJFngrjiBQwIK8=
 github.com/gardener/external-dns-management v0.40.0/go.mod h1:6odJgWR8iG1ICmxFU31kipzMpjrMacB69ROoB4IdLCk=
-github.com/gardener/gardener v1.141.0 h1:B5gkB/pr2GteIljUMzGbzlwwGptitfSq2EocVTiF6VE=
-github.com/gardener/gardener v1.141.0/go.mod h1:n+mRxlSNEosLbMShvbQ0J9DWT73VQRFOyFGM6PNYnEY=
-github.com/gardener/gardener/pkg/apis v1.141.0 h1:X4jK8umXN6x75ebFvNG0yhcD7rAH9O0+fLWKU2VMzdY=
-github.com/gardener/gardener/pkg/apis v1.141.0/go.mod h1:D/FQAzo7GiD3R7TwuHUweU5FU3VYoD28HlbfGXfDe80=
+github.com/gardener/gardener v1.141.1 h1:9jlI9WKx66GFOpG6vhnA4SrwAs2VpiCVcFownQVkv10=
+github.com/gardener/gardener v1.141.1/go.mod h1:n+mRxlSNEosLbMShvbQ0J9DWT73VQRFOyFGM6PNYnEY=
+github.com/gardener/gardener/pkg/apis v1.141.1 h1:yHlOnJ2Lo9i0ZNbhOg5kenXb7Ak6CjnjXDvG+68lM/U=
+github.com/gardener/gardener/pkg/apis v1.141.1/go.mod h1:D/FQAzo7GiD3R7TwuHUweU5FU3VYoD28HlbfGXfDe80=
 github.com/gardener/machine-controller-manager v0.62.0 h1:XZWjAsXlNVj3S7M0AXcLkhNDGRRNm3Tc6ZFlTPPy3sc=
 github.com/gardener/machine-controller-manager v0.62.0/go.mod h1:ICsymXK4VHm7NVr8Mpl6USvYcTZjUNSk6+XaVu/dd74=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/admission/mutator/cloudprofile.go
+++ b/pkg/admission/mutator/cloudprofile.go
@@ -52,15 +52,16 @@ func (p *cloudProfile) Mutate(_ context.Context, newObj, _ client.Object) error 
 		return fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", profile.Name, err)
 	}
 
-	overwriteMachineImageCapabilityFlavors(profile, specConfig)
+	mutateMachineImageCapabilityFlavors(profile.Spec.MachineImages, specConfig)
 	return nil
 }
 
-// overwriteMachineImageCapabilityFlavors updates the capability flavors of machine images in the CloudProfile
-func overwriteMachineImageCapabilityFlavors(profile *gardencorev1beta1.CloudProfile, config *v1alpha1.CloudProfileConfig) {
+// mutateMachineImageCapabilityFlavors populates capabilityFlavors on machine image versions
+// by converting provider config entries (either new format capabilityFlavors or old format regions).
+func mutateMachineImageCapabilityFlavors(machineImages []gardencorev1beta1.MachineImage, config *v1alpha1.CloudProfileConfig) {
 	for _, providerMachineImage := range config.MachineImages {
-		// Find the corresponding machine image in the CloudProfile
-		imageIdx := slices.IndexFunc(profile.Spec.MachineImages, func(mi gardencorev1beta1.MachineImage) bool {
+		// Find the corresponding machine image
+		imageIdx := slices.IndexFunc(machineImages, func(mi gardencorev1beta1.MachineImage) bool {
 			return mi.Name == providerMachineImage.Name
 		})
 		if imageIdx == -1 {
@@ -69,8 +70,8 @@ func overwriteMachineImageCapabilityFlavors(profile *gardencorev1beta1.CloudProf
 
 		// Iterate over versions in the provider's machine image
 		for _, providerVersion := range providerMachineImage.Versions {
-			// Find the corresponding version in the CloudProfile's machine image
-			versionIdx := slices.IndexFunc(profile.Spec.MachineImages[imageIdx].Versions, func(miv gardencorev1beta1.MachineImageVersion) bool {
+			// Find the corresponding version
+			versionIdx := slices.IndexFunc(machineImages[imageIdx].Versions, func(miv gardencorev1beta1.MachineImageVersion) bool {
 				return miv.Version == providerVersion.Version
 			})
 			if versionIdx == -1 {
@@ -80,10 +81,10 @@ func overwriteMachineImageCapabilityFlavors(profile *gardencorev1beta1.CloudProf
 			// Support both new format (capabilityFlavors) and old format (regions with architecture)
 			if len(providerVersion.CapabilityFlavors) > 0 {
 				// New format: use capabilityFlavors directly
-				profile.Spec.MachineImages[imageIdx].Versions[versionIdx].CapabilityFlavors = convertCapabilityFlavors(providerVersion.CapabilityFlavors)
+				machineImages[imageIdx].Versions[versionIdx].CapabilityFlavors = convertCapabilityFlavors(providerVersion.CapabilityFlavors)
 			} else if len(providerVersion.Regions) > 0 {
 				// Old format: convert regions with architecture to capability flavors
-				profile.Spec.MachineImages[imageIdx].Versions[versionIdx].CapabilityFlavors = convertRegionsToCapabilityFlavors(providerVersion.Regions)
+				machineImages[imageIdx].Versions[versionIdx].CapabilityFlavors = convertRegionsToCapabilityFlavors(providerVersion.Regions)
 			}
 		}
 	}

--- a/pkg/admission/mutator/namespacedcloudprofile.go
+++ b/pkg/admission/mutator/namespacedcloudprofile.go
@@ -36,13 +36,13 @@ type namespacedCloudProfile struct {
 }
 
 // Mutate mutates the given NamespacedCloudProfile object.
-func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Object) error {
+func (p *namespacedCloudProfile) Mutate(ctx context.Context, newObj, _ client.Object) error {
 	profile, ok := newObj.(*gardencorev1beta1.NamespacedCloudProfile)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", newObj)
 	}
 
-	if shouldSkipMutation(profile) {
+	if profile.DeletionTimestamp != nil || profile.Spec.ProviderConfig == nil {
 		return nil
 	}
 
@@ -50,23 +50,52 @@ func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Obje
 	if _, _, err := p.decoder.Decode(profile.Spec.ProviderConfig.Raw, nil, specConfig); err != nil {
 		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile spec for '%s': %w", profile.Name, err)
 	}
-	statusConfig := &v1alpha1.CloudProfileConfig{}
-	if _, _, err := p.decoder.Decode(profile.Status.CloudProfileSpec.ProviderConfig.Raw, nil, statusConfig); err != nil {
-		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile status for '%s': %w", profile.Name, err)
+
+	// Mutation 1: Populate capabilityFlavors on spec.machineImages (needs parent lookup)
+	if err := p.mutateSpecCapabilityFlavors(ctx, profile, specConfig); err != nil {
+		return err
 	}
 
-	// Merge spec config into status config without format transformation.
-	// Mixed format (old regions with architecture and new capabilityFlavors) is supported per version.
-	statusConfig.MachineImages = mergeMachineImages(specConfig.MachineImages, statusConfig.MachineImages)
+	// Mutation 2: Merge spec providerConfig into status (only when status is ready)
+	if shouldMergeStatus(profile) {
+		statusConfig := &v1alpha1.CloudProfileConfig{}
+		if _, _, err := p.decoder.Decode(profile.Status.CloudProfileSpec.ProviderConfig.Raw, nil, statusConfig); err != nil {
+			return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile status for '%s': %w", profile.Name, err)
+		}
 
-	return p.updateProfileStatus(profile, statusConfig)
+		// Merge spec config into status config without format transformation.
+		// Mixed format (old regions with architecture and new capabilityFlavors) is supported per version.
+		statusConfig.MachineImages = mergeMachineImages(specConfig.MachineImages, statusConfig.MachineImages)
+
+		return p.updateProfileStatus(profile, statusConfig)
+	}
+
+	return nil
 }
 
-func shouldSkipMutation(profile *gardencorev1beta1.NamespacedCloudProfile) bool {
-	return profile.DeletionTimestamp != nil ||
-		profile.Generation != profile.Status.ObservedGeneration ||
-		profile.Spec.ProviderConfig == nil ||
-		profile.Status.CloudProfileSpec.ProviderConfig == nil
+// mutateSpecCapabilityFlavors populates capabilityFlavors on spec.machineImages from providerConfig.
+// This is needed so the Gardener core API server validation passes when machineCapabilities is defined.
+func (p *namespacedCloudProfile) mutateSpecCapabilityFlavors(ctx context.Context, profile *gardencorev1beta1.NamespacedCloudProfile, specConfig *v1alpha1.CloudProfileConfig) error {
+	if profile.Spec.Parent.Name == "" || len(profile.Spec.MachineImages) == 0 {
+		return nil
+	}
+
+	parentProfile := &gardencorev1beta1.CloudProfile{}
+	if err := p.client.Get(ctx, client.ObjectKey{Name: profile.Spec.Parent.Name}, parentProfile); err != nil {
+		return fmt.Errorf("could not get parent CloudProfile %q: %w", profile.Spec.Parent.Name, err)
+	}
+
+	if len(parentProfile.Spec.MachineCapabilities) == 0 {
+		return nil
+	}
+
+	mutateMachineImageCapabilityFlavors(profile.Spec.MachineImages, specConfig)
+	return nil
+}
+
+func shouldMergeStatus(profile *gardencorev1beta1.NamespacedCloudProfile) bool {
+	return profile.Generation == profile.Status.ObservedGeneration &&
+		profile.Status.CloudProfileSpec.ProviderConfig != nil
 }
 
 func (p *namespacedCloudProfile) updateProfileStatus(profile *gardencorev1beta1.NamespacedCloudProfile, config *v1alpha1.CloudProfileConfig) error {

--- a/pkg/admission/mutator/namespacedcloudprofile_test.go
+++ b/pkg/admission/mutator/namespacedcloudprofile_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/util"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/onsi/ginkgo/v2"
@@ -225,6 +226,163 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 									Regions:      []api.RegionAMIMapping{{Name: "eu3", AMI: "ami-125"}},
 								}},
 							}),
+					}),
+				))
+			})
+		})
+
+		Describe("populate spec.machineImages capabilityFlavors from providerConfig", func() {
+			var parentCloudProfile *v1beta1.CloudProfile
+
+			BeforeEach(func() {
+				parentCloudProfile = &v1beta1.CloudProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "parent-profile",
+					},
+					Spec: v1beta1.CloudProfileSpec{
+						MachineCapabilities: []v1beta1.CapabilityDefinition{
+							{Name: v1beta1constants.ArchitectureName, Values: []string{"amd64", "arm64"}},
+						},
+					},
+				}
+				namespacedCloudProfile.Spec.Parent = v1beta1.CloudProfileReference{
+					Name: "parent-profile",
+					Kind: v1beta1constants.CloudProfileReferenceKindCloudProfile,
+				}
+			})
+
+			It("should populate spec.machineImages capabilityFlavors from old format regions", func() {
+				Expect(fakeClient.Create(ctx, parentCloudProfile)).To(Succeed())
+
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[{"name":"image-1","versions":[
+  {"version":"1.0","regions":[
+    {"name":"eu-west-1","ami":"ami-123","architecture":"amd64"},
+    {"name":"eu-west-1","ami":"ami-456","architecture":"arm64"}
+  ]}
+]}]
+}`)}
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{
+						Name: "image-1",
+						Versions: []v1beta1.MachineImageVersion{
+							{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0"}},
+						},
+					},
+				}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				// Verify capabilityFlavors were populated on spec.machineImages
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(ConsistOf(
+					v1beta1.MachineImageFlavor{Capabilities: v1beta1.Capabilities{v1beta1constants.ArchitectureName: []string{"amd64"}}},
+					v1beta1.MachineImageFlavor{Capabilities: v1beta1.Capabilities{v1beta1constants.ArchitectureName: []string{"arm64"}}},
+				))
+			})
+
+			It("should populate spec.machineImages capabilityFlavors from new format capabilityFlavors", func() {
+				Expect(fakeClient.Create(ctx, parentCloudProfile)).To(Succeed())
+
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[{"name":"image-1","versions":[
+  {"version":"1.0","capabilityFlavors":[
+    {"capabilities":{"architecture":["amd64"]},"regions":[{"name":"eu-west-1","ami":"ami-123"}]},
+    {"capabilities":{"architecture":["arm64"]},"regions":[{"name":"eu-west-1","ami":"ami-456"}]}
+  ]}
+]}]
+}`)}
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{
+						Name: "image-1",
+						Versions: []v1beta1.MachineImageVersion{
+							{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0"}},
+						},
+					},
+				}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				// Verify capabilityFlavors were populated on spec.machineImages
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(ConsistOf(
+					v1beta1.MachineImageFlavor{Capabilities: v1beta1.Capabilities{v1beta1constants.ArchitectureName: []string{"amd64"}}},
+					v1beta1.MachineImageFlavor{Capabilities: v1beta1.Capabilities{v1beta1constants.ArchitectureName: []string{"arm64"}}},
+				))
+			})
+
+			It("should skip spec mutation when parent has no machineCapabilities", func() {
+				parentCloudProfile.Spec.MachineCapabilities = nil
+				Expect(fakeClient.Create(ctx, parentCloudProfile)).To(Succeed())
+
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[{"name":"image-1","versions":[
+  {"version":"1.0","regions":[{"name":"eu-west-1","ami":"ami-123","architecture":"amd64"}]}
+]}]
+}`)}
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{
+						Name: "image-1",
+						Versions: []v1beta1.MachineImageVersion{
+							{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0"}},
+						},
+					},
+				}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				// capabilityFlavors should NOT be populated
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(BeNil())
+			})
+
+			It("should handle combined spec mutation and status merge", func() {
+				Expect(fakeClient.Create(ctx, parentCloudProfile)).To(Succeed())
+
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[{"name":"image-1","versions":[
+  {"version":"1.1","regions":[{"name":"eu-west-1","ami":"ami-new","architecture":"amd64"}]}
+]}]
+}`)}
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{
+						Name: "image-1",
+						Versions: []v1beta1.MachineImageVersion{
+							{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.1"}},
+						},
+					},
+				}
+				// Set up status so status merge also triggers
+				namespacedCloudProfile.Status.CloudProfileSpec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[{"name":"image-1","versions":[
+  {"version":"1.0","regions":[{"name":"eu-west-1","ami":"ami-old","architecture":"amd64"}]}
+]}]
+}`)}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				// Verify spec mutation happened
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(ConsistOf(
+					v1beta1.MachineImageFlavor{Capabilities: v1beta1.Capabilities{v1beta1constants.ArchitectureName: []string{"amd64"}}},
+				))
+
+				// Verify status merge happened
+				mergedConfig, err := decodeCloudProfileConfig(decoder, namespacedCloudProfile.Status.CloudProfileSpec.ProviderConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mergedConfig.MachineImages).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"Name": Equal("image-1"),
+						"Versions": ContainElements(
+							api.MachineImageVersion{Version: "1.0", Regions: []api.RegionAMIMapping{{Name: "eu-west-1", AMI: "ami-old", Architecture: ptr.To("amd64")}}},
+							api.MachineImageVersion{Version: "1.1", Regions: []api.RegionAMIMapping{{Name: "eu-west-1", AMI: "ami-new", Architecture: ptr.To("amd64")}}},
+						),
 					}),
 				))
 			})

--- a/pkg/admission/mutator/webhook.go
+++ b/pkg/admission/mutator/webhook.go
@@ -28,9 +28,12 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Name: Name,
 		Path: "/webhooks/mutate",
 		Mutators: map[extensionswebhook.Mutator][]extensionswebhook.Type{
-			NewShootMutator(mgr):                  {{Obj: &gardencorev1beta1.Shoot{}}},
-			NewNamespacedCloudProfileMutator(mgr): {{Obj: &gardencorev1beta1.NamespacedCloudProfile{}, Subresource: ptr.To("status")}},
-			NewCloudProfileMutator(mgr):           {{Obj: &gardencorev1beta1.CloudProfile{}}},
+			NewShootMutator(mgr): {{Obj: &gardencorev1beta1.Shoot{}}},
+			NewNamespacedCloudProfileMutator(mgr): {
+				{Obj: &gardencorev1beta1.NamespacedCloudProfile{}},
+				{Obj: &gardencorev1beta1.NamespacedCloudProfile{}, Subresource: ptr.To("status")},
+			},
+			NewCloudProfileMutator(mgr): {{Obj: &gardencorev1beta1.CloudProfile{}}},
 		},
 		Target: extensionswebhook.TargetSeed,
 		ObjectSelector: &metav1.LabelSelector{

--- a/pkg/admission/validator/namespacedcloudprofile.go
+++ b/pkg/admission/validator/namespacedcloudprofile.go
@@ -109,6 +109,12 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.Cloud
 				continue
 			}
 
+			// If the version exists in the parent and has no providerConfig entry, it's an
+			// expirationDate-only override that doesn't change image mappings — skip validation.
+			if existsInParent && !exists {
+				continue
+			}
+
 			if len(parentSpec.MachineCapabilities) == 0 {
 				allErrs = append(allErrs, validateMachineImageArchitectures(machineImage, version, providerImageVersion)...)
 			} else {

--- a/pkg/admission/validator/namespacedcloudprofile_test.go
+++ b/pkg/admission/validator/namespacedcloudprofile_test.go
@@ -378,6 +378,38 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile Validator", func(isCapabili
 
 			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(Succeed())
 		})
+
+		It("should succeed for expirationDate-only override of a parent version without providerConfig entry", func() {
+			cloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+				{Name: "ubuntu", Versions: []v1beta1.MachineImageVersion{
+					{ExpirableVersion: v1beta1.ExpirableVersion{Version: "22.04"}, Architectures: []string{"amd64"}},
+				}},
+			}
+			if isCapabilitiesCloudProfile {
+				cloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors = []v1beta1.MachineImageFlavor{
+					{Capabilities: v1beta1.Capabilities{v1beta1constants.ArchitectureName: []string{"amd64"}}},
+				}
+			}
+			cloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[{"name":"ubuntu","versions":[{"version":"22.04","regions":[{"name":"eu1","ami":"ami-123"}]}]}]
+}`)}
+
+			// NCP overrides only the expirationDate, no providerConfig entry for ubuntu
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig"
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{Name: "ubuntu", Versions: []core.MachineImageVersion{
+					{ExpirableVersion: core.ExpirableVersion{Version: "22.04", ExpirationDate: ptr.To(metav1.Now())}},
+				}},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+		})
 	})
 },
 	Entry("CloudProfile uses regions only", false),
@@ -568,6 +600,39 @@ var _ = Describe("NamespacedCloudProfile Validator Mixed Format", func() {
 				"Field":  Equal("spec.providerConfig.machineImages"),
 				"Detail": ContainSubstring("not defined in the NamespacedCloudProfile providerConfig"),
 			}))))
+		})
+
+		It("should succeed for expirationDate-only override of a parent version without providerConfig entry", func() {
+			cloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+				{Name: "ubuntu", Versions: []v1beta1.MachineImageVersion{
+					{
+						ExpirableVersion:  v1beta1.ExpirableVersion{Version: "22.04"},
+						Architectures:     []string{"amd64"},
+						CapabilityFlavors: []v1beta1.MachineImageFlavor{{Capabilities: v1beta1.Capabilities{v1beta1constants.ArchitectureName: []string{"amd64"}}}},
+					},
+				}},
+			}
+			cloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[{"name":"ubuntu","versions":[{"version":"22.04","capabilityFlavors":[
+  {"capabilities":{"architecture":["amd64"]},"regions":[{"name":"eu1","ami":"ami-123"}]}
+]}]}]
+}`)}
+
+			// NCP overrides only the expirationDate, no providerConfig entry for ubuntu
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig"
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{Name: "ubuntu", Versions: []core.MachineImageVersion{
+					{ExpirableVersion: core.ExpirableVersion{Version: "22.04", ExpirationDate: ptr.To(metav1.Now())}},
+				}},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bugfix
/platform aws

**What this PR does / why we need it**:

Fixes `NamespacedCloudProfile` admission to:
1. Populate `capabilityFlavors` on `spec.machineImages` from providerConfig (required by Gardener core validation when parent uses `machineCapabilities`)
2. Allow expirationDate-only overrides of parent versions without requiring a providerConfig entry

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- Requires `github.com/gardener/gardener >= v1.139.4` to test via `make start-admission` (see https://github.com/gardener/gardener/pull/14664)
- The `nscpfl` mutator combines spec mutation + status merge in one `Mutate()` call (GVK routing constraint)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix `NamespacedCloudProfile` admission to populate `capabilityFlavors` on spec machine images and allow expirationDate-only overrides of parent versions without requiring a providerConfig entry.
```