### PR TITLE
Fix: update mutating admission policy logic for K8s versions < 1.36

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -971,45 +971,33 @@ func isMutatingAdmissionPolicyEnabled(cluster *extensionscontroller.Cluster) boo
 		return false
 	}
 
-	// For K8s >= 1.34, MutatingAdmissionPolicy is beta (enabled by default) or GA (>= 1.36).
-	// For beta (>= 1.34 and < 1.36), users can explicitly disable the feature gate.
-	// For GA (>= 1.36), the feature gate is locked on and cannot be disabled.
-	if versionutils.ConstraintK8sGreaterEqual134.Check(k8sVersion) {
-		if constraintK8sGreaterEqual136.Check(k8sVersion) {
-			return true
-		}
-		// Beta: check if user explicitly disabled the feature gate
-		if cluster.Shoot.Spec.Kubernetes.KubeAPIServer != nil &&
-			cluster.Shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates != nil {
-			if enabled, ok := cluster.Shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates["MutatingAdmissionPolicy"]; ok && !enabled {
-				return false
-			}
-		}
+	// For K8s >= 1.36, MutatingAdmissionPolicy is GA (locked on, cannot be disabled).
+	if constraintK8sGreaterEqual136.Check(k8sVersion) {
 		return true
 	}
 
 	if cluster.Shoot.Spec.Kubernetes.KubeAPIServer == nil {
 		return false
 	}
-
 	if cluster.Shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates == nil {
 		return false
 	}
-
 	if enabled, ok := cluster.Shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates["MutatingAdmissionPolicy"]; !ok || !enabled {
 		return false
 	}
-
 	if cluster.Shoot.Spec.Kubernetes.KubeAPIServer.RuntimeConfig == nil {
 		return false
 	}
 
 	rc := cluster.Shoot.Spec.Kubernetes.KubeAPIServer.RuntimeConfig
-	if !rc["admissionregistration.k8s.io/v1alpha1"] && !rc["admissionregistration.k8s.io/v1beta1"] {
-		return false
+
+	// For K8s >= 1.34 and < 1.36, MutatingAdmissionPolicy is in beta but disabled by default.
+	// Users must explicitly enable the feature gate and opt in via RuntimeConfig.
+	if versionutils.ConstraintK8sGreaterEqual134.Check(k8sVersion) {
+		return rc["admissionregistration.k8s.io/v1beta1"]
 	}
 
-	return true
+	return rc["admissionregistration.k8s.io/v1alpha1"] || rc["admissionregistration.k8s.io/v1beta1"]
 }
 
 func mutatingAdmissionPolicyAPIVersion(cluster *extensionscontroller.Cluster) string {

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -819,17 +819,27 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
 		})
 
-		It("should return true for K8s >= 1.34 without any feature gate or RuntimeConfig (beta)", func() {
+		It("should return false for K8s >= 1.34 and < 1.36 without any feature gate or RuntimeConfig (beta, disabled by default)", func() {
 			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
-			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
 		})
 
-		It("should return true for K8s >= 1.34 even without KubeAPIServer config (beta)", func() {
+		It("should return false for K8s 1.35 without KubeAPIServer config (beta, disabled by default)", func() {
 			testCluster.Shoot.Spec.Kubernetes.Version = "1.35.0"
-			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
 		})
 
-		It("should return false for K8s >= 1.34 and < 1.36 if feature gate is explicitly disabled (beta)", func() {
+		It("should return false for K8s >= 1.34 and < 1.36 if feature gate is not set", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"SomeOtherGate": true},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false for K8s >= 1.34 and < 1.36 if feature gate is explicitly disabled", func() {
 			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
 			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
 				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
@@ -839,14 +849,47 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
 		})
 
-		It("should return false for K8s 1.35 if feature gate is explicitly disabled (beta)", func() {
-			testCluster.Shoot.Spec.Kubernetes.Version = "1.35.0"
+		It("should return false for K8s >= 1.34 and < 1.36 if feature gate is enabled but RuntimeConfig is nil", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
 			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
 				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
-					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": false},
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
 				},
 			}
 			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false for K8s >= 1.34 and < 1.36 if feature gate is enabled but v1beta1 is not in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.35.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{"some.other/v1": true},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return true for K8s >= 1.34 and < 1.36 if feature gate is enabled and v1beta1 is in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1beta1": true},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return true for K8s 1.35 if feature gate is enabled and v1beta1 is in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.35.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1beta1": true},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
 		})
 
 		It("should return true for K8s >= 1.36 even if feature gate is explicitly disabled (GA, locked on)", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-provider-aws/pull/1770 introduced a bug because although MutatingAdmissionPolicy is in beta from version 1.34, it is still [disabled by default](https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/3136-beta-apis-off-by-default) in 1.34 and 1.35: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
