### PR TITLE
Migrate mock client usages to fakeclient in tests

### DIFF
--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -7,20 +7,19 @@ package validator_test
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/security"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/admission/validator"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
@@ -34,28 +33,23 @@ var _ = Describe("CredentialsBinding validator", func() {
 		)
 
 		var (
-			credentialsBindingValidator extensionswebhook.Validator
-
-			ctrl      *gomock.Controller
-			mgr       *testutils.FakeManager
-			apiReader *mockclient.MockReader
+			mgr *testutils.FakeManager
 
 			ctx                                = context.TODO()
 			credentialsBindingSecret           *security.CredentialsBinding
 			credentialsBindingInternalSecret   *security.CredentialsBinding
 			credentialsBindingWorkloadIdentity *security.CredentialsBinding
 
-			fakeErr = fmt.Errorf("fake err")
+			scheme = func() *runtime.Scheme {
+				s := runtime.NewScheme()
+				Expect(corev1.AddToScheme(s)).To(Succeed())
+				Expect(gardencorev1beta1.AddToScheme(s)).To(Succeed())
+				Expect(securityv1alpha1.AddToScheme(s)).To(Succeed())
+				return s
+			}()
 		)
 
 		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-
-			apiReader = mockclient.NewMockReader(ctrl)
-			mgr = &testutils.FakeManager{APIReader: apiReader}
-
-			credentialsBindingValidator = validator.NewCredentialsBindingValidator(mgr)
-
 			credentialsBindingSecret = &security.CredentialsBinding{
 				CredentialsRef: corev1.ObjectReference{
 					Name:       name,
@@ -82,186 +76,174 @@ var _ = Describe("CredentialsBinding validator", func() {
 			}
 		})
 
-		AfterEach(func() {
-			ctrl.Finish()
-		})
+		newValidator := func(objects ...client.Object) extensionswebhook.Validator {
+			b := fakeclient.NewClientBuilder().WithScheme(scheme)
+			if len(objects) > 0 {
+				b = b.WithObjects(objects...)
+			}
+			apiReader := b.Build()
+			mgr = &testutils.FakeManager{APIReader: apiReader}
+			return validator.NewCredentialsBindingValidator(mgr)
+		}
 
 		It("should return err when obj is not a CredentialsBinding", func() {
-			err := credentialsBindingValidator.Validate(ctx, &corev1.Secret{}, nil)
+			v := newValidator()
+			err := v.Validate(ctx, &corev1.Secret{}, nil)
 			Expect(err).To(MatchError("wrong object type *v1.Secret"))
 		})
 
 		It("should return err when oldObj is not a CredentialsBinding", func() {
-			err := credentialsBindingValidator.Validate(ctx, &security.CredentialsBinding{}, &corev1.Secret{})
+			v := newValidator()
+			err := v.Validate(ctx, &security.CredentialsBinding{}, &corev1.Secret{})
 			Expect(err).To(MatchError("wrong object type *v1.Secret for old object"))
 		})
 
 		It("should return err if the CredentialsBinding references unknown credentials type", func() {
+			v := newValidator()
 			credentialsBindingSecret.CredentialsRef.APIVersion = "unknown"
-			err := credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, nil)
+			err := v.Validate(ctx, credentialsBindingSecret, nil)
 			Expect(err).To(MatchError(errors.New(`unsupported credentials reference: version "unknown", kind "Secret"`)))
 		})
 
 		It("should return err if it fails to get the corresponding Secret", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
-
-			err := credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, nil)
-			Expect(err).To(MatchError(fakeErr))
+			v := newValidator() // no secret pre-loaded
+			err := v.Validate(ctx, credentialsBindingSecret, nil)
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return err when the corresponding Secret is not valid", func() {
-			secret := &corev1.Secret{Data: map[string][]byte{
-				aws.AccessKeyID:     []byte("AKIAIOSFODNN7EXAMPL_"),                     // 20 chars but has underscore
-				aws.SecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"), // exactly 40 chars, base64
-			}}
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				SetArg(2, *secret)
-
-			err := credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, nil)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data: map[string][]byte{
+					aws.AccessKeyID:     []byte("AKIAIOSFODNN7EXAMPL_"),                     // 20 chars but has underscore
+					aws.SecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"), // exactly 40 chars, base64
+				},
+			}
+			v := newValidator(secret)
+			err := v.Validate(ctx, credentialsBindingSecret, nil)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return nil when the corresponding Secret is valid", func() {
-			secret := &corev1.Secret{Data: map[string][]byte{
-				aws.AccessKeyID:     []byte("AKIAIOSFODNN7EXAMPLE"),                     // exactly 20 chars, uppercase alphanumeric
-				aws.SecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"), // exactly 40 chars, base64
-			}}
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				SetArg(2, *secret)
-
-			err := credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, nil)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data: map[string][]byte{
+					aws.AccessKeyID:     []byte("AKIAIOSFODNN7EXAMPLE"),                     // exactly 20 chars, uppercase alphanumeric
+					aws.SecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"), // exactly 40 chars, base64
+				},
+			}
+			v := newValidator(secret)
+			err := v.Validate(ctx, credentialsBindingSecret, nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should return nil when the CredentialsBinding did not change", func() {
+			v := newValidator()
 			old := credentialsBindingSecret.DeepCopy()
-
-			Expect(credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, old)).To(Succeed())
+			Expect(v.Validate(ctx, credentialsBindingSecret, old)).To(Succeed())
 		})
 
 		It("should return err if it fails to get the corresponding InternalSecret", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).Return(fakeErr)
