### PR TITLE
[GEP-26] Cleanup usage of the deprecated `shoot.spec.dns.providers[].secretName`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following lists known compatibility issues of this extension controller with
 | AWS Extension | Gardener | Action | Notes |
 | ------------- | -------- | ------ | ----- |
 | `<= v1.15.0` | `> v1.10.0` | Please update the provider version to `> v1.15.0` or disable the feature gate `MountHostCADirectories` in the Gardenlet. | Applies if feature flag `MountHostCADirectories` in the Gardenlet is enabled. Shoots with CSI enabled (Kubernetes version >= 1.18) miss a mount to the directory `/etc/ssl` in the Shoot API Server. This can lead to not trusting external Root CAs when the API Server makes requests via webhooks or OIDC. |
-| `>= v1.70.0` | `< v1.135.0` | Please update Gardener to version `>= v1.135.0` | The shoot API field `shoot.spec.dns.providers[].secretName` has been deprecated in favor of `shoot.spec.dns.providers[].credentialsRef` which is available in Gardener `>= v1.135.0`, the provider extension is migrated to use the new field only in `v1.70.0`. |
+| `>= v1.71.0` | `< v1.135.0` | Please update Gardener to version `>= v1.135.0` | The shoot API field `shoot.spec.dns.providers[].secretName` has been deprecated in favor of `shoot.spec.dns.providers[].credentialsRef` which is available in Gardener `>= v1.135.0`, the provider extension is migrated to use the new field only in `v1.71.0`. |
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/
 The following lists known compatibility issues of this extension controller with other Gardener components.
 
 | AWS Extension | Gardener | Action | Notes |
-| ------------- | -------- | ------ |  --- |
-| `<= v1.15.0` | `>v1.10.0` | Please update the provider version to `> v1.15.0` or disable the feature gate `MountHostCADirectories` in the Gardenlet. | Applies if feature flag `MountHostCADirectories` in the Gardenlet is enabled. Shoots with CSI enabled (Kubernetes version >= 1.18) miss a mount to the directory `/etc/ssl` in the Shoot API Server. This can lead to not trusting external Root CAs when the API Server makes requests via webhooks or OIDC.  |
+| ------------- | -------- | ------ | ----- |
+| `<= v1.15.0` | `> v1.10.0` | Please update the provider version to `> v1.15.0` or disable the feature gate `MountHostCADirectories` in the Gardenlet. | Applies if feature flag `MountHostCADirectories` in the Gardenlet is enabled. Shoots with CSI enabled (Kubernetes version >= 1.18) miss a mount to the directory `/etc/ssl` in the Shoot API Server. This can lead to not trusting external Root CAs when the API Server makes requests via webhooks or OIDC. |
+| `>= v1.70.0` | `< v1.135.0` | Please update Gardener to version `>= v1.135.0` | The shoot API field `shoot.spec.dns.providers[].secretName` has been deprecated in favor of `shoot.spec.dns.providers[].credentialsRef` which is available in Gardener `>= v1.135.0`, the provider extension is migrated to use the new field only in `v1.70.0`. |
+
 ----
 
 ## How to start using or developing this extension controller locally

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following lists known compatibility issues of this extension controller with
 | AWS Extension | Gardener | Action | Notes |
 | ------------- | -------- | ------ | ----- |
 | `<= v1.15.0` | `> v1.10.0` | Please update the provider version to `> v1.15.0` or disable the feature gate `MountHostCADirectories` in the Gardenlet. | Applies if feature flag `MountHostCADirectories` in the Gardenlet is enabled. Shoots with CSI enabled (Kubernetes version >= 1.18) miss a mount to the directory `/etc/ssl` in the Shoot API Server. This can lead to not trusting external Root CAs when the API Server makes requests via webhooks or OIDC. |
