### PR TITLE
fix: ValidateWorkersAgainstCloudProfileOnUpdate uses new worker architecture

### DIFF
--- a/pkg/apis/aws/validation/worker.go
+++ b/pkg/apis/aws/validation/worker.go
@@ -215,11 +215,11 @@ func ValidateWorkersAgainstCloudProfileOnUpdate(
 		if w.Name == "" || newWorker.Machine.Image != w.Machine.Image {
 			machineType := gardencorev1beta1helper.FindMachineTypeByName(machineTypes, newWorker.Machine.Type)
 			if machineType == nil {
-				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("machine", "type"), w.Machine.Type, " not found in cloud profile"))
+				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("machine", "type"), newWorker.Machine.Type, " not found in cloud profile"))
 				continue
 			}
 			// Normalize machine type capabilities to include architecture
-			machineTypeCapabilities := apisawshelper.NormalizeMachineTypeCapabilities(machineType.Capabilities, w.Machine.Architecture, normalizedCapabilityDefinitions)
+			machineTypeCapabilities := apisawshelper.NormalizeMachineTypeCapabilities(machineType.Capabilities, newWorker.Machine.Architecture, normalizedCapabilityDefinitions)
 
 			allErrs = append(allErrs, validateWorkerConfigAgainstCloudProfile(newWorker, region, awsCloudProfile, machineTypeCapabilities, normalizedCapabilityDefinitions, fldPath.Index(i))...)
 		}

--- a/pkg/apis/aws/validation/worker_test.go
+++ b/pkg/apis/aws/validation/worker_test.go
@@ -10,6 +10,8 @@ import (
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -715,5 +717,79 @@ var _ = Describe("ValidateWorkerConfig", func() {
 				Expect(validate(wc)).To(BeEmpty())
 			})
 		})
+	})
+})
+
+var _ = Describe("#ValidateWorkersAgainstCloudProfileOnUpdate", func() {
+	const (
+		imageName    = "my-os"
+		imageVersion = "1.1.1"
+		region       = "some-region"
+		armMachine   = "arm-large"
+	)
+
+	// use arm64 machineType to ensure the image is not selected by defaulted architecture
+	machineTypes := []v1beta1.MachineType{{
+		Name:         armMachine,
+		Architecture: ptr.To(v1beta1constants.ArchitectureARM64),
+	}}
+
+	armWorker := func(name, version string) core.Worker {
+		return core.Worker{
+			Name: name,
+			Machine: core.Machine{
+				Type:         armMachine,
+				Architecture: ptr.To(v1beta1constants.ArchitectureARM64),
+				Image:        &core.ShootMachineImage{Name: imageName, Version: version},
+			},
+		}
+	}
+
+	cloudProfileWithAMI := func(arch string) *apisaws.CloudProfileConfig {
+		return &apisaws.CloudProfileConfig{
+			MachineImages: []apisaws.MachineImages{{
+				Name: imageName,
+				Versions: []apisaws.MachineImageVersion{{
+					Version: imageVersion,
+					Regions: []apisaws.RegionAMIMapping{
+						{Name: region, AMI: "ami-test", Architecture: ptr.To(arch)},
+					},
+				}},
+			}},
+		}
+	}
+
+	It("should accept a newly added arm64 worker that references an arm64-only image", func() {
+		errList := ValidateWorkersAgainstCloudProfileOnUpdate(
+			nil,
+			[]core.Worker{armWorker("new-arm", imageVersion)},
+			region,
+			cloudProfileWithAMI(v1beta1constants.ArchitectureARM64),
+			machineTypes,
+			nil,
+			field.NewPath("spec", "provider", "workers"),
+		)
+		Expect(errList).To(BeEmpty())
+	})
+
+	It("should reject a worker whose image is changed to one not supporting its architecture", func() {
+		oldWorkers := []core.Worker{armWorker("w0", "old-version")}
+		newWorkers := []core.Worker{armWorker("w0", imageVersion)}
+
+		errList := ValidateWorkersAgainstCloudProfileOnUpdate(
+			oldWorkers,
+			newWorkers,
+			region,
+			cloudProfileWithAMI(v1beta1constants.ArchitectureAMD64),
+			machineTypes,
+			nil,
+			field.NewPath("spec", "provider", "workers"),
+		)
+		Expect(errList).To(ConsistOf(
+			PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("spec.provider.workers[0].machine.image"),
+			})),
+		))
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**

/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:

Fixes a regression in the admission validator's update path. When adding a new worker to an existing shoot, `ValidateWorkersAgainstCloudProfileOnUpdate` passed the *old* worker's `Machine.Architecture` to `NormalizeMachineTypeCapabilities`. For a brand-new worker the old worker is the zero value, so the architecture was `nil` and silently defaulted to `amd64` — causing arm64 workers referencing arm64-only image flavors to be rejected with `could not determine best flavor: no compatible flavor found`. The fix uses the new worker's architecture, matching the already-correct `OnCreation` path. Adds a regression test plus a counter-case that confirms genuine architecture/image mismatches are still rejected.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Regression introduced in #1645 ([GEP-33] Allow mixed format Capability CloudProfiles). Only the update path was affected; new-shoot creation was already correct.

**Release note**:
```bugfix operator
Fix admission validator rejecting new arm64 worker pools added to existing shoots when the CloudProfile defines no `capabilityDefinitions`.
```
