### PR TITLE
Improve wording for enableMTUCustomizer flag default behavior

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -291,7 +291,7 @@ It only applies for those worker pools whose `iamInstanceProfile` is not set.
 The `enableMTUCustomizer` flag controls whether a systemd unit and script are deployed to the shoot worker nodes that set the MTU of all non-virtual network interfaces to `1460`.
 This is a legacy mechanism from a time when CNIs lacked automatic MTU detection. Modern CNIs detect and configure the MTU automatically, so new clusters should explicitly set this flag to `false`.
 It may still be useful in environments where the default AWS MTU of `9001` causes connectivity issues with peers that have a lower MTU (e.g. `1500`) and the CNI does not handle this automatically.
-If the flag is not provided, the admission webhook defaults it to `false` for newly created shoots. For existing shoots the field remains unset, which also defaults to `true` for backwards compatibility.
+If the flag is not provided, the admission webhook defaults it to `true` for newly created shoots. For existing shoots the field remains unset, which also defaults to `true` for backwards compatibility.
 
 <details>
   <summary>Click to expand the default AWS IAM policy document used for the instance profiles!</summary>

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -291,7 +291,7 @@ It only applies for those worker pools whose `iamInstanceProfile` is not set.
 The `enableMTUCustomizer` flag controls whether a systemd unit and script are deployed to the shoot worker nodes that set the MTU of all non-virtual network interfaces to `1460`.
 This is a legacy mechanism from a time when CNIs lacked automatic MTU detection. Modern CNIs detect and configure the MTU automatically, so new clusters should explicitly set this flag to `false`.
 It may still be useful in environments where the default AWS MTU of `9001` causes connectivity issues with peers that have a lower MTU (e.g. `1500`) and the CNI does not handle this automatically.
-If the flag is not provided, the admission webhook defaults it to `true` for newly created shoots. For existing shoots the field remains unset, which also defaults to `true` for backwards compatibility.
+For newly created shoots, where the flag is not provided, the admission webhook defaults it to `false`. For existing shoots, the fiels is also unset but is defaulted to `true` instead for backwards compatibility.
 
 <details>
   <summary>Click to expand the default AWS IAM policy document used for the instance profiles!</summary>


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area documentation
/kind enhancement
/platform aws

**What this PR does / why we need it**:

Fixes an inconsistency in the enableMTUCustomizer documentation: https://github.com/gardener/gardener-extension-provider-aws/blob/0bc056fd8d1238e2576337a4496b651cd7020473/docs/usage/usage.md?plain=1#L291

The sentence states that the flag is set to `false` for newly created shoots but `true` for newly created shoots. The way the sentence is worded makes me think that it should be `true` in both cases. This would also align with https://github.com/gardener/gardener-extension-provider-aws/pull/1732.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