-| `>= v1.71.0` | `< v1.135.0` | Please update Gardener to version `>= v1.135.0` | The shoot API field `shoot.spec.dns.providers[].secretName` has been deprecated in favor of `shoot.spec.dns.providers[].credentialsRef` which is available in Gardener `>= v1.135.0`, the provider extension is migrated to use the new field only in `v1.71.0`. |
+| `>= v1.71.0` | `< v1.135.0` | Please update Gardener to version `>= v1.135.0` | The shoot API field `shoot.spec.dns.providers[].secretName` has been deprecated in favor of `shoot.spec.dns.providers[].credentialsRef` which is available in Gardener `>= v1.135.0`, the provider extension is adapted to use the new field from `v1.71.0` version onward. |
 
 ----
 

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -243,12 +243,9 @@ func (s *shoot) validateDNS(ctx context.Context, shoot *core.Shoot) field.ErrorL
 
 		providerFldPath := dnsProvidersPath.Index(i)
 
-		// TODO(vpnachev): Enable this validation once the extension does not support github.com/gardener/gardener < v1.135.0
-		// if p.CredentialsRef == nil {
-		// 	allErrs = append(allErrs, field.Required(providerFldPath.Child("credentialsRef"), "must be set"))
-		// }
-
-		if p.CredentialsRef != nil {
+		if p.CredentialsRef == nil {
+			allErrs = append(allErrs, field.Required(providerFldPath.Child("credentialsRef"), "must be set"))
+		} else {
 			credentialsFldPath := providerFldPath.Child("credentialsRef")
 
 			credentials, err := kubernetes.GetCredentialsByCrossVersionObjectReference(ctx, s.apiReader, *p.CredentialsRef, shoot.GetNamespace())
@@ -272,29 +269,6 @@ func (s *shoot) validateDNS(ctx context.Context, shoot *core.Shoot) field.ErrorL
 				}
 			default:
 				allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), "supported credentials types are Secret and WorkloadIdentity"))
