### PR TITLE
Fix byo vpc validation

### DIFF
--- a/pkg/controller/infrastructure/configvalidator.go
+++ b/pkg/controller/infrastructure/configvalidator.go
@@ -70,7 +70,7 @@ func (c *configValidator) Validate(ctx context.Context, infra *extensionsv1alpha
 	// Validate infrastructure config
 	if config.Networks.VPC.ID != nil {
 		logger.Info("Validating infrastructure networks.vpc.id")
-		allErrs = append(allErrs, c.validateVPC(ctx, field.NewPath("networks", "vpc", "id"),
+		allErrs = append(allErrs, c.validateVPC(ctx, field.NewPath("networks"),
 			awsClient, *config, *config.Networks.VPC.ID, infra.Spec.Region)...)
 	}
 
@@ -102,19 +102,21 @@ func (c *configValidator) validateVPC(
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	vpcIdPath := fldPath.Child("vpc", "id")
+
 	// Verify that the VPC exists and the enableDnsSupport and enableDnsHostnames VPC attributes are both true
 	for _, attribute := range []ec2types.VpcAttributeName{ec2types.VpcAttributeNameEnableDnsSupport, ec2types.VpcAttributeNameEnableDnsHostnames} {
 		value, err := awsClient.GetVPCAttribute(ctx, vpcID, attribute)
 		if err != nil {
 			if awsclient.IsNotFoundError(err) {
-				allErrs = append(allErrs, field.NotFound(fldPath, vpcID))
+				allErrs = append(allErrs, field.NotFound(vpcIdPath, vpcID))
 			} else {
-				allErrs = append(allErrs, field.InternalError(fldPath, fmt.Errorf("could not get VPC attribute %s for VPC %s: %w", attribute, vpcID, err)))
+				allErrs = append(allErrs, field.InternalError(vpcIdPath, fmt.Errorf("could not get VPC attribute %s for VPC %s: %w", attribute, vpcID, err)))
 			}
 			return allErrs
 		}
 		if !value {
-			allErrs = append(allErrs, field.Invalid(fldPath, vpcID, fmt.Sprintf("VPC attribute %s must be set to true", attribute)))
+			allErrs = append(allErrs, field.Invalid(vpcIdPath, vpcID, fmt.Sprintf("VPC attribute %s must be set to true", attribute)))
 		}
 	}
 
@@ -122,7 +124,7 @@ func (c *configValidator) validateVPC(
 	if dualStack {
 		_, err := awsClient.GetIPv6Cidr(ctx, vpcID)
 		if err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath, vpcID, fmt.Sprintf("VPC %s has no ipv6 CIDR", vpcID)))
+			allErrs = append(allErrs, field.Invalid(vpcIdPath, vpcID, fmt.Sprintf("VPC %s has no ipv6 CIDR", vpcID)))
 			return allErrs
 		}
 	}
@@ -130,57 +132,41 @@ func (c *configValidator) validateVPC(
 	// Verify that there is an internet gateway attached to the VPC
 	internetGatewayID, err := awsClient.GetVPCInternetGateway(ctx, vpcID)
 	if err != nil {
-		allErrs = append(allErrs, field.InternalError(fldPath, fmt.Errorf("could not get internet gateway for VPC %s: %w", vpcID, err)))
+		allErrs = append(allErrs, field.InternalError(vpcIdPath, fmt.Errorf("could not get internet gateway for VPC %s: %w", vpcID, err)))
 		return allErrs
 	}
 	if internetGatewayID == "" {
-		allErrs = append(allErrs, field.Invalid(fldPath, vpcID, "no attached internet gateway found"))
+		allErrs = append(allErrs, field.Invalid(vpcIdPath, vpcID, "no attached internet gateway found"))
 	}
 
 	// Verify DHCP options
 	dhcpOptions, err := awsClient.GetDHCPOptions(ctx, vpcID)
 	if err != nil {
-		allErrs = append(allErrs, field.InternalError(fldPath, fmt.Errorf("could not get DHCP options for VPC %s: %w", vpcID, err)))
+		allErrs = append(allErrs, field.InternalError(vpcIdPath, fmt.Errorf("could not get DHCP options for VPC %s: %w", vpcID, err)))
 		return allErrs
 	}
 
 	if domainName, ok := dhcpOptions["domain-name"]; !ok {
-		allErrs = append(allErrs, field.Invalid(fldPath, vpcID, "missing domain-name value in DHCP options used by the VPC"))
+		allErrs = append(allErrs, field.Invalid(vpcIdPath, vpcID, "missing domain-name value in DHCP options used by the VPC"))
 	} else if (region == "us-east-1" && domainName != "ec2.internal") || (region != "us-east-1" && domainName != region+".compute.internal") {
-		allErrs = append(allErrs, field.Invalid(fldPath, vpcID, fmt.Sprintf("invalid domain-name specified in DHCP options used by VPC: %s", domainName)))
+		allErrs = append(allErrs, field.Invalid(vpcIdPath, vpcID, fmt.Sprintf("invalid domain-name specified in DHCP options used by VPC: %s", domainName)))
 	}
 
 	// crosscheck subnet CIDRs are subset of VPC CIDR
 	vpc, err := awsClient.GetVpc(ctx, vpcID)
 	if err != nil {
-		allErrs = append(allErrs, field.InternalError(fldPath, fmt.Errorf("could not get CIDR block for VPC %s: %w", vpcID, err)))
+		allErrs = append(allErrs, field.InternalError(vpcIdPath, fmt.Errorf("could not get CIDR block for VPC %s: %w", vpcID, err)))
 		return allErrs
 	}
 
 	cidrsToConsider := []string{vpc.CidrBlock}
 	cidrsToConsider = append(cidrsToConsider, vpc.CidrBlockAssociationSet...)
 
-	networkingPath := field.NewPath("networking")
-
 	if len(cidrsToConsider) == 1 {
 		// Special case, use old behaviour (so we keep the pretty error message)
-		allErrs = append(allErrs, validateZoneSubnetCIDRs(networkingPath, cidrsToConsider[0], infraConfig)...)
+		allErrs = append(allErrs, validateZoneSubnetCIDRs(fldPath, cidrsToConsider[0], infraConfig)...)
 	} else {
-		// Only check if there is at least one valid cidr on the vpc that matches and return an error if there is not
-		haveValidCidr := slices.ContainsFunc(cidrsToConsider, func(cidr string) bool {
-			return validateZoneSubnetCIDRs(networkingPath, cidr, infraConfig).ToAggregate() == nil
-		})
-
-		if !haveValidCidr {
-			allErrs = append(
-				allErrs,
-				field.Invalid(
-					fldPath,
-					vpcID,
-					"provided VPC has no CIDR block matching the clusters configured networks. There must be a CIDR block that is a superset of all subnet ranges.",
-				),
-			)
-		}
+		allErrs = append(allErrs, byoValidateZoneSubnetCIDRs(fldPath, cidrsToConsider, infraConfig.Networks.Zones)...)
 	}
 
 	return allErrs
@@ -188,14 +174,51 @@ func (c *configValidator) validateVPC(
 
 func validateZoneSubnetCIDRs(fldPath *field.Path, cidr string, infraConfig apiaws.InfrastructureConfig) field.ErrorList {
 	allErrs := field.ErrorList{}
-	vpcCIDR := cidrvalidation.NewCIDR(cidr, fldPath)
-	for _, zones := range infraConfig.Networks.Zones {
+	vpcCIDR := cidrvalidation.NewCIDR(cidr, fldPath.Child("vpc"))
+	for i, zones := range infraConfig.Networks.Zones {
 		zoneSubnetCIDRs := []cidrvalidation.CIDR{
-			cidrvalidation.NewCIDR(zones.Workers, fldPath.Child("nodes")),
-			cidrvalidation.NewCIDR(zones.Public, fldPath.Child("public")),
-			cidrvalidation.NewCIDR(zones.Internal, fldPath.Child("internal")),
+			cidrvalidation.NewCIDR(zones.Workers, fldPath.Child("zones").Index(i).Child("nodes")),
+			cidrvalidation.NewCIDR(zones.Public, fldPath.Child("zones").Index(i).Child("public")),
+			cidrvalidation.NewCIDR(zones.Internal, fldPath.Child("zones").Index(i).Child("internal")),
 		}
 		allErrs = append(allErrs, vpcCIDR.ValidateSubset(zoneSubnetCIDRs...)...)
+	}
+	return allErrs
+}
+
+// byoValidateZoneSubnetCIDRs validates that the provided CIDRs (assumed to be from a single VPC whose ID was provided
+// to be used) are set up in a way that it's conceivable that the shoot creation can succeed. It is checked
+// that for each subnet there is at least one CIDR present that is a superset of the subnet's CIDR.
+func byoValidateZoneSubnetCIDRs(fldPath *field.Path, cidrs []string, zones []apiaws.Zone) field.ErrorList {
+	allErrs := field.ErrorList{}
+	zonesPath := fldPath.Child("zones")
+
+	vpcCIDRs := []cidrvalidation.CIDR{}
+	for _, cidr := range cidrs {
+		vpcCIDRs = append(vpcCIDRs, cidrvalidation.NewCIDR(cidr, fldPath.Child("vpc")))
+	}
+
+	validateSubnetFunc := func(subnetCIDR cidrvalidation.CIDR) {
+		if !slices.ContainsFunc(vpcCIDRs, func(vpcCIDR cidrvalidation.CIDR) bool {
+			return vpcCIDR.ValidateSubset(subnetCIDR) == nil
+		}) {
+			allErrs = append(allErrs, field.Invalid(
+				subnetCIDR.GetFieldPath(),
+				subnetCIDR.GetCIDR(),
+				"Subnet not contained in any of the associated CIDRs of the given VPC",
+			))
+		}
+	}
+
+	for i, zone := range zones {
+		ZoneWorkersCIDR := cidrvalidation.NewCIDR(zone.Workers, zonesPath.Index(i).Child("nodes"))
+		ZonePublicCIDR := cidrvalidation.NewCIDR(zone.Public, zonesPath.Index(i).Child("public"))
+		ZoneInternalCIDR := cidrvalidation.NewCIDR(zone.Internal, zonesPath.Index(i).Child("internal"))
+
+		validateSubnetFunc(ZoneWorkersCIDR)
+		validateSubnetFunc(ZonePublicCIDR)
+		validateSubnetFunc(ZoneInternalCIDR)
+
 	}
 	return allErrs
 }

--- a/pkg/controller/infrastructure/configvalidator.go
+++ b/pkg/controller/infrastructure/configvalidator.go
@@ -195,7 +195,7 @@ func validateZoneSubnetCIDRs(fldPath *field.Path, cidrs []string, zones []apiaws
 				allErrs = append(allErrs, field.Invalid(
 					subnetCIDR.GetFieldPath(),
 					subnetCIDR.GetCIDR(),
-					fmt.Sprintf("Subnet %q not contained in any of the associated CIDRs of the given VPC", subnetCIDR.GetFieldPath()),
+					fmt.Sprintf("subnet CIDR %q is not contained in any of the VPC's associated CIDR blocks", subnetCIDR.GetCIDR()),
 				))
 			}
 		}

--- a/pkg/controller/infrastructure/configvalidator.go
+++ b/pkg/controller/infrastructure/configvalidator.go
@@ -162,34 +162,15 @@ func (c *configValidator) validateVPC(
 	cidrsToConsider := []string{vpc.CidrBlock}
 	cidrsToConsider = append(cidrsToConsider, vpc.CidrBlockAssociationSet...)
 
-	if len(cidrsToConsider) == 1 {
-		// Special case, use old behaviour (so we keep the pretty error message)
-		allErrs = append(allErrs, validateZoneSubnetCIDRs(fldPath, cidrsToConsider[0], infraConfig)...)
-	} else {
-		allErrs = append(allErrs, byoValidateZoneSubnetCIDRs(fldPath, cidrsToConsider, infraConfig.Networks.Zones)...)
-	}
+	allErrs = append(allErrs, validateZoneSubnetCIDRs(fldPath, cidrsToConsider, infraConfig.Networks.Zones)...)
 
 	return allErrs
 }
 
-func validateZoneSubnetCIDRs(fldPath *field.Path, cidr string, infraConfig apiaws.InfrastructureConfig) field.ErrorList {
-	allErrs := field.ErrorList{}
-	vpcCIDR := cidrvalidation.NewCIDR(cidr, fldPath.Child("vpc"))
-	for i, zones := range infraConfig.Networks.Zones {
-		zoneSubnetCIDRs := []cidrvalidation.CIDR{
-			cidrvalidation.NewCIDR(zones.Workers, fldPath.Child("zones").Index(i).Child("nodes")),
-			cidrvalidation.NewCIDR(zones.Public, fldPath.Child("zones").Index(i).Child("public")),
-			cidrvalidation.NewCIDR(zones.Internal, fldPath.Child("zones").Index(i).Child("internal")),
-		}
-		allErrs = append(allErrs, vpcCIDR.ValidateSubset(zoneSubnetCIDRs...)...)
-	}
-	return allErrs
-}
-
-// byoValidateZoneSubnetCIDRs validates that the provided CIDRs (assumed to be from a single VPC whose ID was provided
-// to be used) are set up in a way that it's conceivable that the shoot creation can succeed. It is checked
+// ValidateZoneSubnetCIDRs validates that the provided CIDRs (assumed to be from a single VPC) are
+// set up in a way that it's conceivable that the shoot creation can succeed. It is checked
 // that for each subnet there is at least one CIDR present that is a superset of the subnet's CIDR.
-func byoValidateZoneSubnetCIDRs(fldPath *field.Path, cidrs []string, zones []apiaws.Zone) field.ErrorList {
+func validateZoneSubnetCIDRs(fldPath *field.Path, cidrs []string, zones []apiaws.Zone) field.ErrorList {
 	allErrs := field.ErrorList{}
 	zonesPath := fldPath.Child("zones")
 
@@ -198,27 +179,26 @@ func byoValidateZoneSubnetCIDRs(fldPath *field.Path, cidrs []string, zones []api
 		vpcCIDRs = append(vpcCIDRs, cidrvalidation.NewCIDR(cidr, fldPath.Child("vpc")))
 	}
 
-	validateSubnetFunc := func(subnetCIDR cidrvalidation.CIDR) {
-		if !slices.ContainsFunc(vpcCIDRs, func(vpcCIDR cidrvalidation.CIDR) bool {
-			return vpcCIDR.ValidateSubset(subnetCIDR) == nil
-		}) {
-			allErrs = append(allErrs, field.Invalid(
-				subnetCIDR.GetFieldPath(),
-				subnetCIDR.GetCIDR(),
-				"Subnet not contained in any of the associated CIDRs of the given VPC",
-			))
-		}
+	isSubnetCIDRContainedInAnyCIDR := func(cidrsToCheck []cidrvalidation.CIDR, subnetCIDR cidrvalidation.CIDR) bool {
+		return slices.ContainsFunc(cidrsToCheck, func(vpcCIDR cidrvalidation.CIDR) bool {
+			return vpcCIDR.ValidateSubset(subnetCIDR).ToAggregate() == nil
+		})
 	}
 
 	for i, zone := range zones {
-		ZoneWorkersCIDR := cidrvalidation.NewCIDR(zone.Workers, zonesPath.Index(i).Child("nodes"))
-		ZonePublicCIDR := cidrvalidation.NewCIDR(zone.Public, zonesPath.Index(i).Child("public"))
-		ZoneInternalCIDR := cidrvalidation.NewCIDR(zone.Internal, zonesPath.Index(i).Child("internal"))
-
-		validateSubnetFunc(ZoneWorkersCIDR)
-		validateSubnetFunc(ZonePublicCIDR)
-		validateSubnetFunc(ZoneInternalCIDR)
-
+		for _, subnetCIDR := range []cidrvalidation.CIDR{
+			cidrvalidation.NewCIDR(zone.Workers, zonesPath.Index(i).Child("nodes")),
+			cidrvalidation.NewCIDR(zone.Public, zonesPath.Index(i).Child("public")),
+			cidrvalidation.NewCIDR(zone.Internal, zonesPath.Index(i).Child("internal")),
+		} {
+			if !isSubnetCIDRContainedInAnyCIDR(vpcCIDRs, subnetCIDR) {
+				allErrs = append(allErrs, field.Invalid(
+					subnetCIDR.GetFieldPath(),
+					subnetCIDR.GetCIDR(),
+					fmt.Sprintf("Subnet %q not contained in any of the associated CIDRs of the given VPC", subnetCIDR.GetFieldPath()),
+				))
+			}
+		}
 	}
 	return allErrs
 }

--- a/pkg/controller/infrastructure/configvalidator_test.go
+++ b/pkg/controller/infrastructure/configvalidator_test.go
@@ -205,6 +205,74 @@ var _ = Describe("ConfigValidator", func() {
 				Expect(errorList).To(BeEmpty())
 			})
 
+			It("should succeed - Not all subnet CIDRs subset of VPC CIDR", func() {
+				infra.Spec.ProviderConfig.Raw = encode(&apisaws.InfrastructureConfig{
+					Networks: apisaws.Networks{
+						VPC: apisaws.VPC{
+							ID: ptr.To(vpcID),
+						},
+						Zones: []apisaws.Zone{
+							{
+								Workers:  "10.251.127.0/26",
+								Public:   "10.252.125.0/26",
+								Internal: "10.251.126.0/26",
+							},
+						},
+					},
+				})
+				expectValidVPCAttributes(ctx, awsClient, vpcID)
+				expectValidDHCPOptions(ctx, awsClient, vpcID, region)
+				awsClient.EXPECT().GetVpc(ctx, vpcID).Return(&awsclient.VPC{
+					CidrBlock:               "10.251.0.0/16",
+					CidrBlockAssociationSet: []string{"10.252.0.0/16"},
+				}, nil)
+
+				errorList := cv.Validate(ctx, infra)
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should succeed - Not all subnet CIDRs subset of VPC CIDR in multi-zone case", func() {
+				infra.Spec.ProviderConfig.Raw = encode(&apisaws.InfrastructureConfig{
+					Networks: apisaws.Networks{
+						VPC: apisaws.VPC{
+							ID: ptr.To(vpcID),
+						},
+						Zones: []apisaws.Zone{
+							{
+								Workers:  "10.251.127.0/26",
+								Public:   "10.252.125.0/26",
+								Internal: "10.251.126.0/26",
+							},
+							{
+								Workers:  "10.254.128.0/26",
+								Public:   "10.254.129.0/26",
+								Internal: "10.255.130.0/26",
+							},
+							{
+								Workers:  "10.256.128.0/26",
+								Public:   "10.256.129.0/26",
+								Internal: "10.256.130.0/26",
+							},
+						},
+					},
+				})
+				expectValidVPCAttributes(ctx, awsClient, vpcID)
+				expectValidDHCPOptions(ctx, awsClient, vpcID, region)
+				awsClient.EXPECT().GetVpc(ctx, vpcID).Return(&awsclient.VPC{
+					CidrBlock: "10.251.0.0/16",
+					CidrBlockAssociationSet: []string{
+						"10.252.0.0/16",
+						"10.253.0.0/16",
+						"10.254.0.0/16",
+						"10.255.0.0/16",
+						"10.256.0.0/16",
+					},
+				}, nil)
+
+				errorList := cv.Validate(ctx, infra)
+				Expect(errorList).To(BeEmpty())
+			})
+
 			It("should fail - a subnet CIDR is not a subset of the VPC cidr", func() {
 				infra.Spec.ProviderConfig.Raw = encode(&apisaws.InfrastructureConfig{
 					Networks: apisaws.Networks{
@@ -228,13 +296,13 @@ var _ = Describe("ConfigValidator", func() {
 				errorList := cv.Validate(ctx, infra)
 				Expect(errorList).To(ConsistOfFields(Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("networking.nodes"), // workers -> nodes in validator
+					"Field": Equal("networks.zones[0].nodes"), // workers -> nodes in validator
 				}, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("networking.public"),
+					"Field": Equal("networks.zones[0].public"),
 				}, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("networking.internal"),
+					"Field": Equal("networks.zones[0].internal"),
 				}))
 			})
 
@@ -293,9 +361,10 @@ var _ = Describe("ConfigValidator", func() {
 				errorList := cv.Validate(ctx, infra)
 				Expect(errorList).To(ConsistOfFields(Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("networking.nodes"),
+					"Field": Equal("networks.zones[1].nodes"),
 				}))
 			})
+
 		})
 	})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...
If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug
/platform aws

**What this PR does / why we need it**: Previous validation assumed that all subnets need to be covered by one associated CIDR of the provided VPC. With this PR, subnets are verified independent from each other in the BYO case.
I've also updated some of the field-paths to be more precise.

**Which issue(s) this PR fixes**:
Fixes #1811 🤞

**Special notes for your reviewer**: Not yet tested

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Validation no longer assumes all subnets of a zone must be covered by a single VPC cidr
```
