### PR TITLE
Retrieve the natgateway by cluster key only

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -241,8 +241,8 @@ func (c *Client) GetElasticIPsAssociationIDForAllocationIDs(ctx context.Context,
 func (c *Client) GetNATGatewayAddressAllocations(ctx context.Context, shootNamespace string) (sets.Set[string], error) {
 	describeAddressesInput := &ec2.DescribeNatGatewaysInput{
 		Filter: []ec2types.Filter{{
-			Name:   aws.String(fmt.Sprintf("tag:kubernetes.io/cluster/%s", shootNamespace)),
-			Values: []string{"1"},
+			Name:   aws.String("tag-key"),
+			Values: []string{fmt.Sprintf("kubernetes.io/cluster/%s", shootNamespace)},
 		}},
 	}
 

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -263,8 +263,11 @@ func (c *Client) GetNATGatewayAddressAllocations(ctx context.Context, shootNames
 
 		// add all allocation IDS for the addresses for this NAT Gateway
 		// these are the allocation IDS which identify the associated EIP
+		// private NAT gateways have no AllocationId — skip nil to avoid panic
 		for _, address := range natGateway.NatGatewayAddresses {
-			result.Insert(*address.AllocationId)
+			if address.AllocationId != nil {
+				result.Insert(*address.AllocationId)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement
/platform aws

**What this PR does / why we need it**:
This PR fixes the natgateway retrieval in the byo elastic IP case.
With the byo everything PR we switched from TagValueCluster ("1") to TagValueClusterOwned ("owned").
This should be respected everywhere.
Instead of checking the tag value we only check the tag key from now on.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NAT gateway discovery by recognizing resources with the cluster tag regardless of its tag value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->