### PR TITLE
Add `minStepAbsolute` defaulting to pvc-autoscaler webhook

### DIFF
--- a/pkg/webhook/pvca/mutator.go
+++ b/pkg/webhook/pvca/mutator.go
@@ -12,12 +12,16 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	pvcautoscalingv1alpha1 "github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // A volume can be modified up to four times within a rolling 24-hour period (https://docs.aws.amazon.com/ebs/latest/userguide/ebs-modify-volume.html)
 const minCooldownDuration = 6 * time.Hour
+
+// minStepAbsolute is the minimum absolute change in capacity enforced during scaling.
+var minStepAbsolute = resource.MustParse("5Gi")
 
 type mutator struct {
 	logger logr.Logger
@@ -41,6 +45,11 @@ func (m *mutator) Mutate(_ context.Context, newObj, _ client.Object) error {
 		if pvca.Spec.VolumePolicies[i].ScaleUp != nil &&
 			(pvca.Spec.VolumePolicies[i].ScaleUp.CooldownDuration == nil || pvca.Spec.VolumePolicies[i].ScaleUp.CooldownDuration.Duration < minCooldownDuration) {
 			pvca.Spec.VolumePolicies[i].ScaleUp.CooldownDuration = &metav1.Duration{Duration: minCooldownDuration}
+		}
+		if pvca.Spec.VolumePolicies[i].ScaleUp != nil &&
+			(pvca.Spec.VolumePolicies[i].ScaleUp.MinStepAbsolute == nil || pvca.Spec.VolumePolicies[i].ScaleUp.MinStepAbsolute.Cmp(minStepAbsolute) < 0) {
+			step := minStepAbsolute.DeepCopy()
+			pvca.Spec.VolumePolicies[i].ScaleUp.MinStepAbsolute = &step
 		}
 	}
 

--- a/pkg/webhook/pvca/mutator.go
+++ b/pkg/webhook/pvca/mutator.go
@@ -48,7 +48,7 @@ func (m *mutator) Mutate(_ context.Context, newObj, _ client.Object) error {
 		}
 		if pvca.Spec.VolumePolicies[i].ScaleUp != nil &&
 			(pvca.Spec.VolumePolicies[i].ScaleUp.MinStepAbsolute == nil || pvca.Spec.VolumePolicies[i].ScaleUp.MinStepAbsolute.Cmp(minStepAbsolute) < 0) {
-			pvca.Spec.VolumePolicies[i].ScaleUp.MinStepAbsolute = &minStepAbsolute
+			pvca.Spec.VolumePolicies[i].ScaleUp.MinStepAbsolute = new(minStepAbsolute.DeepCopy())
 		}
 	}
 

--- a/pkg/webhook/pvca/mutator.go
+++ b/pkg/webhook/pvca/mutator.go
@@ -12,12 +12,16 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	pvcautoscalingv1alpha1 "github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // A volume can be modified up to four times within a rolling 24-hour period (https://docs.aws.amazon.com/ebs/latest/userguide/ebs-modify-volume.html)
 const minCooldownDuration = 6 * time.Hour
