### PR TITLE
Add self-referencing egress rule for EFA-enabled worker pools

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -912,6 +912,10 @@ This expands to 33 NICs total: 1 primary `interface` on card 0 device 0, 1 `efa-
 
 For more details on EFA, see the [AWS EFA documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html). For instance-specific recommended NIC layouts, see [Maximize network bandwidth on EC2 instances with multiple network cards](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-acc-inst-types.html).
 
+### Security group
+
+When at least one worker pool has an EFA-enabled network interface (`type: efa` or `type: efa-only`), the infrastructure controller automatically adds a self-referencing egress rule (`protocol: -1`, source/destination = the worker security group itself) to the shoot's worker security group. This is required because EFA traffic uses the Scalable Reliable Datagram (SRD) protocol, which is not authorized by CIDR-based rules. AWS evaluates CIDR rules and security-group-id rules at different layers, and EFA traffic is only matched by the latter, even though the security group already allows `egress 0.0.0.0/0`. See AWS's [Get started with EFA, Step 1: Prepare an EFA-enabled security group](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-security) for details.
+
 
 ## Placement
 

--- a/pkg/apis/aws/helper/scheme.go
+++ b/pkg/apis/aws/helper/scheme.go
@@ -9,8 +9,10 @@ import (
 	"errors"
 	"fmt"
 
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/util"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -162,6 +164,32 @@ func HasFlowState(status extensionsv1alpha1.InfrastructureStatus) (bool, error) 
 		Version: apiv1alpha1.SchemeGroupVersion.Version,
 		Kind:    "InfrastructureState",
 	}, nil
+}
+
+// HasEFAWorkerPool returns true if any worker pool in the given list has at least one
+// network interface configured with type "efa" or "efa-only" in its provider config.
+// EFA-enabled worker pools require a self-referencing security group egress rule on the
+// shoot's worker security group, since EFA's SRD traffic is not authorized by CIDR-based
+// rules; see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-security.
+func HasEFAWorkerPool(workers []gardencorev1beta1.Worker) (bool, error) {
+	for _, worker := range workers {
+		if worker.ProviderConfig == nil || worker.ProviderConfig.Raw == nil {
+			continue
+		}
+		workerConfig := &api.WorkerConfig{}
+		if _, _, err := lenientDecoder.Decode(worker.ProviderConfig.Raw, nil, workerConfig); err != nil {
+			return false, fmt.Errorf("could not decode providerConfig of worker pool %q: %w", worker.Name, err)
+		}
+		for _, ni := range workerConfig.NetworkInterfaces {
+			if ni.Type == nil {
+				continue
+			}
+			if *ni.Type == string(ec2types.NetworkInterfaceTypeEfa) || *ni.Type == string(ec2types.NetworkInterfaceTypeEfaOnly) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 // InfrastructureStateFromRaw extracts the state from the Infrastructure. If no state was available, it returns a "zero" value InfrastructureState object.

--- a/pkg/apis/aws/helper/scheme_test.go
+++ b/pkg/apis/aws/helper/scheme_test.go
@@ -5,6 +5,8 @@
 package helper_test
 
 import (
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -107,6 +109,104 @@ roleARN: role-arn
 			config, err := helper.WorkloadIdentityConfigFromRaw(raw)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(config.RoleARN).To(Equal("role-arn"))
+		})
+	})
+
+	Describe("HasEFAWorkerPool", func() {
+		newWorker := func(name string, providerConfig string) gardencorev1beta1.Worker {
+			worker := gardencorev1beta1.Worker{Name: name}
+			if providerConfig != "" {
+				worker.ProviderConfig = &runtime.RawExtension{Raw: []byte(providerConfig)}
+			}
+			return worker
+		}
+
+		It("should return false for nil workers", func() {
+			has, err := helper.HasEFAWorkerPool(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(has).To(BeFalse())
+		})
+
+		It("should return false for workers without provider config", func() {
+			has, err := helper.HasEFAWorkerPool([]gardencorev1beta1.Worker{newWorker("pool-1", "")})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(has).To(BeFalse())
+		})
+
+		It("should return false for workers without networkInterfaces", func() {
+			has, err := helper.HasEFAWorkerPool([]gardencorev1beta1.Worker{
+				newWorker("pool-1", `apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
+kind: WorkerConfig
+`),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(has).To(BeFalse())
+		})
+
+		It("should return false for workers with non-EFA networkInterfaces only", func() {
+			has, err := helper.HasEFAWorkerPool([]gardencorev1beta1.Worker{
+				newWorker("pool-1", `apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
+kind: WorkerConfig
+networkInterfaces:
+- type: interface
+`),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(has).To(BeFalse())
+		})
+
+		It("should return true when at least one worker has an efa interface", func() {
+			has, err := helper.HasEFAWorkerPool([]gardencorev1beta1.Worker{
+				newWorker("pool-1", `apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
+kind: WorkerConfig
+networkInterfaces:
+- type: interface
+`),
+				newWorker("pool-2", `apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
+kind: WorkerConfig
+networkInterfaces:
+- type: efa
+`),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(has).To(BeTrue())
+		})
+
+		It("should return true when a worker has an efa-only interface", func() {
+			has, err := helper.HasEFAWorkerPool([]gardencorev1beta1.Worker{
+				newWorker("pool-1", `apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
+kind: WorkerConfig
+networkInterfaces:
+- type: interface
+- type: efa-only
+`),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(has).To(BeTrue())
+		})
+
+		It("should match the AWS SDK constants for efa types", func() {
+			Expect(string(ec2types.NetworkInterfaceTypeEfa)).To(Equal("efa"))
+			Expect(string(ec2types.NetworkInterfaceTypeEfaOnly)).To(Equal("efa-only"))
+		})
+
+		It("should ignore network interfaces with nil type", func() {
+			workerConfig := `apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
+kind: WorkerConfig
+networkInterfaces:
+- {}
+`
+			has, err := helper.HasEFAWorkerPool([]gardencorev1beta1.Worker{newWorker("pool-1", workerConfig)})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(has).To(BeFalse())
+		})
+
+		It("should return an error for invalid provider config", func() {
+			has, err := helper.HasEFAWorkerPool([]gardencorev1beta1.Worker{
+				newWorker("pool-1", `not yaml at all: [{`),
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(has).To(BeFalse())
 		})
 	})
 })

--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -142,6 +142,7 @@ type FlowContext struct {
 	updater       awsclient.Updater
 	commonTags    awsclient.Tags
 	networking    *v1beta1.Networking
+	hasEFAWorker  bool
 	*shared.BasicFlowContext
 }
 
@@ -157,6 +158,11 @@ func NewFlowContext(opts Opts) (*FlowContext, error) {
 		return nil, err
 	}
 
+	hasEFAWorker, err := helper.HasEFAWorkerPool(opts.Shoot.Spec.Provider.Workers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect EFA worker pools: %w", err)
+	}
+
 	flowContext := &FlowContext{
 		log:           opts.Log,
 		state:         whiteboard,
@@ -169,6 +175,7 @@ func NewFlowContext(opts Opts) (*FlowContext, error) {
 		runtimeClient: opts.RuntimeClient,
 		networking:    opts.Shoot.Spec.Networking,
 		shootUUID:     string(opts.Shoot.UID),
+		hasEFAWorker:  hasEFAWorker,
 	}
 	flowContext.commonTags = awsclient.Tags{
 		flowContext.tagKeyCluster(): TagValueCluster,

--- a/pkg/controller/infrastructure/infraflow/nodes_security_group_internal_test.go
+++ b/pkg/controller/infrastructure/infraflow/nodes_security_group_internal_test.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package infraflow
+
+import (
+	"testing"
+
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/onsi/gomega"
+
+	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
+)
+
+func TestComputeNodesSecurityGroupBaseRules(t *testing.T) {
+	containsSelfEgress := func(rules []*awsclient.SecurityGroupRule) bool {
+		for _, r := range rules {
+			if r.Type == awsclient.SecurityGroupRuleTypeEgress && r.Self && r.Protocol == "-1" {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("no EFA worker → no self-referencing egress rule", func(t *testing.T) {
+		g := NewWithT(t)
+		c := &FlowContext{
+			networking:   &v1beta1.Networking{IPFamilies: []v1beta1.IPFamily{v1beta1.IPFamilyIPv4}},
+			hasEFAWorker: false,
+		}
+		rules := c.computeNodesSecurityGroupBaseRules()
+
+		g.Expect(rules).To(HaveLen(4))
+		g.Expect(containsSelfEgress(rules)).To(BeFalse())
+	})
+
+	t.Run("EFA worker → self-referencing egress rule appended", func(t *testing.T) {
+		g := NewWithT(t)
+		c := &FlowContext{
+			networking:   &v1beta1.Networking{IPFamilies: []v1beta1.IPFamily{v1beta1.IPFamilyIPv4}},
+			hasEFAWorker: true,
+		}
+		rules := c.computeNodesSecurityGroupBaseRules()
+
+		g.Expect(rules).To(HaveLen(5))
+		g.Expect(containsSelfEgress(rules)).To(BeTrue())
+
+		// last rule should be the EFA self-ref egress rule
+		last := rules[len(rules)-1]
+		g.Expect(last.Type).To(Equal(awsclient.SecurityGroupRuleTypeEgress))
+		g.Expect(last.Protocol).To(Equal("-1"))
+		g.Expect(last.Self).To(BeTrue())
+		g.Expect(last.CidrBlocks).To(BeNil())
+		g.Expect(last.CidrBlocksv6).To(BeNil())
+	})
+
+	t.Run("base rules unchanged when EFA enabled", func(t *testing.T) {
+		g := NewWithT(t)
+		cNoEFA := &FlowContext{
+			networking:   &v1beta1.Networking{IPFamilies: []v1beta1.IPFamily{v1beta1.IPFamilyIPv4}},
+			hasEFAWorker: false,
+		}
+		cWithEFA := &FlowContext{
+			networking:   &v1beta1.Networking{IPFamilies: []v1beta1.IPFamily{v1beta1.IPFamilyIPv4}},
+			hasEFAWorker: true,
+		}
+
+		baseRules := cNoEFA.computeNodesSecurityGroupBaseRules()
+		efaRules := cWithEFA.computeNodesSecurityGroupBaseRules()
+
+		// the first 4 rules must match exactly
+		g.Expect(efaRules[:4]).To(Equal(baseRules))
+	})
+
+	t.Run("IPv6-only worker pool emits IPv6 CIDRs and still gets EFA rule", func(t *testing.T) {
+		g := NewWithT(t)
+		c := &FlowContext{
+			networking:   &v1beta1.Networking{IPFamilies: []v1beta1.IPFamily{v1beta1.IPFamilyIPv6}},
+			hasEFAWorker: true,
+		}
+		rules := c.computeNodesSecurityGroupBaseRules()
+
+		g.Expect(rules).To(HaveLen(5))
+		// the v4 0.0.0.0/0 egress rule (index 3) should have only v6 CIDRs
+		g.Expect(rules[3].Type).To(Equal(awsclient.SecurityGroupRuleTypeEgress))
+		g.Expect(rules[3].CidrBlocks).To(BeNil())
+		g.Expect(rules[3].CidrBlocksv6).To(Equal([]string{allIPv6}))
+		// the EFA rule has no CIDRs
+		g.Expect(rules[4].Self).To(BeTrue())
+		g.Expect(rules[4].CidrBlocks).To(BeNil())
+		g.Expect(rules[4].CidrBlocksv6).To(BeNil())
+	})
+}

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -536,6 +536,73 @@ func (c *FlowContext) ensureMainRouteTable(ctx context.Context) error {
 	return nil
 }
 
+// computeNodesSecurityGroupBaseRules returns the base set of security group rules
+// for the worker security group: self-referencing ingress, NodePort ingress (TCP/UDP),
+// 0.0.0.0/0 egress (and IPv6 equivalents where applicable), plus a self-referencing
+// egress rule when at least one worker pool has an EFA-enabled network interface.
+//
+// EFA traffic uses the SRD protocol and is not matched by CIDR-based rules (those only
+// apply at the IP layer). EFA-enabled worker pools therefore require a self-referencing
+// egress rule on the worker security group, in addition to the 0.0.0.0/0 egress rule.
+// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-security.
+func (c *FlowContext) computeNodesSecurityGroupBaseRules() []*awsclient.SecurityGroupRule {
+	ipv4 := containsIPv4(c.getIpFamilies())
+	ipv6 := ContainsIPv6(c.getIpFamilies())
+
+	cidrV4 := func() []string {
+		if ipv4 {
+			return []string{allIPv4}
+		}
+		return nil
+	}
+	cidrV6 := func() []string {
+		if ipv6 {
+			return []string{allIPv6}
+		}
+		return nil
+	}
+
+	rules := []*awsclient.SecurityGroupRule{
+		{
+			Type:     awsclient.SecurityGroupRuleTypeIngress,
+			Protocol: "-1",
+			Self:     true,
+		},
+		{
+			Type:         awsclient.SecurityGroupRuleTypeIngress,
+			FromPort:     ptr.To[int32](30000),
+			ToPort:       ptr.To[int32](32767),
+			Protocol:     "tcp",
+			CidrBlocks:   cidrV4(),
+			CidrBlocksv6: cidrV6(),
+		},
+		{
+			Type:         awsclient.SecurityGroupRuleTypeIngress,
+			FromPort:     ptr.To[int32](30000),
+			ToPort:       ptr.To[int32](32767),
+			Protocol:     "udp",
+			CidrBlocks:   cidrV4(),
+			CidrBlocksv6: cidrV6(),
+		},
+		{
+			Type:         awsclient.SecurityGroupRuleTypeEgress,
+			Protocol:     "-1",
+			CidrBlocks:   cidrV4(),
+			CidrBlocksv6: cidrV6(),
+		},
+	}
+
+	if c.hasEFAWorker {
+		rules = append(rules, &awsclient.SecurityGroupRule{
+			Type:     awsclient.SecurityGroupRuleTypeEgress,
+			Protocol: "-1",
+			Self:     true,
+		})
+	}
+
+	return rules
+}
+
 func (c *FlowContext) ensureNodesSecurityGroup(ctx context.Context) error {
 	log := LogFromContext(ctx)
 	groupName := fmt.Sprintf("%s-nodes", c.namespace)
@@ -545,65 +612,7 @@ func (c *FlowContext) ensureNodesSecurityGroup(ctx context.Context) error {
 		GroupName:   groupName,
 		VpcId:       c.state.Get(IdentifierVPC),
 		Description: ptr.To("Security group for nodes"),
-		Rules: []*awsclient.SecurityGroupRule{
-			{
-				Type:     awsclient.SecurityGroupRuleTypeIngress,
-				Protocol: "-1",
-				Self:     true,
-			},
-			{
-				Type:     awsclient.SecurityGroupRuleTypeIngress,
-				FromPort: ptr.To[int32](30000),
-				ToPort:   ptr.To[int32](32767),
-				Protocol: "tcp",
-				CidrBlocks: func() []string {
-					if containsIPv4(c.getIpFamilies()) {
-						return []string{allIPv4}
-					}
-					return nil
-				}(),
-				CidrBlocksv6: func() []string {
-					if ContainsIPv6(c.getIpFamilies()) {
-						return []string{allIPv6}
-					}
-					return nil
-				}(),
-			},
-			{
-				Type:     awsclient.SecurityGroupRuleTypeIngress,
-				FromPort: ptr.To[int32](30000),
-				ToPort:   ptr.To[int32](32767),
-				Protocol: "udp",
-				CidrBlocks: func() []string {
-					if containsIPv4(c.getIpFamilies()) {
-						return []string{allIPv4}
-					}
-					return nil
-				}(),
-				CidrBlocksv6: func() []string {
-					if ContainsIPv6(c.getIpFamilies()) {
-						return []string{allIPv6}
-					}
-					return nil
-				}(),
-			},
-			{
-				Type:     awsclient.SecurityGroupRuleTypeEgress,
-				Protocol: "-1",
-				CidrBlocks: func() []string {
-					if containsIPv4(c.getIpFamilies()) {
-						return []string{allIPv4}
-					}
-					return nil
-				}(),
-				CidrBlocksv6: func() []string {
-					if ContainsIPv6(c.getIpFamilies()) {
-						return []string{allIPv6}
-					}
-					return nil
-				}(),
-			},
-		},
+		Rules:       c.computeNodesSecurityGroupBaseRules(),
 	}
 
 	// TODO: @hebelsan - remove processedZones after migration of shoots with duplicated zone name entries


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/area security
/kind bug
/platform aws

**What this PR does / why we need it**:
The infrastructure controller now adds a self-referencing security group egress rule (`protocol: -1`, source/destination = the worker security group itself) to the shoot's worker security group whenever any worker pool has an EFA-enabled network interface (`networkInterfaces[].type` of `efa` or `efa-only`). More details at #1832 .

The rule is only added when at least one worker pool actually requests EFA, so non-AI/HPC shoots are unaffected.

**Which issue(s) this PR fixes**:
Fixes #1832 

**Special notes for your reviewer**:
Continuation (fix) for #1790 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The AWS infrastructure controller now adds a self-referencing security group egress rule to the worker security group when any worker pool has an EFA-enabled network interface (`networkInterfaces[].type: efa` or `efa-only`). This rule is required for EFA's SRD traffic, which is not covered by the existing `egress 0.0.0.0/0` rule.
```