-
-			err := credentialsBindingValidator.Validate(ctx, credentialsBindingInternalSecret, nil)
-			Expect(err).To(MatchError(fakeErr))
+			v := newValidator() // no InternalSecret pre-loaded
+			err := v.Validate(ctx, credentialsBindingInternalSecret, nil)
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return err when the corresponding InternalSecret is not valid", func() {
-			internalSecret := &gardencorev1beta1.InternalSecret{Data: map[string][]byte{
-				aws.AccessKeyID:     []byte("AKIAIOSFODNN7EXAMPL_"),                     // 20 chars but has underscore
-				aws.SecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"), // exactly 40 chars, base64
-			}}
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).
-				SetArg(2, *internalSecret)
-
-			err := credentialsBindingValidator.Validate(ctx, credentialsBindingInternalSecret, nil)
+			internalSecret := &gardencorev1beta1.InternalSecret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data: map[string][]byte{
+					aws.AccessKeyID:     []byte("AKIAIOSFODNN7EXAMPL_"),                     // 20 chars but has underscore
+					aws.SecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"), // exactly 40 chars, base64
+				},
+			}
+			v := newValidator(internalSecret)
+			err := v.Validate(ctx, credentialsBindingInternalSecret, nil)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return nil when the corresponding InternalSecret is valid", func() {
-			internalSecret := &gardencorev1beta1.InternalSecret{Data: map[string][]byte{
-				aws.AccessKeyID:     []byte("AKIAIOSFODNN7EXAMPLE"),                     // exactly 20 chars, uppercase alphanumeric
-				aws.SecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"), // exactly 40 chars, base64
-			}}
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).
-				SetArg(2, *internalSecret)
-
-			err := credentialsBindingValidator.Validate(ctx, credentialsBindingInternalSecret, nil)
+			internalSecret := &gardencorev1beta1.InternalSecret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data: map[string][]byte{
+					aws.AccessKeyID:     []byte("AKIAIOSFODNN7EXAMPLE"),                     // exactly 20 chars, uppercase alphanumeric
+					aws.SecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"), // exactly 40 chars, base64
+				},
+			}
+			v := newValidator(internalSecret)
+			err := v.Validate(ctx, credentialsBindingInternalSecret, nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should succeed when the corresponding WorkloadIdentity is valid", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-					workloadIdentity := &securityv1alpha1.WorkloadIdentity{
-						Spec: securityv1alpha1.WorkloadIdentitySpec{
-							Audiences: []string{"foo"},
-							TargetSystem: securityv1alpha1.TargetSystem{
-								Type: "aws",
-								ProviderConfig: &runtime.RawExtension{
-									Raw: []byte(`
-apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-roleARN: "foo"
-`),
-								},
-							},
+			workloadIdentity := &securityv1alpha1.WorkloadIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: securityv1alpha1.WorkloadIdentitySpec{
+					Audiences: []string{"foo"},
+					TargetSystem: securityv1alpha1.TargetSystem{
+						Type: "aws",
+						ProviderConfig: &runtime.RawExtension{
+							Raw: []byte(`{"apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1","kind":"WorkloadIdentityConfig","roleARN":"foo"}`),
 						},
-					}
-					*obj = *workloadIdentity
-					return nil
-				})
-
-			Expect(credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)).To(Succeed())
+					},
+				},
+			}
+			v := newValidator(workloadIdentity)
+			Expect(v.Validate(ctx, credentialsBindingWorkloadIdentity, nil)).To(Succeed())
 		})
 
 		It("should return err if it fails to get the corresponding WorkloadIdentity", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).Return(fakeErr)
-
-			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
-			Expect(err).To(MatchError(fakeErr))
+			v := newValidator() // no WorkloadIdentity pre-loaded
+			err := v.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return err when the corresponding WorkloadIdentity is missing config for target system", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-					workloadIdentity := &securityv1alpha1.WorkloadIdentity{
-						Spec: securityv1alpha1.WorkloadIdentitySpec{
-							Audiences: []string{"foo"},
-							TargetSystem: securityv1alpha1.TargetSystem{
-								Type: "aws",
-							},
-						},
-					}
-					*obj = *workloadIdentity
-					return nil
-				})
-
-			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
+			workloadIdentity := &securityv1alpha1.WorkloadIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: securityv1alpha1.WorkloadIdentitySpec{
+					Audiences: []string{"foo"},
+					TargetSystem: securityv1alpha1.TargetSystem{
+						Type: "aws",
+					},
+				},
+			}
+			v := newValidator(workloadIdentity)
+			err := v.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
 			Expect(err).To(MatchError("the target system is missing configuration"))
 		})
 
 		It("should return err when the corresponding WorkloadIdentity has empty config for target system", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-					workloadIdentity := &securityv1alpha1.WorkloadIdentity{
-						Spec: securityv1alpha1.WorkloadIdentitySpec{
-							Audiences: []string{"foo"},
-							TargetSystem: securityv1alpha1.TargetSystem{
-								Type:           "aws",
-								ProviderConfig: &runtime.RawExtension{},
-							},
-						},
-					}
-					*obj = *workloadIdentity
-					return nil
-				})
-
-			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
+			workloadIdentity := &securityv1alpha1.WorkloadIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: securityv1alpha1.WorkloadIdentitySpec{
+					Audiences: []string{"foo"},
+					TargetSystem: securityv1alpha1.TargetSystem{
+						Type:           "aws",
+						ProviderConfig: &runtime.RawExtension{Raw: []byte("{}")},
+					},
+				},
+			}
+			v := newValidator(workloadIdentity)
+			err := v.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
 			Expect(err.Error()).To(ContainSubstring("target system's configuration is not valid"))
 		})
 
 		It("should return err when the corresponding WorkloadIdentity has invalid target system configuration", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-					workloadIdentity := &securityv1alpha1.WorkloadIdentity{
-						Spec: securityv1alpha1.WorkloadIdentitySpec{
-							Audiences: []string{"foo"},
-							TargetSystem: securityv1alpha1.TargetSystem{
-								Type: "aws",
-								ProviderConfig: &runtime.RawExtension{
-									Raw: []byte(`
-apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-`),
-								},
-							},
+			workloadIdentity := &securityv1alpha1.WorkloadIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: securityv1alpha1.WorkloadIdentitySpec{
+					Audiences: []string{"foo"},
+					TargetSystem: securityv1alpha1.TargetSystem{
+						Type: "aws",
+						ProviderConfig: &runtime.RawExtension{
+							Raw: []byte(`{"apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1","kind":"WorkloadIdentityConfig"}`),
 						},
-					}
-					*obj = *workloadIdentity
-					return nil
-				})
-			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
+					},
+				},
+			}
+			v := newValidator(workloadIdentity)
+			err := v.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
 			Expect(err.Error()).To(ContainSubstring("referenced workload identity garden-dev/my-provider-account is not valid"))
 		})
 	})

