### PR TITLE
[port] chore: configure dependabot to update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,10 @@ updates:
   labels:
   - area/compliance
   - kind/enhancement
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  labels:
+  - area/compliance
+  - kind/enhancement


### PR DESCRIPTION
Port of gardener/gardener-extension-provider-azure#1536 from azure.

## Changes

- Configure dependabot to update GitHub Actions dependencies on a weekly schedule

/area compliance
/kind enhancement