+
+// minStepAbsolute is the minimum absolute change in capacity enforced during scaling.
+var minStepAbsolute = resource.MustParse("5Gi")
 
 type mutator struct {
 	logger logr.Logger
@@ -41,6 +45,10 @@ func (m *mutator) Mutate(_ context.Context, newObj, _ client.Object) error {
 		if pvca.Spec.VolumePolicies[i].ScaleUp != nil &&
 			(pvca.Spec.VolumePolicies[i].ScaleUp.CooldownDuration == nil || pvca.Spec.VolumePolicies[i].ScaleUp.CooldownDuration.Duration < minCooldownDuration) {
 			pvca.Spec.VolumePolicies[i].ScaleUp.CooldownDuration = &metav1.Duration{Duration: minCooldownDuration}
+		}
+		if pvca.Spec.VolumePolicies[i].ScaleUp != nil &&
+			(pvca.Spec.VolumePolicies[i].ScaleUp.MinStepAbsolute == nil || pvca.Spec.VolumePolicies[i].ScaleUp.MinStepAbsolute.Cmp(minStepAbsolute) < 0) {
+			pvca.Spec.VolumePolicies[i].ScaleUp.MinStepAbsolute = &minStepAbsolute
 		}
 	}
 

--- a/pkg/webhook/pvca/mutator_test.go
+++ b/pkg/webhook/pvca/mutator_test.go
@@ -136,4 +136,65 @@ var _ = Describe("Mutator", func() {
 		Expect(pvca.Spec.VolumePolicies[0].ScaleUp.CooldownDuration).ToNot(BeNil())
 		Expect(pvca.Spec.VolumePolicies[0].ScaleUp.CooldownDuration.Duration).To(Equal(8 * time.Hour))
 	})
+
+	It("should default minStepAbsolute to 5Gi when missing", func() {
+		pvca := &pvcautoscalingv1alpha1.PersistentVolumeClaimAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
+			Spec: pvcautoscalingv1alpha1.PersistentVolumeClaimAutoscalerSpec{
+				VolumePolicies: []pvcautoscalingv1alpha1.VolumePolicy{
+					{
+						MaxCapacity: resource.MustParse("10Gi"),
+						ScaleUp:     &pvcautoscalingv1alpha1.ScalingRules{},
+					},
+				},
+			},
+		}
+
+		err := mutator.Mutate(context.Background(), pvca, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(pvca.Spec.VolumePolicies).To(HaveLen(1))
+		Expect(pvca.Spec.VolumePolicies[0].ScaleUp.MinStepAbsolute).ToNot(BeNil())
+		Expect(pvca.Spec.VolumePolicies[0].ScaleUp.MinStepAbsolute.Cmp(resource.MustParse("5Gi"))).To(Equal(0))
+	})
+
+	It("should overwrite minStepAbsolute when smaller than 5Gi", func() {
+		existing := resource.MustParse("1Gi")
+		pvca := &pvcautoscalingv1alpha1.PersistentVolumeClaimAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
+			Spec: pvcautoscalingv1alpha1.PersistentVolumeClaimAutoscalerSpec{
+				VolumePolicies: []pvcautoscalingv1alpha1.VolumePolicy{
+					{
+						MaxCapacity: resource.MustParse("10Gi"),
+						ScaleUp:     &pvcautoscalingv1alpha1.ScalingRules{MinStepAbsolute: &existing},
+					},
+				},
+			},
+		}
+
+		err := mutator.Mutate(context.Background(), pvca, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(pvca.Spec.VolumePolicies[0].ScaleUp.MinStepAbsolute.Cmp(resource.MustParse("5Gi"))).To(Equal(0))
+	})
+
+	It("should keep minStepAbsolute when already at least 5Gi", func() {
+		existing := resource.MustParse("10Gi")
+		pvca := &pvcautoscalingv1alpha1.PersistentVolumeClaimAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
+			Spec: pvcautoscalingv1alpha1.PersistentVolumeClaimAutoscalerSpec{
+				VolumePolicies: []pvcautoscalingv1alpha1.VolumePolicy{
+					{
+						MaxCapacity: resource.MustParse("20Gi"),
+						ScaleUp:     &pvcautoscalingv1alpha1.ScalingRules{MinStepAbsolute: &existing},
+					},
+				},
+			},
+		}
+
+		err := mutator.Mutate(context.Background(), pvca, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(pvca.Spec.VolumePolicies[0].ScaleUp.MinStepAbsolute.Cmp(resource.MustParse("10Gi"))).To(Equal(0))
+	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area storage
/kind enhancement
/platform aws

**What this PR does / why we need it**:
AWS EBS volumes can only be modified a limited number of times within a rolling 24-hour period. Enforcing a minimum absolute scaling step of `5Gi` (in addition to the cooldown) ensures each scaling operation makes a meaningfully large change, reducing the risk of exhausting the modification quota through many small resizes.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/14383 and related to #1745

**Special notes for your reviewer**:
@plkokanov @Kostov6 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Extends the `PersistentVolumeClaimAutoscaler` mutating webhook to default and enforce a minimum `MinStepAbsolute` of `5Gi` on scale-up policies, alongside the existing `CooldownDuration` defaulting.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scale-up volume policies now enforce a minimum absolute scaling step of 5 GiB.
  * Policies without a configured minimum automatically default to 5 GiB.
  * Configured values below 5 GiB are raised to the minimum, while larger values remain unchanged.
  * This provides consistent minimum growth behavior across all configured volume policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->