### PR TITLE
Revert "Add support for Kubernetes 1.36"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support | Conformance test results                                                                                                                                                                                           |
 |-----------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Kubernetes 1.36 | 1.36.0+ | N/A                                                                                                                                                                                                                |
 | Kubernetes 1.35 | 1.35.0+ | [![Gardener v1.35 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.35%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.35%20AWS) |
 | Kubernetes 1.34 | 1.34.0+ | [![Gardener v1.34 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.34%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.34%20AWS) |
 | Kubernetes 1.33 | 1.33.0+ | [![Gardener v1.33 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.33%20AWS/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.33%20AWS) |

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -86,6 +86,7 @@ images:
       availability_requirement: low
     signing: false
   targetVersion: 1.34.x
+# max-supported-k8s
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-aws
   repository: registry.k8s.io/provider-aws/cloud-controller-manager
@@ -100,23 +101,7 @@ images:
       integrity_requirement: high
       availability_requirement: low
     signing: false
-  targetVersion: 1.35.x
-# max-supported-k8s
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-aws
-  repository: registry.k8s.io/provider-aws/cloud-controller-manager
-  tag: v1.36.0
-  labels:
-  - name: gardener.cloud/cve-categorisation
-    value:
-      network_exposure: protected
-      authentication_enforced: false
-      user_interaction: gardener-operator
-      confidentiality_requirement: high
-      integrity_requirement: high
-      availability_requirement: low
-    signing: false
-  targetVersion: '>= 1.36'
+  targetVersion: '>= 1.35'
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
   repository: registry.k8s.io/sig-storage/csi-attacher
@@ -346,22 +331,7 @@ images:
       integrity_requirement: high
       availability_requirement: low
     signing: false
-  targetVersion: '1.35.x'
-- name: ecr-credential-provider
-  sourceRepository: github.com/gardener/ecr-credential-provider
-  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/ecr-credential-provider
-  tag: v1.36.0
-  labels:
-  - name: gardener.cloud/cve-categorisation
-    value:
-      network_exposure: protected
-      authentication_enforced: false
-      user_interaction: end-user
-      confidentiality_requirement: high
-      integrity_requirement: high
-      availability_requirement: low
-    signing: false
-  targetVersion: '>= 1.36'
+  targetVersion: '>= 1.35'
 - name: machine-controller-manager-provider-aws
   sourceRepository: github.com/gardener/machine-controller-manager-provider-aws
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-aws

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -962,6 +962,9 @@ func isUsingCalico(cluster *extensionscontroller.Cluster) bool {
 		*cluster.Shoot.Spec.Networking.Type == "calico"
 }
 
+// constraintK8sGreaterEqual136 is a version constraint for Kubernetes versions >= 1.36.
+var constraintK8sGreaterEqual136 = versionutils.MustNewConstraint(">= 1.36-0")
+
 func isMutatingAdmissionPolicyEnabled(cluster *extensionscontroller.Cluster) bool {
 	k8sVersion, err := semver.NewVersion(cluster.Shoot.Spec.Kubernetes.Version)
 	if err != nil {
@@ -969,7 +972,7 @@ func isMutatingAdmissionPolicyEnabled(cluster *extensionscontroller.Cluster) boo
 	}
 
 	// For K8s >= 1.36, MutatingAdmissionPolicy is GA (locked on, cannot be disabled).
-	if versionutils.ConstraintK8sGreaterEqual136.Check(k8sVersion) {
+	if constraintK8sGreaterEqual136.Check(k8sVersion) {
 		return true
 	}
 
@@ -1005,7 +1008,7 @@ func mutatingAdmissionPolicyAPIVersion(cluster *extensionscontroller.Cluster) st
 	}
 
 	// For K8s >= 1.36, MutatingAdmissionPolicy is GA
-	if versionutils.ConstraintK8sGreaterEqual136.Check(k8sVersion) {
+	if constraintK8sGreaterEqual136.Check(k8sVersion) {
 		return "v1"
 	}
 


### PR DESCRIPTION
Reverts gardener/gardener-extension-provider-aws#1878

The upstream cloud-provider-aws images is not yet available in `registry.k8s.io/provider-aws/cloud-controller-manager` causing our builds to fail.

See also: https://github.com/kubernetes/cloud-provider-aws/issues/1450