### PR TITLE
Restrict MutatingAdmissionPolicy to v1alpha1 for K8s < 1.34

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -997,7 +997,8 @@ func isMutatingAdmissionPolicyEnabled(cluster *extensionscontroller.Cluster) boo
 		return rc["admissionregistration.k8s.io/v1beta1"]
 	}
 
-	return rc["admissionregistration.k8s.io/v1alpha1"] || rc["admissionregistration.k8s.io/v1beta1"]
+	// For K8s < 1.34, MutatingAdmissionPolicy is only available via v1alpha1.
+	return rc["admissionregistration.k8s.io/v1alpha1"]
 }
 
 func mutatingAdmissionPolicyAPIVersion(cluster *extensionscontroller.Cluster) string {
@@ -1013,13 +1014,6 @@ func mutatingAdmissionPolicyAPIVersion(cluster *extensionscontroller.Cluster) st
 
 	// For K8s >= 1.34, MutatingAdmissionPolicy is beta
 	if versionutils.ConstraintK8sGreaterEqual134.Check(k8sVersion) {
-		return "v1beta1"
-	}
-
-	// For older versions, prefer v1beta1 over v1alpha1 when explicitly enabled
-	if cluster.Shoot.Spec.Kubernetes.KubeAPIServer != nil &&
-		cluster.Shoot.Spec.Kubernetes.KubeAPIServer.RuntimeConfig != nil &&
-		cluster.Shoot.Spec.Kubernetes.KubeAPIServer.RuntimeConfig["admissionregistration.k8s.io/v1beta1"] {
 		return "v1beta1"
 	}
 

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -796,17 +796,17 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
 		})
 
-		It("should return true if feature gate is enabled and v1beta1 is in RuntimeConfig", func() {
+		It("should return false for K8s < 1.34 if feature gate is enabled and only v1beta1 is in RuntimeConfig", func() {
 			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
 				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
 					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
 				},
 				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1beta1": true},
 			}
-			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
 		})
 
-		It("should return true if feature gate is enabled and both v1alpha1 and v1beta1 are in RuntimeConfig", func() {
+		It("should return true for K8s < 1.34 if feature gate is enabled and both v1alpha1 and v1beta1 are in RuntimeConfig", func() {
 			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
 				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
 					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
@@ -939,21 +939,21 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1alpha1"))
 		})
 
-		It("should return v1beta1 if v1beta1 is in RuntimeConfig (< 1.34)", func() {
+		It("should return v1alpha1 if v1beta1 is in RuntimeConfig (< 1.34, v1beta1 not supported)", func() {
 			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
 				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1beta1": true},
 			}
-			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1beta1"))
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1alpha1"))
 		})
 
-		It("should return v1beta1 if both v1alpha1 and v1beta1 are in RuntimeConfig (< 1.34)", func() {
+		It("should return v1alpha1 if both v1alpha1 and v1beta1 are in RuntimeConfig (< 1.34)", func() {
 			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
 				RuntimeConfig: map[string]bool{
 					"admissionregistration.k8s.io/v1alpha1": true,
 					"admissionregistration.k8s.io/v1beta1":  true,
 				},
 			}
-			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1beta1"))
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1alpha1"))
 		})
 
 		It("should return v1alpha1 if v1beta1 is explicitly disabled in RuntimeConfig (< 1.34)", func() {


### PR DESCRIPTION
## Summary
- For Kubernetes versions below 1.34, `MutatingAdmissionPolicy` is only served via `admissionregistration.k8s.io/v1alpha1`.
- `isMutatingAdmissionPolicyEnabled` no longer treats `v1beta1` in the runtime config as enabling the feature on pre-1.34 clusters.
- `mutatingAdmissionPolicyAPIVersion` always returns `v1alpha1` for pre-1.34 clusters, even when `v1beta1` is set in the runtime config.
- Tests updated to reflect the corrected behavior.

## Test plan
- [x] `go test ./pkg/controller/controlplane/...`