### PR TITLE
Fix renovate glob patterns

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,12 +25,12 @@
     {
       matchManagers: ['gomod'],
       matchPackageNames: [
-        '!github.com/gardener/*',
-        '!github.com/aws/*',
-        '!k8s.io/*',
-        '!sigs.k8s.io/*',
-        '!github.com/gardener/etcd-druid/*',
-        '!github.com/prometheus-operator/*',
+        '!github.com/gardener/**',
+        '!github.com/aws/**',
+        '!k8s.io/**',
+        '!sigs.k8s.io/**',
+        '!github.com/gardener/etcd-druid/**',
+        '!github.com/prometheus-operator/**',
       ],
       groupName: 'non-gardener-dependencies',
       matchUpdateTypes: ['minor', 'patch', 'digest'],
@@ -39,12 +39,12 @@
     {
       matchManagers: ['gomod'],
       matchPackageNames: [
-        '!github.com/gardener/*',
-        '!github.com/aws/*',
-        '!k8s.io/*',
-        '!sigs.k8s.io/*',
-        '!github.com/gardener/etcd-druid/*',
-        '!github.com/prometheus-operator/*',
+        '!github.com/gardener/**',
+        '!github.com/aws/**',
+        '!k8s.io/**',
+        '!sigs.k8s.io/**',
+        '!github.com/gardener/etcd-druid/**',
+        '!github.com/prometheus-operator/**',
       ],
       groupName: 'non-gardener-dependencies',
       matchUpdateTypes: ['major'],
@@ -52,14 +52,14 @@
     // gomod: aws provider SDK
     {
       matchManagers: ['gomod'],
-      matchPackageNames: ['github.com/aws/*'],
+      matchPackageNames: ['github.com/aws/**'],
       groupName: 'provider-sdk-dependencies',
       matchUpdateTypes: ['minor', 'patch', 'digest'],
       automerge: true,
     },
     {
       matchManagers: ['gomod'],
-      matchPackageNames: ['github.com/aws/*'],
+      matchPackageNames: ['github.com/aws/**'],
       groupName: 'provider-sdk-dependencies',
       matchUpdateTypes: ['major'],
     },
@@ -68,7 +68,7 @@
       matchManagers: ['gomod'],
       matchPackageNames: [
         'github.com/gardener/gardener',
-        'github.com/gardener/gardener/*',
+        'github.com/gardener/gardener/**',
       ],
       groupName: 'gardener-dependencies',
     },
@@ -76,10 +76,10 @@
     {
       matchManagers: ['gomod'],
       matchPackageNames: [
-        'k8s.io/*',
-        'sigs.k8s.io/*',
-        'github.com/gardener/etcd-druid/*',
-        'github.com/prometheus-operator/*',
+        'k8s.io/**',
+        'sigs.k8s.io/**',
+        'github.com/gardener/etcd-druid/**',
+        'github.com/prometheus-operator/**',
       ],
       enabled: false,
     },


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug
/platform aws

**What this PR does / why we need it**:
Fix renovate glob patterns as documented here: https://docs.renovatebot.com/string-pattern-matching/#example-glob-patterns

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
