### PR TITLE
Broaden MAP to suppress aws-custom-route-controller NetworkUnavailable=true cold-start race

### DIFF
--- a/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/chart_test.go
+++ b/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/chart_test.go
@@ -1,0 +1,319 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package calicomutatingadmissionpolicy contains tests for the calico
+// MutatingAdmissionPolicy chart. The tests render the chart for each
+// supported apiVersion and assert behavioural properties of the produced
+// MutatingAdmissionPolicy: that it targets both the calico-node and the
+// aws-custom-route-controller service accounts, that it only intercepts
+// flips of NetworkUnavailable from False (or unset) to True, and that it
+// strips NetworkUnavailable from the new conditions while restoring it
+// from the old object.
+package calicomutatingadmissionpolicy_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	calicoNodeUser              = "system:serviceaccount:kube-system:calico-node"
+	awsCustomRouteControllerUser = "system:serviceaccount:kube-system:aws-custom-route-controller"
+)
+
+// renderCalicoMAPChart renders the chart's mutating-admission-policy.yaml for
+// the given values. It uses Go's text/template (which is the engine helm uses
+// under the hood) and intentionally does not pull in the helm engine for this
+// test, since the chart only references {{ .Values.enabled }} and
+// {{ .Values.apiVersion }} and uses no sprig helpers or chart partials.
+func renderCalicoMAPChart(t *testing.T, values map[string]interface{}) string {
+	t.Helper()
+
+	path := filepath.Join("templates", "mutating-admission-policy.yaml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read chart template: %v", err)
+	}
+
+	// helm's whitespace-trim syntax {{- ... -}} is identical to Go's
+	// text/template trim markers. The chart additionally uses sprig
+	// dictionary access via {{ .Values.foo }}, which is just standard
+	// Go template field access on a map.
+	tpl, err := template.New("map").Parse(string(raw))
+	if err != nil {
+		t.Fatalf("parse chart template: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tpl.Execute(&buf, map[string]interface{}{"Values": values}); err != nil {
+		t.Fatalf("execute chart template: %v", err)
+	}
+	return buf.String()
+}
+
+// parseDocs splits a multi-document YAML stream and decodes each non-empty
+// document into a generic map.
+func parseDocs(t *testing.T, in string) []map[string]interface{} {
+	t.Helper()
+	var out []map[string]interface{}
+	dec := yaml.NewDecoder(strings.NewReader(in))
+	for {
+		var doc map[string]interface{}
+		err := dec.Decode(&doc)
+		if err != nil {
+			break
+		}
+		if doc != nil {
+			out = append(out, doc)
+		}
+	}
+	return out
+}
+
+func TestCalicoMAPChart_DisabledRendersEmpty(t *testing.T) {
+	got := renderCalicoMAPChart(t, map[string]interface{}{"enabled": false, "apiVersion": "v1beta1"})
+	if strings.TrimSpace(got) != "" {
+		t.Fatalf("expected empty render when enabled=false, got:\n%s", got)
+	}
+}
+
+func TestCalicoMAPChart_RendersAPIVersion(t *testing.T) {
+	for _, apiVersion := range []string{"v1alpha1", "v1beta1", "v1"} {
+		t.Run(apiVersion, func(t *testing.T) {
+			out := renderCalicoMAPChart(t, map[string]interface{}{"enabled": true, "apiVersion": apiVersion})
+			docs := parseDocs(t, out)
+			if len(docs) != 2 {
+				t.Fatalf("expected 2 documents (binding + policy), got %d", len(docs))
+			}
+			for _, d := range docs {
+				gotAV, _ := d["apiVersion"].(string)
+				want := "admissionregistration.k8s.io/" + apiVersion
+				if gotAV != want {
+					t.Errorf("doc kind=%v apiVersion = %q, want %q", d["kind"], gotAV, want)
+				}
+			}
+		})
+	}
+}
+
+func TestCalicoMAPChart_PolicyAndBinding(t *testing.T) {
+	out := renderCalicoMAPChart(t, map[string]interface{}{"enabled": true, "apiVersion": "v1beta1"})
+	docs := parseDocs(t, out)
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 documents, got %d", len(docs))
+	}
+
+	var binding, policy map[string]interface{}
+	for _, d := range docs {
+		switch d["kind"] {
+		case "MutatingAdmissionPolicyBinding":
+			binding = d
+		case "MutatingAdmissionPolicy":
+			policy = d
+		}
+	}
+	if binding == nil {
+		t.Fatal("MutatingAdmissionPolicyBinding not rendered")
+	}
+	if policy == nil {
+		t.Fatal("MutatingAdmissionPolicy not rendered")
+	}
+
+	bindingPolicyName, _ := bindingSpec(binding)["policyName"].(string)
+	policyName, _ := metaName(policy)
+	if bindingPolicyName != policyName {
+		t.Errorf("binding.spec.policyName=%q does not match policy.metadata.name=%q", bindingPolicyName, policyName)
+	}
+}
+
+func TestCalicoMAPChart_MatchConditions_TargetBothServiceAccounts(t *testing.T) {
+	policy := getPolicy(t, "v1beta1")
+
+	mc := matchConditions(policy)
+	if len(mc) < 2 {
+		t.Fatalf("expected at least 2 matchConditions, got %d", len(mc))
+	}
+
+	// The first match condition selects the SAs whose writes we want to
+	// intercept. Both calico-node and aws-custom-route-controller must be
+	// covered: the prod-haas RCA (issues-live#9754) showed that the
+	// route controller is the dominant writer of NetworkUnavailable=True
+	// during overlay disablement, and the previously calico-only MAP let
+	// those writes through.
+	saExpr := matchExpression(mc[0])
+	for _, want := range []string{calicoNodeUser, awsCustomRouteControllerUser} {
+		if !strings.Contains(saExpr, want) {
+			t.Errorf("matchCondition[0].expression should reference %q, got:\n%s", want, saExpr)
+		}
+	}
+}
+
+func TestCalicoMAPChart_MatchConditions_OnlyInterceptFalseOrNilToTrueFlip(t *testing.T) {
+	policy := getPolicy(t, "v1beta1")
+	mc := matchConditions(policy)
+
+	// We must intercept *only* updates that try to flip NetworkUnavailable
+	// from False (or unset) to True. Steady-state =True heartbeats and
+	// any =False write must be allowed through, so that:
+	//   - the route controller can still mark a node ready after the VPC
+	//     route exists, and
+	//   - a node that is genuinely network-unavailable stays marked as such.
+	flipExpr := ""
+	for _, c := range mc {
+		expr := matchExpression(c)
+		if strings.Contains(expr, "object.status.conditions") &&
+			strings.Contains(expr, "NetworkUnavailable") {
+			flipExpr = expr
+		}
+	}
+	if flipExpr == "" {
+		t.Fatal("did not find a matchCondition referencing object.status.conditions / NetworkUnavailable")
+	}
+
+	// New object must have NetworkUnavailable=True.
+	if !strings.Contains(flipExpr, "c.status == 'True'") {
+		t.Errorf("flip matchCondition must require new NetworkUnavailable.status == 'True', got:\n%s", flipExpr)
+	}
+	// Old object must NOT already have NetworkUnavailable=True (otherwise
+	// the rule would suppress legitimate heartbeat refreshes on a node that
+	// is genuinely network-unavailable).
+	if !strings.Contains(flipExpr, "oldObject") {
+		t.Errorf("flip matchCondition must inspect oldObject to detect a real flip, got:\n%s", flipExpr)
+	}
+	if !strings.Contains(flipExpr, "!oldObject.status.conditions.exists") {
+		t.Errorf("flip matchCondition must require old NetworkUnavailable!=True, got:\n%s", flipExpr)
+	}
+}
+
+func TestCalicoMAPChart_StripsNetworkUnavailableAndRestoresFromOld(t *testing.T) {
+	policy := getPolicy(t, "v1beta1")
+
+	// The mutation must replace /status/conditions with finalConditions.
+	mut := mutations(policy)
+	if len(mut) == 0 {
+		t.Fatal("expected at least one mutation")
+	}
+	patchExpr := jsonPatchExpression(mut[0])
+	for _, want := range []string{`op: "replace"`, `path: "/status/conditions"`, "variables.finalConditions"} {
+		if !strings.Contains(patchExpr, want) {
+			t.Errorf("mutation jsonPatch.expression missing %q, got:\n%s", want, patchExpr)
+		}
+	}
+
+	// finalConditions must be conditionsWithoutNetworkUnavailable PLUS the
+	// old NetworkUnavailable condition (when there was one) — i.e. the old
+	// value of NetworkUnavailable is preserved while the rest of the new
+	// conditions land.
+	vars := variables(policy)
+	finalExpr := variableExpression(vars, "finalConditions")
+	if finalExpr == "" {
+		t.Fatal("variable finalConditions not found")
+	}
+	for _, want := range []string{
+		"variables.conditionsWithoutNetworkUnavailable",
+		"variables.oldNetworkUnavailableCondition",
+	} {
+		if !strings.Contains(finalExpr, want) {
+			t.Errorf("finalConditions expression missing %q, got:\n%s", want, finalExpr)
+		}
+	}
+
+	stripExpr := variableExpression(vars, "conditionsWithoutNetworkUnavailable")
+	if !strings.Contains(stripExpr, "c.type != 'NetworkUnavailable'") {
+		t.Errorf("conditionsWithoutNetworkUnavailable must filter out NetworkUnavailable, got:\n%s", stripExpr)
+	}
+}
+
+// helpers
+
+func getPolicy(t *testing.T, apiVersion string) map[string]interface{} {
+	t.Helper()
+	out := renderCalicoMAPChart(t, map[string]interface{}{"enabled": true, "apiVersion": apiVersion})
+	for _, d := range parseDocs(t, out) {
+		if d["kind"] == "MutatingAdmissionPolicy" {
+			return d
+		}
+	}
+	t.Fatal("MutatingAdmissionPolicy not found in rendered chart")
+	return nil
+}
+
+func metaName(d map[string]interface{}) (string, bool) {
+	m, ok := d["metadata"].(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+	n, ok := m["name"].(string)
+	return n, ok
+}
+
+func bindingSpec(d map[string]interface{}) map[string]interface{} {
+	if s, ok := d["spec"].(map[string]interface{}); ok {
+		return s
+	}
+	return nil
+}
+
+func matchConditions(policy map[string]interface{}) []map[string]interface{} {
+	spec, _ := policy["spec"].(map[string]interface{})
+	raw, _ := spec["matchConditions"].([]interface{})
+	out := make([]map[string]interface{}, 0, len(raw))
+	for _, c := range raw {
+		if m, ok := c.(map[string]interface{}); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func matchExpression(c map[string]interface{}) string {
+	s, _ := c["expression"].(string)
+	return s
+}
+
+func variables(policy map[string]interface{}) []map[string]interface{} {
+	spec, _ := policy["spec"].(map[string]interface{})
+	raw, _ := spec["variables"].([]interface{})
+	out := make([]map[string]interface{}, 0, len(raw))
+	for _, c := range raw {
+		if m, ok := c.(map[string]interface{}); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func variableExpression(vars []map[string]interface{}, name string) string {
+	for _, v := range vars {
+		if n, _ := v["name"].(string); n == name {
+			s, _ := v["expression"].(string)
+			return s
+		}
+	}
+	return ""
+}
+
+func mutations(policy map[string]interface{}) []map[string]interface{} {
+	spec, _ := policy["spec"].(map[string]interface{})
+	raw, _ := spec["mutations"].([]interface{})
+	out := make([]map[string]interface{}, 0, len(raw))
+	for _, c := range raw {
+		if m, ok := c.(map[string]interface{}); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func jsonPatchExpression(m map[string]interface{}) string {
+	jp, _ := m["jsonPatch"].(map[string]interface{})
+	s, _ := jp["expression"].(string)
+	return s
+}

--- a/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/templates/mutating-admission-policy.yaml
+++ b/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/templates/mutating-admission-policy.yaml
@@ -7,9 +7,23 @@ metadata:
 spec:
   policyName: block-calico-network-unavailable
 ---
-# MutatingAdmissionPolicy to block Calico from setting the NetworkUnavailable condition on nodes.
-# This policy intercepts node/status updates from the calico-node service account and removes
-# any changes to the NetworkUnavailable condition, effectively preserving the existing condition.
+# MutatingAdmissionPolicy to prevent calico-node and aws-custom-route-controller
+# from flipping the NetworkUnavailable condition on nodes from False (or unset)
+# to True. Updates that keep NetworkUnavailable=True (heartbeat refreshes on a
+# genuinely network-unavailable node) and updates that set NetworkUnavailable=
+# False pass through unchanged.
+#
+# Rationale: during overlay disablement on a long-running cluster, the
+# aws-custom-route-controller restarts with an empty in-memory route cache and
+# patches every node it has not yet observed a VPC route for to
+# NetworkUnavailable=True, even though the routes already exist. This caused a
+# ~5 minute outage on a large shoot. By blocking only False/unset -> True
+# flips, we suppress the cold-start race while still preserving the route
+# controller's authority to keep a genuinely-broken node marked unavailable.
+#
+# TODO: long-term this should be replaced by a migration-phase-scoped policy
+# that is only deployed while the calico DS is being rolled, rather than
+# permanently active. See https://github.tools.sap/kubernetes-live/issues-live/issues/9754.
 apiVersion: admissionregistration.k8s.io/{{ .Values.apiVersion }}
 kind: MutatingAdmissionPolicy
 metadata:
@@ -24,14 +38,30 @@ spec:
       operations: ["UPDATE"]
       resources: ["nodes/status"]
   matchConditions:
-  # Only apply to requests from the calico-node service account
-  - name: is-calico-node
+  # Only apply to requests from the calico-node service account or the
+  # aws-custom-route-controller, which writes NetworkUnavailable=true on
+  # every node it has not yet observed a VPC route for during overlay
+  # disablement. NetworkUnavailable=false writes from these accounts are
+  # still allowed through (see the next match condition).
+  - name: is-calico-node-or-aws-custom-route-controller
     expression: >-
-      request.userInfo.username == "system:serviceaccount:kube-system:calico-node"
-  # Only apply if calico is trying to set/modify NetworkUnavailable condition
-  - name: has-network-unavailable-in-request
+      request.userInfo.username == "system:serviceaccount:kube-system:calico-node" ||
+      request.userInfo.username == "system:serviceaccount:kube-system:aws-custom-route-controller"
+  # Only intercept attempts to FLIP NetworkUnavailable from False (or unset)
+  # to True. This catches the cold-start race during overlay disablement
+  # without permanently silencing the route controller's authority over the
+  # condition: a node that is already correctly marked NetworkUnavailable=True
+  # stays that way (heartbeat refreshes pass through), and =False writes
+  # always pass through.
+  - name: flipping-networkunavailable-false-or-nil-to-true
     expression: >-
-      object.status.conditions.exists(c, c.type == 'NetworkUnavailable')
+      object.status.conditions.exists(c,
+        c.type == 'NetworkUnavailable' && c.status == 'True') &&
+      (
+        !has(oldObject.status) || !has(oldObject.status.conditions) ||
+        !oldObject.status.conditions.exists(c,
+          c.type == 'NetworkUnavailable' && c.status == 'True')
+      )
   variables:
   # Extract the current NetworkUnavailable condition from the old object (may be empty for new nodes)
   - name: oldNetworkUnavailableCondition


### PR DESCRIPTION
## Why

When the overlay is disabled on a long-running shoot, [`aws-custom-route-controller`](https://github.com/gardener/aws-custom-route-controller) restarts with an empty in-memory route cache and patches every node it has not yet observed a VPC route for to `NetworkUnavailable=True`, even though the routes already exist. On a recent migration of a large prod shoot this caused **~5 minutes of user-visible downtime** even though the calico-scoped MutatingAdmissionPolicy was deployed and active — the MAP had no `matchCondition` for the route controller's ServiceAccount, so its 183 cold-start patches went straight through admission.

Detailed RCA: https://github.tools.sap/kubernetes-live/issues-live/issues/9754

## What

Broaden `block-calico-network-unavailable` to also intercept node/status writes from `system:serviceaccount:kube-system:aws-custom-route-controller`, but only when the request tries to **flip** `NetworkUnavailable` from `False` (or unset) to `True`.

This narrowly catches the cold-start race during overlay disablement without permanently silencing the route controller's authority over the condition:

- heartbeat refreshes that keep `NetworkUnavailable=True` on a genuinely broken node pass through unchanged
- `=False` writes always pass through, so nodes can still be marked network-ready once routes are in place
- `False`/unset → `True` flips from calico-node or aws-custom-route-controller are stripped (the condition is restored to its previous value)

## Tests

`charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/chart_test.go` renders the chart and asserts:

- `enabled=false` produces no manifest
- `apiVersion` value flows into both `MutatingAdmissionPolicy` and `MutatingAdmissionPolicyBinding` for `v1alpha1`, `v1beta1`, `v1`
- Binding's `policyName` matches policy's `metadata.name`
- The first `matchCondition` references both `calico-node` and `aws-custom-route-controller` SAs
- The flip `matchCondition` requires the new condition to be `=True` AND the old condition to NOT already be `=True` (so heartbeat refreshes pass through)
- The mutation replaces `/status/conditions` with `finalConditions = conditionsWithoutNetworkUnavailable + oldNetworkUnavailableCondition`

A negative-test verification (reverting the chart to the old single-SA form) confirms the SA-coverage assertion correctly fails on regression.

## Caveats / future work

- The MAP is permanently active once deployed, not scoped to the migration window. Long-term the right shape is for the AWS provider extension to deploy the MAP only while overlay disablement is in flight, and remove it after. A `TODO` in the chart points at this.
- A new node legitimately starts with no route in AWS yet — the route controller will try to set `NetworkUnavailable=True`, the MAP will block it. That signal is lost during the brief new-node-bring-up window. Trade accepted: the alternative (5-min outage for every overlay disablement) is much worse.

## Test plan

- [ ] Existing unit tests continue to pass.
- [ ] On a test shoot with overlay enabled, set `MutatingAdmissionPolicy=true` + `runtimeConfig admissionregistration.k8s.io/v1beta1=true`, then disable overlay. Confirm the MAP is created and that the rolling calico DS restart does **not** see mass `NetworkUnavailable=true` flips on nodes.
- [ ] Confirm `aws-custom-route-controller` can still flip a node from `=True` to `=False` after creating its VPC route (i.e., recovery still works).
- [ ] Confirm a new node added during steady state still becomes Ready (its `=True` from the route controller is suppressed; the route controller's subsequent `=False` lands and the node is healthy).