--- a/pkg/admission/validator/secretbinding_test.go
+++ b/pkg/admission/validator/secretbinding_test.go
@@ -6,17 +6,16 @@ package validator_test
 
 import (
 	"context"
-	"fmt"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/admission/validator"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
@@ -33,9 +32,7 @@ var _ = Describe("SecretBinding validator", func() {
 		var (
 			secretBindingValidator extensionswebhook.Validator
 
-			ctrl      *gomock.Controller
-			mgr       *testutils.FakeManager
-			apiReader *mockclient.MockReader
+			mgr *testutils.FakeManager
 
 			ctx           = context.TODO()
 			secretBinding = &core.SecretBinding{
@@ -44,58 +41,69 @@ var _ = Describe("SecretBinding validator", func() {
 					Namespace: namespace,
 				},
 			}
-			fakeErr = fmt.Errorf("fake err")
+
+			scheme = func() *runtime.Scheme {
+				s := runtime.NewScheme()
+				Expect(corev1.AddToScheme(s)).To(Succeed())
+				return s
+			}()
 		)
 
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-
-			apiReader = mockclient.NewMockReader(ctrl)
-			mgr = &testutils.FakeManager{APIReader: apiReader}
-
-			secretBindingValidator = validator.NewSecretBindingValidator(mgr)
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
-		})
-
 		It("should return err when obj is not a SecretBinding", func() {
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+			mgr = &testutils.FakeManager{APIReader: apiReader}
+			secretBindingValidator = validator.NewSecretBindingValidator(mgr)
+
 			err := secretBindingValidator.Validate(ctx, &corev1.Secret{}, nil)
 			Expect(err).To(MatchError("wrong object type *v1.Secret"))
 		})
 
 		It("should return err when oldObj is not a SecretBinding", func() {
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+			mgr = &testutils.FakeManager{APIReader: apiReader}
+			secretBindingValidator = validator.NewSecretBindingValidator(mgr)
+
 			err := secretBindingValidator.Validate(ctx, &core.SecretBinding{}, &corev1.Secret{})
 			Expect(err).To(MatchError("wrong object type *v1.Secret for old object"))
 		})
 
 		It("should return err if it fails to get the corresponding Secret", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
+			// secret does not exist → Get returns NotFound
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+			mgr = &testutils.FakeManager{APIReader: apiReader}
+			secretBindingValidator = validator.NewSecretBindingValidator(mgr)
 
 			err := secretBindingValidator.Validate(ctx, secretBinding, nil)
-			Expect(err).To(MatchError(fakeErr))
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return err when the corresponding Secret is not valid", func() {
-			secret := &corev1.Secret{Data: map[string][]byte{
-				aws.AccessKeyID:     []byte("AKIAIOSFODNN7EXAMPL_"),                     // 20 chars but has underscore
-				aws.SecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"), // exactly 40 chars, base64
-			}}
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				SetArg(2, *secret)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data: map[string][]byte{
+					aws.AccessKeyID:     []byte("AKIAIOSFODNN7EXAMPL_"),                     // 20 chars but has underscore
+					aws.SecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"), // exactly 40 chars, base64
+				},
+			}
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+			mgr = &testutils.FakeManager{APIReader: apiReader}
+			secretBindingValidator = validator.NewSecretBindingValidator(mgr)
 
 			err := secretBindingValidator.Validate(ctx, secretBinding, nil)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return nil when the corresponding Secret is valid", func() {
-			secret := &corev1.Secret{Data: map[string][]byte{
-				aws.AccessKeyID:     []byte("AKIAIOSFODNN7EXAMPLE"),                     // exactly 20 chars, uppercase alphanumeric
-				aws.SecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"), // exactly 40 chars, base64
-			}}
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				SetArg(2, *secret)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data: map[string][]byte{
+					aws.AccessKeyID:     []byte("AKIAIOSFODNN7EXAMPLE"),                     // exactly 20 chars, uppercase alphanumeric
+					aws.SecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"), // exactly 40 chars, base64
+				},
+			}
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+			mgr = &testutils.FakeManager{APIReader: apiReader}
+			secretBindingValidator = validator.NewSecretBindingValidator(mgr)
 
 			err := secretBindingValidator.Validate(ctx, secretBinding, nil)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -14,20 +14,17 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"go.uber.org/mock/gomock"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/admission/validator"
 	apisaws "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
@@ -42,40 +39,46 @@ var _ = Describe("Shoot validator", func() {
 		var (
 			shootValidator extensionswebhook.Validator
 
-			ctrl                   *gomock.Controller
 			mgr                    *testutils.FakeManager
-			c                      *mockclient.MockClient
-			reader                 *mockclient.MockReader
 			cloudProfile           *gardencorev1beta1.CloudProfile
 			namespacedCloudProfile *gardencorev1beta1.NamespacedCloudProfile
 			oldShoot               *core.Shoot
 			shoot                  *core.Shoot
 
-			ctx                       = context.Background()
-			cloudProfileKey           = client.ObjectKey{Name: "aws"}
-			namespacedCloudProfileKey = client.ObjectKey{Name: "aws-nscpfl", Namespace: namespace}
-			gp2type                   = string(apisaws.VolumeTypeGP2)
+			ctx     = context.Background()
+			gp2type = string(apisaws.VolumeTypeGP2)
 
 			regionName   = "us-west"
 			imageName    = "Foo"
 			imageVersion = "1.0.0"
 			architecture = ptr.To("analog")
 			machineType  = "large"
+
+			scheme *runtime.Scheme
 		)
 
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
+		// newValidator creates a fresh validator with clientObjects loaded into the
+		// main client and apiReaderObjects loaded into the API reader.
+		newValidator := func(clientObjects []client.Object, apiReaderObjects []client.Object) extensionswebhook.Validator {
+			cb := fakeclient.NewClientBuilder().WithScheme(scheme)
+			if len(clientObjects) > 0 {
+				cb = cb.WithObjects(clientObjects...)
+			}
+			rb := fakeclient.NewClientBuilder().WithScheme(scheme)
+			if len(apiReaderObjects) > 0 {
+				rb = rb.WithObjects(apiReaderObjects...)
+			}
+			mgr = &testutils.FakeManager{Scheme: scheme, Client: cb.Build(), APIReader: rb.Build()}
+			return validator.NewShootValidator(mgr)
+		}
 
-			scheme := runtime.NewScheme()
+		BeforeEach(func() {
+			scheme = runtime.NewScheme()
 			Expect(apisaws.AddToScheme(scheme)).To(Succeed())
 			Expect(apisawsv1alpha1.AddToScheme(scheme)).To(Succeed())
 			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
-
-			c = mockclient.NewMockClient(ctrl)
-			reader = mockclient.NewMockReader(ctrl)
-			mgr = &testutils.FakeManager{Scheme: scheme, Client: c, APIReader: reader}
-
-			shootValidator = validator.NewShootValidator(mgr)
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(securityv1alpha1.AddToScheme(scheme)).To(Succeed())
 
 			cloudProfile = &gardencorev1beta1.CloudProfile{
 				ObjectMeta: metav1.ObjectMeta{
@@ -130,7 +133,8 @@ var _ = Describe("Shoot validator", func() {
 
 			namespacedCloudProfile = &gardencorev1beta1.NamespacedCloudProfile{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "aws-nscpfl",
+					Name:      "aws-nscpfl",
+					Namespace: namespace,
 				},
 				Spec: gardencorev1beta1.NamespacedCloudProfileSpec{
 					Parent: gardencorev1beta1.CloudProfileReference{
@@ -203,6 +207,7 @@ var _ = Describe("Shoot validator", func() {
 			}
 
 			oldShoot = shoot.DeepCopy()
+			shootValidator = newValidator([]client.Object{cloudProfile}, nil)
 		})
 
 		Context("Shoot creation (old is nil)", func() {
@@ -212,7 +217,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when infrastructureConfig is nil", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 				shoot.Spec.Provider.InfrastructureConfig = nil
 
 				err := shootValidator.Validate(ctx, shoot, nil)
@@ -223,7 +227,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when infrastructureConfig fails to be decoded", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 				shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: []byte("foo")}
 
 				err := shootValidator.Validate(ctx, shoot, nil)
@@ -234,8 +237,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when infrastructureConfig is invalid against CloudProfile", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{
 					Raw: encode(&apisawsv1alpha1.InfrastructureConfig{
 						TypeMeta: metav1.TypeMeta{
@@ -260,7 +261,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when worker image is not present in CloudConfiguration", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 				shoot.Spec.Provider.Workers[0].Machine = core.Machine{
 					Type: machineType,
 					Image: &core.ShootMachineImage{
@@ -278,8 +278,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when worker image is not present in CloudConfiguration on update", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				newShoot := shoot.DeepCopy()
 				newShoot.Spec.Provider.Workers[0].Machine = core.Machine{
 					Image: &core.ShootMachineImage{
@@ -298,8 +296,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should not err when old worker image is not present in CloudConfiguration on update", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				newShoot := shoot.DeepCopy()
 				shoot.Spec.Provider.Workers[0].Machine = core.Machine{
 					Type: machineType,
@@ -315,8 +311,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when networking is invalid", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Networking.Nodes = nil
 
 				err := shootValidator.Validate(ctx, shoot, nil)
@@ -327,8 +321,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should allow with IPv6-only networking", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Networking.ProviderConfig = &runtime.RawExtension{
 					Raw: []byte(`{"overlay":{"enabled":false}}`),
 				}
@@ -339,8 +331,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should allow with dual-stack networking", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv6, core.IPFamilyIPv4}
 				shoot.Spec.Networking.ProviderConfig = &runtime.RawExtension{
 					Raw: []byte(`{"overlay":{"enabled":false}}`),
@@ -351,8 +341,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should deny with dual-stack networking and overlay explicitly enabled", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6}
 				shoot.Spec.Networking.ProviderConfig = &runtime.RawExtension{
 					Raw: []byte(`{"overlay":{"enabled":true}}`),
@@ -366,8 +354,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should deny with dual-stack networking and overlay implicitly enabled", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6}
 				shoot.Spec.Networking.ProviderConfig = &runtime.RawExtension{
 					Raw: []byte(`{}`),
@@ -381,8 +367,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when infrastructureConfig is invalid", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{
 					Raw: encode(&apisawsv1alpha1.InfrastructureConfig{
 						TypeMeta: metav1.TypeMeta{
@@ -410,8 +394,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when controlPlaneConfig fails to be decoded", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Provider.ControlPlaneConfig = &runtime.RawExtension{Raw: []byte("foo")}
 
 				err := shootValidator.Validate(ctx, shoot, nil)
@@ -422,8 +404,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when worker's providerConfig fails to be decoded", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Provider.Workers = []core.Worker{
 					{
 						Name:           "worker-1",
@@ -442,8 +422,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when worker is invalid", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Provider.Workers = []core.Worker{
 					{
 						Name:   "worker-1",
@@ -466,15 +444,11 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should succeed for valid Shoot", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				err := shootValidator.Validate(ctx, shoot, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should return err when worker providerConfig has invalid network interface config", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Provider.Workers = []core.Worker{
 					{
 						Name: "worker-1",
@@ -512,8 +486,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when worker providerConfig has invalid placement config", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Provider.Workers = []core.Worker{
 					{
 						Name: "worker-1",
@@ -548,8 +520,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when worker providerConfig has invalid market options config", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Provider.Workers = []core.Worker{
 					{
 						Name: "worker-1",
@@ -586,18 +556,17 @@ var _ = Describe("Shoot validator", func() {
 			It("should also work for CloudProfileName instead of CloudProfile reference in Shoot", func() {
 				shoot.Spec.CloudProfileName = ptr.To("aws")
 				shoot.Spec.CloudProfile = nil
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 
 				err := shootValidator.Validate(ctx, shoot, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should also work for NamespacedCloudProfile referenced from Shoot", func() {
+				shootValidator = newValidator([]client.Object{namespacedCloudProfile}, nil)
 				shoot.Spec.CloudProfile = &core.CloudProfileReference{
 					Kind: "NamespacedCloudProfile",
 					Name: "aws-nscpfl",
 				}
-				c.EXPECT().Get(ctx, namespacedCloudProfileKey, &gardencorev1beta1.NamespacedCloudProfile{}).SetArg(2, *namespacedCloudProfile)
 
 				err := shootValidator.Validate(ctx, shoot, nil)
 				Expect(err).NotTo(HaveOccurred())
@@ -606,8 +575,6 @@ var _ = Describe("Shoot validator", func() {
 
 		Context("shoot update validation", func() {
 			It("should return error if old InfrastructureConfig is nil", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				oldShoot.Spec.Provider.InfrastructureConfig = nil
 
 				err := shootValidator.Validate(ctx, shoot, oldShoot)
@@ -618,8 +585,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return error if old InfrastructureConfig fails to decode", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				oldShoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{Raw: []byte("invalid")}
 
 				err := shootValidator.Validate(ctx, shoot, oldShoot)
@@ -630,8 +595,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return error if InfrastructureConfig update is invalid", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{
 					Raw: encode(&apisawsv1alpha1.InfrastructureConfig{
 						TypeMeta: metav1.TypeMeta{
@@ -673,8 +636,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return error if worker update is invalid", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Provider.Workers[0].Zones = []string{"zone2"}
 
 				err := shootValidator.Validate(ctx, shoot, oldShoot)
@@ -686,8 +647,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return error if worker update is invalid against CloudProfile", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
 					Name:    "Bar",
 					Version: imageVersion,
@@ -702,8 +661,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should not return error if worker update is invalid against CloudProfile is shoot has deletion timestamp", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
 					Name:    "Bar",
 					Version: imageVersion,
@@ -715,8 +672,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should succeed for valid Shoot update", func() {
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				err := shootValidator.Validate(ctx, shoot, oldShoot)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -725,7 +680,6 @@ var _ = Describe("Shoot validator", func() {
 		Context("Shoot with custom DNS provider", func() {
 			Context("primaryProvider", func() {
 				It("should skip validation for non-primary aws-dns provider", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -739,12 +693,10 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					// No reader.EXPECT() call - secret should not be fetched for non-primary provider
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 				})
 
 				It("should skip validation for aws-dns provider with Primary=nil", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -758,12 +710,10 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					// No reader.EXPECT() call - secret should not be fetched when Primary is nil
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 				})
 
 				It("should validate only primary provider when multiple aws-dns providers exist", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -795,7 +745,6 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					// Only the primary secret should be validated
 					validSecret := &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{Name: "primary-secret", Namespace: namespace},
 						Data: map[string][]byte{
@@ -803,16 +752,11 @@ var _ = Describe("Shoot validator", func() {
 							aws.DNSSecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"),
 						},
 					}
-					reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "primary-secret"},
-						&corev1.Secret{}).
-						SetArg(2, *validSecret).
-						Return(nil)
-
+					shootValidator = newValidator([]client.Object{cloudProfile}, []client.Object{validSecret})
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 				})
 
 				It("should validate primary provider even when mixed with other provider types", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -851,16 +795,11 @@ var _ = Describe("Shoot validator", func() {
 							aws.DNSSecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"),
 						},
 					}
-					reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "aws-secret"},
-						&corev1.Secret{}).
-						SetArg(2, *validSecret).
-						Return(nil)
-
+					shootValidator = newValidator([]client.Object{cloudProfile}, []client.Object{validSecret})
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 				})
 
 				It("should return error for invalid primary provider secret among multiple providers", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -890,11 +829,7 @@ var _ = Describe("Shoot validator", func() {
 							// Missing secretAccessKey
 						},
 					}
-					reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "primary-secret"},
-						&corev1.Secret{}).
-						SetArg(2, *invalidSecret).
-						Return(nil)
-
+					shootValidator = newValidator([]client.Object{cloudProfile}, []client.Object{invalidSecret})
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.dns.providers[1].credentialsRef"),
@@ -903,7 +838,6 @@ var _ = Describe("Shoot validator", func() {
 				})
 
 				It("should succeed when no aws-dns providers have Primary=true", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -926,15 +860,12 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					// No reader.EXPECT() calls - no secrets should be validated
-
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 				})
 			})
 
 			Context("credentialsRef", func() {
 				It("should return error when aws-dns provider has no credentialsRef", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{Type: ptr.To(aws.DNSType), Primary: ptr.To(true)}, // credentialsRef missing
@@ -949,7 +880,6 @@ var _ = Describe("Shoot validator", func() {
 				})
 
 				It("should return error when aws-dns provider Secret not found", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -963,10 +893,7 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-						&corev1.Secret{}).
-						Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "dns-secret"))
-
+					// no secret pre-loaded → NotFound
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeNotFound),
 						"Field": Equal("spec.dns.providers[0].credentialsRef"),
@@ -974,7 +901,6 @@ var _ = Describe("Shoot validator", func() {
 				})
 
 				It("should return error when aws-dns provider WorkloadIdentity not found", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -988,10 +914,7 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-workload-identity"},
-						&securityv1alpha1.WorkloadIdentity{}).
-						Return(apierrors.NewNotFound(schema.GroupResource{Resource: "workloadidentities"}, "dns-workload-identity"))
-
+					// no WorkloadIdentity pre-loaded → NotFound
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeNotFound),
 						"Field": Equal("spec.dns.providers[0].credentialsRef"),
@@ -999,7 +922,6 @@ var _ = Describe("Shoot validator", func() {
 				})
 
 				It("should succeed with valid aws-dns Secret", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -1020,16 +942,11 @@ var _ = Describe("Shoot validator", func() {
 							aws.DNSSecretAccessKey: []byte("wJalrXUtnFEMI/K7MDEN+/=PxRfiCYEXAMPLEKEY"),
 						},
 					}
-					reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-						&corev1.Secret{}).
-						SetArg(2, *validSecret).
-						Return(nil)
-
+					shootValidator = newValidator([]client.Object{cloudProfile}, []client.Object{validSecret})
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 				})
 
 				It("should return error with invalid aws-dns Secret", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -1043,17 +960,13 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					validSecret := &corev1.Secret{
+					invalidSecret := &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
 						Data: map[string][]byte{
 							"foo": []byte("bar"),
 						},
 					}
-					reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"},
-						&corev1.Secret{}).
-						SetArg(2, *validSecret).
-						Return(nil)
-
+					shootValidator = newValidator([]client.Object{cloudProfile}, []client.Object{invalidSecret})
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("spec.dns.providers[0].credentialsRef"),
@@ -1065,7 +978,6 @@ var _ = Describe("Shoot validator", func() {
 				})
 
 				It("should succeed with valid aws-dns WorkloadIdentity", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -1085,25 +997,16 @@ var _ = Describe("Shoot validator", func() {
 							TargetSystem: securityv1alpha1.TargetSystem{
 								Type: "aws",
 								ProviderConfig: &runtime.RawExtension{
-									Raw: []byte(`
-apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-roleARN: "foo"
-`),
+									Raw: []byte(`{"apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1","kind":"WorkloadIdentityConfig","roleARN":"foo"}`),
 								},
 							},
 						},
 					}
-					reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-workload-identity"},
-						&securityv1alpha1.WorkloadIdentity{}).
-						SetArg(2, *validWorkloadIdentity).
-						Return(nil)
-
+					shootValidator = newValidator([]client.Object{cloudProfile}, []client.Object{validWorkloadIdentity})
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 				})
 
 				It("should return error with invalid aws-dns WorkloadIdentity", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -1117,26 +1020,18 @@ roleARN: "foo"
 							},
 						},
 					}
-					validWorkloadIdentity := &securityv1alpha1.WorkloadIdentity{
+					invalidWorkloadIdentity := &securityv1alpha1.WorkloadIdentity{
 						ObjectMeta: metav1.ObjectMeta{Name: "dns-workload-identity", Namespace: namespace},
 						Spec: securityv1alpha1.WorkloadIdentitySpec{
 							TargetSystem: securityv1alpha1.TargetSystem{
 								Type: "aws",
 								ProviderConfig: &runtime.RawExtension{
-									Raw: []byte(`
-apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-roleARN: ""
-`),
+									Raw: []byte(`{"apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1","kind":"WorkloadIdentityConfig","roleARN":""}`),
 								},
 							},
 						},
 					}
-					reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-workload-identity"},
-						&securityv1alpha1.WorkloadIdentity{}).
-						SetArg(2, *validWorkloadIdentity).
-						Return(nil)
-
+					shootValidator = newValidator([]client.Object{cloudProfile}, []client.Object{invalidWorkloadIdentity})
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
@@ -1145,7 +1040,6 @@ roleARN: ""
 				})
 
 				It("should return error with unsupported credentials type", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -1168,7 +1062,6 @@ roleARN: ""
 				})
 
 				It("should return error with InternalSecret type", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.DNS = &core.DNS{
 						Providers: []core.DNSProvider{
 							{
@@ -1188,11 +1081,7 @@ roleARN: ""
 							"foo": []byte("bar"),
 						},
 					}
-					reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-internal-secret-ref"},
-						&gardencorev1beta1.InternalSecret{}).
-						SetArg(2, *internalSecret).
-						Return(nil)
-
+					shootValidator = newValidator([]client.Object{cloudProfile}, []client.Object{internalSecret})
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.dns.providers[0].credentialsRef"),

--- a/pkg/aws/secret_test.go
+++ b/pkg/aws/secret_test.go
@@ -6,14 +6,13 @@ package aws_test
 
 import (
 	"context"
-	"errors"
 
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/gardener/gardener-extension-provider-aws/pkg/aws"
 	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
@@ -34,9 +33,6 @@ var _ = Describe("Secret", func() {
 
 	Describe("#GetCredentialsFromSecretRef", func() {
 		var (
-			ctrl *gomock.Controller
-			c    *mockclient.MockClient
-
 			ctx       = context.TODO()
 			namespace = "namespace"
 			name      = "name"
@@ -45,39 +41,32 @@ var _ = Describe("Secret", func() {
 				Name:      name,
 				Namespace: namespace,
 			}
+
+			scheme = runtime.NewScheme()
 		)
 
 		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-
-			c = mockclient.NewMockClient(ctrl)
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
 		})
 
 		It("should fail if the secret could not be read", func() {
-			fakeErr := errors.New("error")
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
-
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+			// secret does not exist → Get returns NotFound
 			credentials, err := GetCredentialsFromSecretRef(ctx, c, secretRef, false, "")
-
 			Expect(credentials).To(BeNil())
-			Expect(err).To(Equal(fakeErr))
+			Expect(err).To(HaveOccurred())
 		})
 
 		Context("DNS keys are not allowed", func() {
 			It("should return the correct credentials object if non-DNS keys are used", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
-						secret.Data = map[string][]byte{
-							AccessKeyID:     accessKeyID,
-							SecretAccessKey: secretAccessKey,
-						}
-						return nil
+				s := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data: map[string][]byte{
+						AccessKeyID:     accessKeyID,
+						SecretAccessKey: secretAccessKey,
 					},
-				)
+				}
+				c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(s).Build()
 
 				credentials, err := GetCredentialsFromSecretRef(ctx, c, secretRef, false, "sample")
 
@@ -92,15 +81,14 @@ var _ = Describe("Secret", func() {
 			})
 
 			It("should fail if DNS keys are used", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
-						secret.Data = map[string][]byte{
-							DNSAccessKeyID:     accessKeyID,
-							DNSSecretAccessKey: secretAccessKey,
-						}
-						return nil
+				s := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data: map[string][]byte{
+						DNSAccessKeyID:     accessKeyID,
+						DNSSecretAccessKey: secretAccessKey,
 					},
-				)
+				}
+				c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(s).Build()
 
 				credentials, err := GetCredentialsFromSecretRef(ctx, c, secretRef, false, "")
 
@@ -111,16 +99,15 @@ var _ = Describe("Secret", func() {
 
 		Context("DNS keys are allowed", func() {
 			It("should return the correct credentials object if DNS keys are used", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
-						secret.Data = map[string][]byte{
-							DNSAccessKeyID:     accessKeyID,
-							DNSSecretAccessKey: secretAccessKey,
-							DNSRegion:          region,
-						}
-						return nil
+				s := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data: map[string][]byte{
+						DNSAccessKeyID:     accessKeyID,
+						DNSSecretAccessKey: secretAccessKey,
+						DNSRegion:          region,
 					},
-				)
+				}
+				c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(s).Build()
 
 				credentials, err := GetCredentialsFromSecretRef(ctx, c, secretRef, true, "")
 
@@ -135,16 +122,15 @@ var _ = Describe("Secret", func() {
 			})
 
 			It("should return the correct credentials object if non-DNS keys are used", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
-						secret.Data = map[string][]byte{
-							AccessKeyID:     accessKeyID,
-							SecretAccessKey: secretAccessKey,
-							Region:          region,
-						}
-						return nil
+				s := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data: map[string][]byte{
+						AccessKeyID:     accessKeyID,
+						SecretAccessKey: secretAccessKey,
+						Region:          region,
 					},
-				)
+				}
+				c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(s).Build()
 
 				credentials, err := GetCredentialsFromSecretRef(ctx, c, secretRef, true, "")
 

--- a/pkg/controller/backupbucket/actuator_test.go
+++ b/pkg/controller/backupbucket/actuator_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/backupbucket"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apisaws "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
@@ -44,10 +44,8 @@ const (
 
 var _ = Describe("Actuator", func() {
 	var (
-		ctrl             *gomock.Controller
-		c                *mockclient.MockClient
+		c                client.Client
 		mgr              *testutils.FakeManager
-		sw               *mockclient.MockStatusWriter
 		a                backupbucket.Actuator
 		awsClientFactory *mockawsclient.MockFactory
 		awsClient        *mockawsclient.MockInterface
@@ -59,23 +57,18 @@ var _ = Describe("Actuator", func() {
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
 		scheme := runtime.NewScheme()
 
 		Expect(extensionsv1alpha1.AddToScheme(scheme)).To(Succeed())
 		Expect(apisawsv1alpha1.AddToScheme(scheme)).To(Succeed())
 		Expect(apisaws.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
-		c = mockclient.NewMockClient(ctrl)
+		c = fakeclient.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&extensionsv1alpha1.BackupBucket{}).Build()
 		mgr = &testutils.FakeManager{Client: c}
-		c.EXPECT().Scheme().Return(scheme).MaxTimes(1)
 
-		sw = mockclient.NewMockStatusWriter(ctrl)
-		awsClientFactory = mockawsclient.NewMockFactory(ctrl)
-		awsClient = mockawsclient.NewMockInterface(ctrl)
-
-		c.EXPECT().Status().Return(sw).AnyTimes()
-		sw.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		awsClientFactory = mockawsclient.NewMockFactory(gomock.NewController(GinkgoT()))
+		awsClient = mockawsclient.NewMockInterface(gomock.NewController(GinkgoT()))
 
 		ctx = context.Background()
 		logger = log.Log.WithName("test")
@@ -103,10 +96,6 @@ var _ = Describe("Actuator", func() {
 		a = NewActuator(mgr, awsClientFactory)
 	})
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	Describe("#Reconcile", func() {
 		var backupBucket *extensionsv1alpha1.BackupBucket
 
@@ -122,12 +111,7 @@ var _ = Describe("Actuator", func() {
 				},
 			}
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					*obj = *secret
-					return nil
-				},
-			)
+			Expect(c.Create(ctx, secret)).To(Succeed())
 		})
 
 		Context("when creating aws client fails", func() {
@@ -472,12 +456,7 @@ var _ = Describe("Actuator", func() {
 				},
 			}
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					*obj = *secret
-					return nil
-				},
-			)
+			Expect(c.Create(ctx, secret)).To(Succeed())
 		})
 
 		It("should return error if aws client creation fails", func() {

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -19,11 +19,9 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,8 +42,7 @@ const (
 
 var _ = Describe("ValuesProvider", func() {
 	var (
-		ctrl         *gomock.Controller
-		c            *mockclient.MockClient
+		c            client.Client
 		mgr          *testutils.FakeManager
 		encoder      runtime.Encoder
 		ctx          context.Context
@@ -211,17 +208,13 @@ var _ = Describe("ValuesProvider", func() {
 		enabledTrue = map[string]interface{}{"enabled": true}
 		enabledFalse = map[string]interface{}{"enabled": false}
 
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		c = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 		mgr = &testutils.FakeManager{Client: c, Scheme: scheme}
 		vp = NewValuesProvider(mgr)
 
 		fakeClient = fakeclient.NewClientBuilder().Build()
 		fakeSecretsManager = fakesecretsmanager.New(fakeClient, namespace)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
 	})
 
 	Describe("#GetConfigChartValues", func() {
@@ -338,7 +331,7 @@ var _ = Describe("ValuesProvider", func() {
 					Namespace: namespace,
 				},
 			}
-			c.EXPECT().Get(context.TODO(), client.ObjectKeyFromObject(cloudProviderSecret), cloudProviderSecret).Return(nil)
+			Expect(c.Create(context.TODO(), cloudProviderSecret)).To(Succeed())
 		})
 
 		It("should return correct control plane chart values", func() {
@@ -510,7 +503,7 @@ var _ = Describe("ValuesProvider", func() {
 					Namespace: namespace,
 				},
 			}
-			c.EXPECT().Get(context.TODO(), client.ObjectKeyFromObject(cloudProviderSecret), cloudProviderSecret).Return(nil)
+			Expect(c.Create(context.TODO(), cloudProviderSecret)).To(Succeed())
 		})
 
 		Context("shoot control plane chart values", func() {

--- a/pkg/controller/dnsrecord/actuator_test.go
+++ b/pkg/controller/dnsrecord/actuator_test.go
@@ -14,15 +14,16 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
@@ -46,9 +47,8 @@ const (
 var _ = Describe("Actuator", func() {
 	var (
 		ctrl             *gomock.Controller
-		c                *mockclient.MockClient
+		c                client.Client
 		mgr              *testutils.FakeManager
-		sw               *mockclient.MockStatusWriter
 		awsClientFactory *mockawsclient.MockFactory
 		awsClient        *mockawsclient.MockInterface
 		ctx              context.Context
@@ -63,14 +63,15 @@ var _ = Describe("Actuator", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		c = mockclient.NewMockClient(ctrl)
+		scheme := runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+		c = fakeclient.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&extensionsv1alpha1.DNSRecord{}).Build()
 		mgr = &testutils.FakeManager{Client: c}
 
-		sw = mockclient.NewMockStatusWriter(ctrl)
 		awsClientFactory = mockawsclient.NewMockFactory(ctrl)
 		awsClient = mockawsclient.NewMockInterface(ctrl)
-
-		c.EXPECT().Status().Return(sw).AnyTimes()
 
 		ctx = context.TODO()
 		logger = log.Log.WithName("test")
@@ -122,35 +123,23 @@ var _ = Describe("Actuator", func() {
 		}
 	})
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	Describe("#Reconcile", func() {
 		BeforeEach(func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					*obj = *secret
-					return nil
-				},
-			)
+			Expect(c.Create(ctx, secret)).To(Succeed())
 			awsClientFactory.EXPECT().NewClient(authConfig).Return(awsClient, nil)
 		})
 
 		It("should reconcile the DNSRecord", func() {
 			awsClient.EXPECT().GetDNSHostedZones(ctx).Return(zones, nil)
 			awsClient.EXPECT().CreateOrUpdateDNSRecordSet(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120), awsclient.IPStackIPv4).Return(nil)
-			sw.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.DNSRecord{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, obj *extensionsv1alpha1.DNSRecord, _ client.Patch, _ ...client.PatchOption) error {
-					Expect(obj.Status).To(Equal(extensionsv1alpha1.DNSRecordStatus{
-						Zone: ptr.To(zone),
-					}))
-					return nil
-				},
-			)
 
+			Expect(c.Create(ctx, dns)).To(Succeed())
 			err := a.Reconcile(ctx, logger, dns, nil)
 			Expect(err).NotTo(HaveOccurred())
+
+			updated := &extensionsv1alpha1.DNSRecord{}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(dns), updated)).To(Succeed())
+			Expect(updated.Status.Zone).To(Equal(ptr.To(zone)))
 		})
 
 		It("should fail if creating the DNS record set failed", func() {
@@ -207,12 +196,7 @@ var _ = Describe("Actuator", func() {
 
 	Describe("#Delete", func() {
 		BeforeEach(func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					*obj = *secret
-					return nil
-				},
-			)
+			Expect(c.Create(ctx, secret)).To(Succeed())
 			awsClientFactory.EXPECT().NewClient(authConfig).Return(awsClient, nil)
 
 		})

--- a/pkg/controller/infrastructure/configvalidator_test.go
+++ b/pkg/controller/infrastructure/configvalidator_test.go
@@ -15,7 +15,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apisaws "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
@@ -50,7 +50,7 @@ const (
 var _ = Describe("ConfigValidator", func() {
 	var (
 		ctrl             *gomock.Controller
-		c                *mockclient.MockClient
+		c                client.Client
 		awsClientFactory *mockawsclient.MockFactory
 		awsClient        *mockawsclient.MockInterface
 		ctx              context.Context
@@ -63,11 +63,14 @@ var _ = Describe("ConfigValidator", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
 		awsClientFactory = mockawsclient.NewMockFactory(ctrl)
 		awsClient = mockawsclient.NewMockInterface(ctrl)
 		ctx = context.TODO()
 		logger = log.Log.WithName("test")
+
+		scheme := runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		c = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 
 		mgr := &testutils.FakeManager{Client: c}
 		cv = NewConfigValidator(mgr, awsClientFactory, logger)
@@ -76,11 +79,7 @@ var _ = Describe("ConfigValidator", func() {
 		infra = baseInfra(region, ptr.To(vpcID))
 		secret, authConfig = baseSecretAuth(accessKeyID, secretAccessKey, region)
 
-		c.EXPECT().Get(ctx, client.ObjectKey{Namespace: infra.Namespace, Name: infra.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-			DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-				*obj = *secret
-				return nil
-			})
+		Expect(c.Create(ctx, secret)).To(Succeed())
 		awsClientFactory.EXPECT().NewClient(authConfig).Return(awsClient, nil)
 	})
 

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -20,24 +20,21 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	awsmachineapi "github.com/gardener/machine-controller-manager-provider-aws/pkg/aws/apis"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	api "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
@@ -47,23 +44,6 @@ import (
 var ctx = context.TODO()
 
 var _ = Describe("Machines", func() {
-	var (
-		ctrl         *gomock.Controller
-		c            *mockclient.MockClient
-		statusWriter *mockclient.MockStatusWriter
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-
-		c = mockclient.NewMockClient(ctrl)
-		statusWriter = mockclient.NewMockStatusWriter(ctrl)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	Context("WorkerDelegate", func() {
 		workerDelegate, _ := NewWorkerDelegate(nil, nil, nil, "", nil, nil)
 
@@ -151,6 +131,7 @@ var _ = Describe("Machines", func() {
 
 				shootVersionMajorMinor           string
 				shootVersion                     string
+				c                                client.Client
 				scheme                           *runtime.Scheme
 				decoder                          runtime.Decoder
 				clusterWithoutImages             *extensionscontroller.Cluster
@@ -442,6 +423,7 @@ var _ = Describe("Machines", func() {
 
 				w = &extensionsv1alpha1.Worker{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:      "worker",
 						Namespace: namespace,
 					},
 					Spec: extensionsv1alpha1.WorkerSpec{
@@ -595,6 +577,10 @@ var _ = Describe("Machines", func() {
 				scheme = runtime.NewScheme()
 				_ = api.AddToScheme(scheme)
 				_ = apiv1alpha1.AddToScheme(scheme)
+				_ = corev1.AddToScheme(scheme)
+				_ = machinev1alpha1.AddToScheme(scheme)
+				_ = extensionsv1alpha1.AddToScheme(scheme)
+				c = fakeclient.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&extensionsv1alpha1.Worker{}).Build()
 				decoder = serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder()
 
 				additionalData := []string{strconv.FormatBool(volumeEncrypted), fmt.Sprintf("%dGi", dataVolume1Size), dataVolume1Type, strconv.FormatBool(dataVolume1Encrypted), fmt.Sprintf("%dGi", dataVolume2Size), dataVolume2Type, strconv.FormatBool(dataVolume2Encrypted)}
@@ -606,12 +592,10 @@ var _ = Describe("Machines", func() {
 			})
 
 			expectedUserDataSecretRefRead := func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: userDataSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
-						secret.Data = map[string][]byte{userDataSecretDataKey: userData}
-						return nil
-					},
-				).AnyTimes()
+				Expect(c.Create(ctx, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: userDataSecretName, Namespace: namespace},
+					Data:       map[string][]byte{userDataSecretDataKey: userData},
+				})).To(Succeed())
 			}
 
 			Describe("machine images", func() {
@@ -624,41 +608,21 @@ var _ = Describe("Machines", func() {
 
 				expectMachineClassesAndSecrets := func() {
 					for _, secret := range machineClassSecrets {
-						existing := &corev1.Secret{
+						Expect(c.Create(ctx, &corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      secret.Name,
 								Namespace: secret.Namespace,
 							},
-						}
-
-						c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(secret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-							func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-								defer GinkgoRecover()
-
-								*obj = *existing
-								return nil
-							})
-
-						test.EXPECTPatch(gomock.Any(), c, secret, existing, types.MergePatchType)
+						})).To(Succeed())
 					}
 
 					for _, machineClass := range machineClasses {
-						existing := &machinev1alpha1.MachineClass{
+						Expect(c.Create(ctx, &machinev1alpha1.MachineClass{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      machineClass.Name,
 								Namespace: machineClass.Namespace,
 							},
-						}
-
-						c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(machineClass), gomock.AssignableToTypeOf(&machinev1alpha1.MachineClass{})).DoAndReturn(
-							func(_ context.Context, _ client.ObjectKey, obj *machinev1alpha1.MachineClass, _ ...client.GetOption) error {
-								defer GinkgoRecover()
-
-								*obj = *existing
-								return nil
-							})
-
-						test.EXPECTPatch(gomock.Any(), c, machineClass, existing, types.MergePatchType)
+						})).To(Succeed())
 					}
 				}
 
@@ -1041,12 +1005,14 @@ var _ = Describe("Machines", func() {
 							Name:         machineImageName,
 							Version:      machineImageVersion,
 							AMI:          machineImageAMI,
+							Architecture: ptr.To(archAMD),
 							Capabilities: capabilitiesAmd,
 						},
 						{
 							Name:         machineImageName,
 							Version:      machineImageVersion,
 							AMI:          machineImageAMI,
+							Architecture: ptr.To(archAMD),
 							Capabilities: capabilitiesArm,
 						},
 					}
@@ -1076,16 +1042,18 @@ var _ = Describe("Machines", func() {
 						MachineImages: machineImages,
 					}
 
-					workerWithExpectedImages := w.DeepCopy()
-					workerWithExpectedImages.Status.ProviderStatus = &runtime.RawExtension{
-						Object: expectedImages,
-					}
-
-					c.EXPECT().Status().Return(statusWriter)
-					statusWriter.EXPECT().Patch(ctx, workerWithExpectedImages, gomock.Any()).Return(nil)
+					Expect(c.Create(ctx, w)).To(Succeed())
 
 					err = workerDelegate.UpdateMachineImagesStatus(ctx)
 					Expect(err).NotTo(HaveOccurred())
+
+					updatedWorker := &extensionsv1alpha1.Worker{}
+					Expect(c.Get(ctx, client.ObjectKeyFromObject(w), updatedWorker)).To(Succeed())
+					Expect(updatedWorker.Status.ProviderStatus).NotTo(BeNil())
+					decodedStatus := &apiv1alpha1.WorkerStatus{}
+					_, _, decodeErr := decoder.Decode(updatedWorker.Status.ProviderStatus.Raw, nil, decodedStatus)
+					Expect(decodeErr).NotTo(HaveOccurred())
+					Expect(decodedStatus).To(Equal(expectedImages))
 
 					// Test WorkerDelegate.GenerateMachineDeployments()
 

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -23,10 +23,8 @@ import (
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
 	"github.com/gardener/gardener/pkg/utils/version"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +33,7 @@ import (
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-aws/imagevector"
 	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws/v1alpha1"
@@ -55,9 +54,9 @@ var _ = BeforeSuite(func() {
 
 var _ = Describe("Ensurer", func() {
 	var (
-		ctrl *gomock.Controller
-		c    *mockclient.MockClient
-		ctx  = context.TODO()
+		c      client.Client
+		scheme *runtime.Scheme
+		ctx    = context.TODO()
 
 		dummyContext          = gcontext.NewGardenContext(nil, nil)
 		eContextK8s134        gcontext.GardenContext
@@ -70,8 +69,9 @@ var _ = Describe("Ensurer", func() {
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		c = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 
 		infraConfig = &v1alpha1.InfrastructureConfig{
 			TypeMeta: metav1.TypeMeta{
@@ -147,10 +147,6 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
 	})
 
 	Describe("#EnsureKubeAPIServerDeployment", func() {
@@ -867,9 +863,7 @@ done
 					Namespace: deployment.Namespace,
 				},
 			}
-			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(secret), secret).DoAndReturn(func(_ context.Context, _ client.ObjectKey, _ runtime.Object, _ ...client.GetOption) error {
-				return nil
-			})
+			ensurer = NewEnsurer(logger, fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build())
 
 			Expect(deployment.Spec.Template.Spec.Containers).To(BeEmpty())
 			Expect(ensurer.EnsureMachineControllerManagerDeployment(context.TODO(), eContextK8s133, deployment, nil)).To(Succeed())
@@ -882,14 +876,12 @@ done
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cloudprovider",
 					Namespace: deployment.Namespace,
+					Labels: map[string]string{
+						"security.gardener.cloud/purpose": "workload-identity-token-requestor",
+					},
 				},
 			}
-			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(secret), secret).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-				obj.Labels = map[string]string{
-					"security.gardener.cloud/purpose": "workload-identity-token-requestor",
-				}
-				return nil
-			})
+			ensurer = NewEnsurer(logger, fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build())
 			Expect(deployment.Spec.Template.Spec.Containers).To(BeEmpty())
 			Expect(ensurer.EnsureMachineControllerManagerDeployment(context.TODO(), eContextK8s133, deployment, nil)).To(Succeed())
 			expectedContainer := machinecontrollermanager.ProviderSidecarContainer(shoot133, deployment.Namespace, "provider-aws", "foo:bar")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind cleanup
/platform aws

**What this PR does / why we need it**:
This PR follows the cleanup process outlined in https://github.com/gardener/gardener/issues/14572.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Migrate test mock clients to fakeclient following https://github.com/gardener/gardener/pull/14799
```
