### PR TITLE
fix: capture correct csi-driver detach pending metric

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-servicemonitor.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-servicemonitor.yaml
@@ -19,4 +19,4 @@ spec:
         - sourceLabels:
             - __name__
           action: keep
-          regex: ^(aws_ebs_csi_api_request_duration_seconds_(bucket|sum|count)|aws_ebs_csi_api_request_errors_total|aws_ebs_csi_api_request_throttles_total|aws_ebs_csi_ec2_detach_pending_seconds)$
+          regex: ^(aws_ebs_csi_api_request_duration_seconds_(bucket|sum|count)|aws_ebs_csi_api_request_errors_total|aws_ebs_csi_api_request_throttles_total|aws_ebs_csi_ec2_detach_pending_seconds(_total)?)$


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind bug
/platform aws

**What this PR does / why we need it**:

Capture the correct csi-driver metric for detach pending. While [the documentation](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/metrics.md) mentions `aws_ebs_csi_ec2_detach_pending_seconds`, [the code](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/pkg/metrics/async.go#L27) is actually using `aws_ebs_csi_ec2_detach_pending_seconds_total`. The new regex captures both to be on the safe side.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Capture correct `aws_ebs_csi_ec2_detach_pending_seconds_total` metric for CSI driver.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring coverage by allowing the total variant of the EBS CSI detach-pending duration metric to be collected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->