### PR TITLE
[release-v1.71] Automated cherry pick of #1906: Enhance workload identity roleARN validation

### DIFF
--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -182,7 +182,7 @@ var _ = Describe("CredentialsBinding validator", func() {
 									Raw: []byte(`
 apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
 kind: WorkloadIdentityConfig
-roleARN: "foo"
+roleARN: "arn:aws:iam::123456789012:role/my-role"
 `),
 								},
 							},

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -1088,7 +1088,7 @@ var _ = Describe("Shoot validator", func() {
 									Raw: []byte(`
 apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
 kind: WorkloadIdentityConfig
-roleARN: "foo"
+roleARN: "arn:aws:iam::123456789012:role/my-role"
 `),
 								},
 							},
@@ -1140,7 +1140,7 @@ roleARN: ""
 					Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
-						"Detail": ContainSubstring("roleARN is required"),
+						"Detail": ContainSubstring("cannot be empty"),
 					}))))
 				})
 

--- a/pkg/admission/validator/workloadidentity_test.go
+++ b/pkg/admission/validator/workloadidentity_test.go
@@ -34,7 +34,7 @@ var _ = Describe("WorkloadIdentity validator", func() {
 							Raw: []byte(`
 apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
 kind: WorkloadIdentityConfig
-roleARN: "foo"
+roleARN: "arn:aws:iam::123456789012:role/my-role"
 `),
 						},
 					},
@@ -57,7 +57,7 @@ roleARN: "foo"
 			newWorkloadIdentity.Spec.TargetSystem.ProviderConfig.Raw = []byte(`
 apiVersion: aws.provider.extensions.gardener.cloud/v1alpha1
 kind: WorkloadIdentityConfig
-roleARN: "foo"
+roleARN: "arn:aws:iam::123456789012:role/my-role"
 `)
 			Expect(workloadIdentityValidator.Validate(ctx, newWorkloadIdentity, workloadIdentity)).To(Succeed())
 		})

--- a/pkg/apis/aws/validation/filter.go
+++ b/pkg/apis/aws/validation/filter.go
@@ -45,6 +45,17 @@ var (
 	// see https://docs.aws.amazon.com/general/latest/gr/rande.html
 	// and https://aws.amazon.com/de/blogs/aws/opening-the-aws-european-sovereign-cloud/ (section "Some technical details")
 	RegionRegex = `^[a-z-]+-\d+$`
+	// RoleARNRegex matches AWS IAM role ARNs, e.g. arn:aws:iam::123456789012:role/path/to/role-name
+	// The ARN format is arn:<partition>:iam::<account-id>:role/<optional-path>/<role-name> where:
+	//   - <partition> is one of the AWS partitions, e.g. aws, aws-cn, aws-us-gov, aws-iso
+	//   - the region segment is always empty because IAM is a global service
+	//   - <account-id> is the 12-digit AWS account ID
+	//   - the resource is a role/ followed by an optional path and the role name consisting of
+	//     the characters [a-zA-Z0-9+=,.@_-] as documented in
+	//     https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html
+	//
+	// see https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html
+	RoleARNRegex = `^arn:aws[a-z0-9-]*:iam::\d{12}:role(/[\w+=,.@-]+)*/[\w+=,.@-]+$`
 
 	validateK8sResourceName          = combineValidationFuncs(regex(k8sResourceNameRegex), notEmpty, maxLength(253))
 	validateVpcID                    = combineValidationFuncs(regex(VpcIDRegex), notEmpty, maxLength(255))
@@ -59,6 +70,7 @@ var (
 	validateAccessKeyID              = hideSensitiveValue(combineValidationFuncs(regex(AccessKeyIDRegex), minLength(20), maxLength(20)))
 	validateSecretAccessKey          = hideSensitiveValue(combineValidationFuncs(regex(SecretAccessKeyRegex), minLength(40), maxLength(40)))
 	validateRegion                   = combineValidationFuncs(regex(RegionRegex), maxLength(32))
+	validateRoleARN                  = combineValidationFuncs(regex(RoleARNRegex), notEmpty)
 )
 
 type validateFunc[T any] func(T, *field.Path) field.ErrorList

--- a/pkg/apis/aws/validation/workloadidentity.go
+++ b/pkg/apis/aws/validation/workloadidentity.go
@@ -13,10 +13,7 @@ import (
 // ValidateWorkloadIdentityConfig checks whether the given workload identity configuration contains expected fields and values.
 func ValidateWorkloadIdentityConfig(config *apisaws.WorkloadIdentityConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-
-	if len(config.RoleARN) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("roleARN"), "roleARN is required"))
-	}
+	allErrs = append(allErrs, validateRoleARN(config.RoleARN, fldPath.Child("roleARN"))...)
 
 	return allErrs
 }