-			}
-		} else { // TODO(vpnachev): Remove the else block once the extension does not support github.com/gardener/gardener < v1.135.0
-			secretNameFldPath := providerFldPath.Child("secretName")
-			if p.SecretName == nil || *p.SecretName == "" {
-				allErrs = append(allErrs, field.Required(secretNameFldPath,
-					fmt.Sprintf("secretName must be specified for %v provider", aws.DNSType)))
-				continue
-			}
-
-			secret := &corev1.Secret{}
-			key := client.ObjectKey{Namespace: shoot.Namespace, Name: *p.SecretName}
-			if err := s.apiReader.Get(ctx, key, secret); err != nil {
-				if apierrors.IsNotFound(err) {
-					allErrs = append(allErrs, field.Invalid(secretNameFldPath,
-						*p.SecretName, "referenced secret not found"))
-				} else {
-					allErrs = append(allErrs, field.InternalError(secretNameFldPath, err))
-				}
-				continue
-			}
-
-			if err := ValidateSecret(secret, nil); err != nil {
-				allErrs = append(allErrs, field.Invalid(secretNameFldPath, p.SecretName, err.Error()))
 			}
 		}
 	}

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -612,122 +612,76 @@ var _ = Describe("Shoot validator", func() {
 		})
 
 		Context("Shoot with custom DNS provider", func() {
-			Context("secretName", func() {
-				It("should return error when aws-dns provider has no secretName", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					shoot.Spec.DNS = &core.DNS{
-						Providers: []core.DNSProvider{
-							{Type: ptr.To(aws.DNSType), Primary: ptr.To(true)}, // secretName missing
-						},
-					}
-
-					err := shootValidator.Validate(ctx, shoot, nil)
-					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("spec.dns.providers[0].secretName"),
-					}))))
-				})
-
-				It("should return error when aws-dns provider secret not found", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					shoot.Spec.DNS = &core.DNS{
-						Providers: []core.DNSProvider{
-							{Type: ptr.To(aws.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
-						},
-					}
-					reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-						&corev1.Secret{}).
-						Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "dns-secret"))
-
-					err := shootValidator.Validate(ctx, shoot, nil)
-					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("spec.dns.providers[0].secretName"),
-					}))))
-				})
-
-				It("should return error when aws-dns secret is invalid (missing secretAccessKey)", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					shoot.Spec.DNS = &core.DNS{
-						Providers: []core.DNSProvider{
-							{Type: ptr.To(aws.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
-						},
-					}
-					invalidSecret := &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
-						Data: map[string][]byte{
-							aws.DNSAccessKeyID: []byte("AKIAIOSFODNN7EXAMPLE"),
-						},
-					}
-					reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-						&corev1.Secret{}).
-						SetArg(2, *invalidSecret).
-						Return(nil)
-
-					err := shootValidator.Validate(ctx, shoot, nil)
-					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(field.ErrorTypeInvalid),
-						"Field":  Equal("spec.dns.providers[0].secretName"),
-						"Detail": Equal("secret.data[secretAccessKey]: Required value: missing required field \"secretAccessKey\" in secret garden-dev/dns-secret"),
-					}))))
-				})
-
-				It("should succeed with valid aws-dns provider secret", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					shoot.Spec.DNS = &core.DNS{
-						Providers: []core.DNSProvider{
-							{Type: ptr.To(aws.DNSType), SecretName: ptr.To("dns-secret"), Primary: ptr.To(true)},
-						},
-					}
-					validSecret := &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
-						Data: map[string][]byte{
-							aws.DNSAccessKeyID:     []byte("AKIAIOSFODNN7EXAMPLE"),
-							aws.DNSSecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"),
-						},
-					}
-					reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-						&corev1.Secret{}).
-						SetArg(2, *validSecret).
-						Return(nil)
-
-					err := shootValidator.Validate(ctx, shoot, nil)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
+			Context("primaryProvider", func() {
 				It("should skip validation for non-primary aws-dns provider", func() {
 					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
-							{Type: ptr.To(aws.DNSType), Primary: ptr.To(false), SecretName: ptr.To("dns-secret")},
+							{
+								Primary: ptr.To(false),
+								Type:    ptr.To(aws.DNSType),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "dns-secret",
+								},
+							},
 						},
 					}
 					// No reader.EXPECT() call - secret should not be fetched for non-primary provider
-
-					err := shootValidator.Validate(ctx, shoot, nil)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 				})
 
 				It("should skip validation for aws-dns provider with Primary=nil", func() {
 					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
-							{Type: ptr.To(aws.DNSType), Primary: nil, SecretName: ptr.To("dns-secret")},
+							{
+								Primary: nil,
+								Type:    ptr.To(aws.DNSType),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "dns-secret",
+								},
+							},
 						},
 					}
 					// No reader.EXPECT() call - secret should not be fetched when Primary is nil
-
-					err := shootValidator.Validate(ctx, shoot, nil)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 				})
 
 				It("should validate only primary provider when multiple aws-dns providers exist", func() {
 					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
-							{Type: ptr.To(aws.DNSType), Primary: ptr.To(false), SecretName: ptr.To("non-primary-secret")},
-							{Type: ptr.To(aws.DNSType), Primary: ptr.To(true), SecretName: ptr.To("primary-secret")},
-							{Type: ptr.To(aws.DNSType), Primary: ptr.To(false), SecretName: ptr.To("another-non-primary")},
+							{
+								Primary: ptr.To(false),
+								Type:    ptr.To(aws.DNSType),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "non-primary-secret",
+								},
+							},
+							{
+								Primary: ptr.To(true),
+								Type:    ptr.To(aws.DNSType),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "primary-secret",
+								},
+							},
+							{
+								Primary: ptr.To(false),
+								Type:    ptr.To(aws.DNSType),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "another-non-primary",
+								},
+							},
 						},
 					}
 					// Only the primary secret should be validated
