### PR TITLE
Fix EIP validation to exclude deleted NAT gateways

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -257,6 +257,9 @@ func (c *Client) GetNATGatewayAddressAllocations(ctx context.Context, shootNames
 	}
 
 	for _, natGateway := range describeNatGatewaysOutput.NatGateways {
+		if natGateway.State == ec2types.NatGatewayStateDeleted {
+			continue
+		}
 		if len(natGateway.NatGatewayAddresses) == 0 {
 			continue
 		}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement
/platform aws

**What this PR does / why we need it**:
`GetNATGatewayAddressAllocations` retrieves all allocation IDs from NAT gateways tagged with `kubernetes.io/cluster/<shoot-namespace>`, including those in deleted state. AWS retains the AllocationId on deleted NAT gateways in its API response.

This could caused `validateEIPS` to incorrectly consider a previously-used EIP as still belonging to the Shoot's NAT gateways, even after the NAT gateway was deleted and the EIP was disassociated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix EIP validation to exclude deleted NAT gateways
```