--- a/pkg/apis/aws/validation/workloadidentity_test.go
+++ b/pkg/apis/aws/validation/workloadidentity_test.go
@@ -22,7 +22,7 @@ var _ = Describe("#ValidateWorkloadIdentityConfig", func() {
 
 	BeforeEach(func() {
 		workloadIdentityConfig = &apisaws.WorkloadIdentityConfig{
-			RoleARN: "foo",
+			RoleARN: "arn:aws:iam::123456789012:role/my-role",
 		}
 	})
 
@@ -30,14 +30,53 @@ var _ = Describe("#ValidateWorkloadIdentityConfig", func() {
 		Expect(validation.ValidateWorkloadIdentityConfig(workloadIdentityConfig, field.NewPath(""))).To(BeEmpty())
 	})
 
-	It("should contain all expected validation errors", func() {
+	DescribeTable("should accept valid IAM role ARNs",
+		func(roleARN string) {
+			workloadIdentityConfig.RoleARN = roleARN
+			Expect(validation.ValidateWorkloadIdentityConfig(workloadIdentityConfig, field.NewPath(""))).To(BeEmpty())
+		},
+		Entry("simple role", "arn:aws:iam::123456789012:role/my-role"),
+		Entry("role with path", "arn:aws:iam::123456789012:role/path/to/my-role"),
+		Entry("role name with allowed special characters", "arn:aws:iam::123456789012:role/my.role_name+=,.@-"),
+		Entry("china partition", "arn:aws-cn:iam::123456789012:role/my-role"),
+		Entry("gov cloud partition", "arn:aws-us-gov:iam::123456789012:role/my-role"),
+		Entry("eusc partition", "arn:aws-eusc:iam::123456789012:role/my-role"),
+		Entry("iso partition", "arn:aws-iso:iam::123456789012:role/my-role"),
+	)
+
+	DescribeTable("should reject invalid IAM role ARNs",
+		func(roleARN string) {
+			workloadIdentityConfig.RoleARN = roleARN
+			errorList := validation.ValidateWorkloadIdentityConfig(workloadIdentityConfig, field.NewPath("providerConfig"))
+			Expect(errorList).To(ConsistOfFields(
+				Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("providerConfig.roleARN"),
+					"Detail": Equal("does not match expected regex ^arn:aws[a-z0-9-]*:iam::\\d{12}:role(/[\\w+=,.@-]+)*/[\\w+=,.@-]+$"),
+				},
+			))
+		},
+		Entry("arbitrary string", "foo"),
+		Entry("missing arn prefix", "aws:iam::123456789012:role/my-role"),
+		Entry("wrong service", "arn:aws:s3::123456789012:role/my-role"),
+		Entry("wrong resource type", "arn:aws:iam::123456789012:user/my-user"),
+		Entry("account id too short", "arn:aws:iam::12345:role/my-role"),
+		Entry("account id with non-digits", "arn:aws:iam::12345678901a:role/my-role"),
+		Entry("non-empty region segment", "arn:aws:iam:us-east-1:123456789012:role/my-role"),
+		Entry("missing role name", "arn:aws:iam::123456789012:role/"),
+		Entry("missing role name and slash", "arn:aws:iam::123456789012:role"),
+		Entry("trailing whitespace", "arn:aws:iam::123456789012:role/my-role "),
+		Entry("invalid character in role name", "arn:aws:iam::123456789012:role/my-role*"),
+	)
+
+	It("should contain all expected validation errors when roleARN is empty", func() {
 		workloadIdentityConfig.RoleARN = ""
 		errorList := validation.ValidateWorkloadIdentityConfig(workloadIdentityConfig, field.NewPath("providerConfig"))
 		Expect(errorList).To(ConsistOfFields(
 			Fields{
 				"Type":   Equal(field.ErrorTypeRequired),
 				"Field":  Equal("providerConfig.roleARN"),
-				"Detail": Equal("roleARN is required"),
+				"Detail": Equal("cannot be empty"),
 			},
 		))
 	})
@@ -49,8 +88,21 @@ var _ = Describe("#ValidateWorkloadIdentityConfig", func() {
 
 	It("should allow changing the roleARN during update", func() {
 		newConfig := workloadIdentityConfig.DeepCopy()
-		newConfig.RoleARN = "bar"
+		newConfig.RoleARN = "arn:aws:iam::123456789012:role/another-role"
 		errorList := validation.ValidateWorkloadIdentityConfigUpdate(workloadIdentityConfig, newConfig, field.NewPath("providerConfig"))
 		Expect(errorList).To(BeEmpty())
+	})
+
+	It("should reject changing the roleARN to an invalid value during update", func() {
+		newConfig := workloadIdentityConfig.DeepCopy()
+		newConfig.RoleARN = "not-a-valid-role-arn"
+		errorList := validation.ValidateWorkloadIdentityConfigUpdate(workloadIdentityConfig, newConfig, field.NewPath("providerConfig"))
+		Expect(errorList).To(ConsistOfFields(
+			Fields{
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("providerConfig.roleARN"),
+				"Detail": Equal("does not match expected regex ^arn:aws[a-z0-9-]*:iam::\\d{12}:role(/[\\w+=,.@-]+)*/[\\w+=,.@-]+$"),
+			},
+		))
 	})
 })


### PR DESCRIPTION
/area ops-productivity
/area quality
/kind enhancement

Cherry pick of #1906 on release-v1.71.

#1906: Enhance workload identity roleARN validation

**Release Notes:**
```noteworthy user
The `WorkloadIdentity` validation has been improved to ensure the configured `roleARN` is formatted correctly.
```