@@ -743,17 +697,40 @@ var _ = Describe("Shoot validator", func() {
 						SetArg(2, *validSecret).
 						Return(nil)
 
-					err := shootValidator.Validate(ctx, shoot, nil)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 				})
 
 				It("should validate primary provider even when mixed with other provider types", func() {
 					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
-							{Type: ptr.To("cloudflare"), Primary: ptr.To(false), SecretName: ptr.To("cloudflare-secret")},
-							{Type: ptr.To(aws.DNSType), Primary: ptr.To(true), SecretName: ptr.To("aws-secret")},
-							{Type: ptr.To("google-clouddns"), Primary: ptr.To(false), SecretName: ptr.To("gcp-secret")},
+							{
+								Primary: ptr.To(false),
+								Type:    ptr.To("cloudflare"),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "cloudflare-secret",
+								},
+							},
+							{
+								Primary: ptr.To(true),
+								Type:    ptr.To(aws.DNSType),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "aws-secret",
+								},
+							},
+							{
+								Primary: ptr.To(false),
+								Type:    ptr.To("google-clouddns"),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "gcp-secret",
+								},
+							},
 						},
 					}
 					validSecret := &corev1.Secret{
@@ -768,16 +745,31 @@ var _ = Describe("Shoot validator", func() {
 						SetArg(2, *validSecret).
 						Return(nil)
 
-					err := shootValidator.Validate(ctx, shoot, nil)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 				})
 
 				It("should return error for invalid primary provider secret among multiple providers", func() {
 					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
-							{Type: ptr.To(aws.DNSType), Primary: ptr.To(false), SecretName: ptr.To("non-primary-secret")},
-							{Type: ptr.To(aws.DNSType), Primary: ptr.To(true), SecretName: ptr.To("primary-secret")},
+							{
+								Primary: ptr.To(false),
+								Type:    ptr.To(aws.DNSType),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "non-primary-secret",
+								},
+							},
+							{
+								Primary: ptr.To(true),
+								Type:    ptr.To(aws.DNSType),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "primary-secret",
+								},
+							},
 						},
 					}
 					invalidSecret := &corev1.Secret{
@@ -792,10 +784,9 @@ var _ = Describe("Shoot validator", func() {
 						SetArg(2, *invalidSecret).
 						Return(nil)
 
-					err := shootValidator.Validate(ctx, shoot, nil)
-					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
-						"Field":  Equal("spec.dns.providers[1].secretName"),
+						"Field":  Equal("spec.dns.providers[1].credentialsRef"),
 						"Detail": Equal("secret.data[secretAccessKey]: Required value: missing required field \"secretAccessKey\" in secret garden-dev/primary-secret"),
 					}))))
 				})
@@ -804,18 +795,48 @@ var _ = Describe("Shoot validator", func() {
 					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
-							{Type: ptr.To(aws.DNSType), Primary: ptr.To(false), SecretName: ptr.To("secret1")},
-							{Type: ptr.To(aws.DNSType), Primary: ptr.To(false), SecretName: ptr.To("secret2")},
+							{
+								Primary: ptr.To(false),
+								Type:    ptr.To(aws.DNSType),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "secret1",
+								},
+							},
+							{
+								Primary: ptr.To(false),
+								Type:    ptr.To(aws.DNSType),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "secret2",
+								},
+							},
 						},
 					}
 					// No reader.EXPECT() calls - no secrets should be validated
 
-					err := shootValidator.Validate(ctx, shoot, nil)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 				})
 			})
 
 			Context("credentialsRef", func() {
+				It("should return error when aws-dns provider has no credentialsRef", func() {
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{Type: ptr.To(aws.DNSType), Primary: ptr.To(true)}, // credentialsRef missing
+						},
+					}
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.dns.providers[0].credentialsRef"),
+					}))))
+				})
+
 				It("should return error when aws-dns provider Secret not found", func() {
 					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind cleanup
/label ipcei/workload-identity
/platform aws

**What this PR does / why we need it**:
Cleanup usage of the deprecated `shoot.spec.dns.providers[].secretName`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up on https://github.com/gardener/gardener-extension-provider-aws/pull/1730
Part of https://github.com/gardener/gardener/issues/9586

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
⚠️ This extension no longer support Gardener installation running with `github.com/gardener/gardener < v1.135.0`, kindly update `github.com/gardener/gardener` to version `>= v1.135.0` before updating the extension.
```

