### PR TITLE
Add describe retry after subnet creation to prevent race condition

### DIFF
--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -1733,6 +1733,7 @@ func (c *Client) CreateSubnet(ctx context.Context, subnet *Subnet, maxWaitDur ti
 		func(o *ec2.SubnetAvailableWaiterOptions) {
 			o.MinDelay = 5 * time.Second  // Optional; defaults to 15s if not set
 			o.MaxDelay = 60 * time.Second // Optional; defaults to 120s if not set
+			o.Retryable = subnetAvailableRetryable
 		})
 	if err != nil {
 		return nil, fmt.Errorf("subnet %s did not become available: %w", *output.Subnet.SubnetId, err)
@@ -2582,6 +2583,28 @@ func ignoreNotFound(err error) error {
 		return nil
 	}
 	return err
+}
+
+// subnetAvailableRetryable is a custom retryable function for SubnetAvailableWaiter that
+// treats InvalidSubnetID.NotFound as a transient error. EC2 eventual consistency means a
+// subnet may not be immediately visible via DescribeSubnets after CreateSubnet returns.
+func subnetAvailableRetryable(_ context.Context, _ *ec2.DescribeSubnetsInput, output *ec2.DescribeSubnetsOutput, err error) (bool, error) {
+	if err == nil {
+		for _, subnet := range output.Subnets {
+			if subnet.State != ec2types.SubnetStateAvailable {
+				return true, nil
+			}
+		}
+		if len(output.Subnets) > 0 {
+			return false, nil
+		}
+		return true, nil
+	}
+
+	if apiErr, ok := errors.AsType[smithy.APIError](err); ok && apiErr.ErrorCode() == "InvalidSubnetID.NotFound" {
+		return true, nil
+	}
+	return false, err
 }
 
 func ignoreAlreadyAssociated(err error) error {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area robustness
/kind enhancement
/platform aws

**What this PR does / why we need it**:
The AWS SDK v2's default subnetAvailableStateRetryable treats any error from DescribeSubnets as a terminal failure (return false, err). When EC2 eventual consistency causes InvalidSubnetID.NotFound immediately after CreateSubnet, the waiter gives up instead of retrying.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-aws/issues/1947

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix subnet describe race condition after creation due to EC2 eventual consistency
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subnet creation reliability by waiting through temporary availability states.
  * Reduced failures caused by short-lived subnet lookup inconsistencies during provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->