### PR TITLE
Support switching to byo eip with the one gardener created

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -1790,22 +1790,24 @@ func (c *FlowContext) ensureElasticIP(zone *aws.Zone) flow.TaskFn {
 		child := c.getSubnetZoneChild(zone.Name)
 		id := child.Get(IdentifierManagedZoneNATGWElasticIP)
 		if zone.ElasticIPAllocationID != nil {
-			// check if we need to clean up gardener managed IP, after user switched from managed to unmanaged
 			if id != nil && *id != *zone.ElasticIPAllocationID {
+				// User switched to a different EIP; try to clean up the old gardener-managed one.
 				ip, err := c.client.GetElasticIP(ctx, *id)
 				if err != nil {
 					return err
 				}
-				// make sure that the EIP is not in use
-				if ip != nil && ip.AssociationID == nil {
-					log.Info("deleting unused managed elastic IP found in state", "id", *id)
-					err = c.deleteElasticIpWithWait(ctx, ip)
-					if err != nil {
-						return err
-					}
-					child.Delete(IdentifierManagedZoneNATGWElasticIP)
+				// If still in use, leave state intact and retry on the next reconcile.
+				if ip == nil || ip.AssociationID != nil {
+					return nil
+				}
+				log.Info("deleting unused managed elastic IP found in state", "id", *id)
+				if err = c.deleteElasticIpWithWait(ctx, ip); err != nil {
+					return err
 				}
 			}
+			// Either IDs match (user adopted this EIP) or the old managed EIP was just deleted above.
+			// Clear managed state so the delete flow does not release it on shoot deletion.
+			child.Delete(IdentifierManagedZoneNATGWElasticIP)
 			return nil
 		}
 		desired := &awsclient.ElasticIP{

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -1796,14 +1796,11 @@ func (c *FlowContext) ensureElasticIP(zone *aws.Zone) flow.TaskFn {
 				if err != nil {
 					return err
 				}
-				switch {
-				case ip == nil:
-					// The old managed EIP no longer exists; nothing to delete.
-					// Fall through to clear the stale state below.
-				case ip.AssociationID != nil:
+				if ip != nil && ip.AssociationID != nil {
 					// Still associated (in use); leave state intact and retry on the next reconcile.
 					return nil
-				default:
+				}
+				if ip != nil {
 					log.Info("deleting unused managed elastic IP found in state", "id", *id)
 					if err = c.deleteElasticIpWithWait(ctx, ip); err != nil {
 						return err

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -1796,13 +1796,18 @@ func (c *FlowContext) ensureElasticIP(zone *aws.Zone) flow.TaskFn {
 				if err != nil {
 					return err
 				}
-				// If still in use, leave state intact and retry on the next reconcile.
-				if ip == nil || ip.AssociationID != nil {
+				switch {
+				case ip == nil:
+					// The old managed EIP no longer exists; nothing to delete.
+					// Fall through to clear the stale state below.
+				case ip.AssociationID != nil:
+					// Still associated (in use); leave state intact and retry on the next reconcile.
 					return nil
-				}
-				log.Info("deleting unused managed elastic IP found in state", "id", *id)
-				if err = c.deleteElasticIpWithWait(ctx, ip); err != nil {
-					return err
+				default:
+					log.Info("deleting unused managed elastic IP found in state", "id", *id)
+					if err = c.deleteElasticIpWithWait(ctx, ip); err != nil {
+						return err
+					}
 				}
 			}
 			// Either IDs match (user adopted this EIP) or the old managed EIP was just deleted above.

--- a/pkg/controller/infrastructure/infraflow/reconcile_elastic_ip_test.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile_elastic_ip_test.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package infraflow
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+
+	"github.com/gardener/gardener-extension-provider-aws/pkg/apis/aws"
+	awsclient "github.com/gardener/gardener-extension-provider-aws/pkg/aws/client"
+)
+
+var _ = Describe("#ensureElasticIP", func() {
+	const (
+		zoneName     = "eu-central-1a"
+		managedEIP   = "eipalloc-managed1111"
+		differentEIP = "eipalloc-user22222"
+	)
+
+	var f flowContextFixture
+
+	BeforeEach(func() {
+		f.setup()
+		// Pre-set the zone suffix so zoneSuffixHelpers doesn't need to scan other zones.
+		f.c.state.GetChild(ChildIdZones).GetChild(zoneName).Set(IdentifierZoneSuffix, "z0")
+	})
+
+	// helper to set the managed EIP state key
+	setManagedEIP := func(id string) {
+		f.c.state.GetChild(ChildIdZones).GetChild(zoneName).Set(IdentifierManagedZoneNATGWElasticIP, id)
+	}
+
+	// helper to read the managed EIP state key
+	getManagedEIPState := func() *string {
+		return f.c.state.GetChild(ChildIdZones).GetChild(zoneName).Get(IdentifierManagedZoneNATGWElasticIP)
+	}
+
+	zone := func(eipAllocationID *string) *aws.Zone {
+		return &aws.Zone{Name: zoneName, ElasticIPAllocationID: eipAllocationID}
+	}
+
+	Describe("user pins to the gardener-managed EIP (issue #1897)", func() {
+		It("should remove the managed state entry so the EIP is not deleted on shoot teardown", func() {
+			setManagedEIP(managedEIP)
+
+			// No AWS calls expected: we just clear state without touching AWS.
+			Expect(f.c.ensureElasticIP(zone(ptr.To(managedEIP)))(f.ctx)).To(Succeed())
+
+			Expect(getManagedEIPState()).To(BeNil(), "managed state entry must be cleared so deleteElasticIP skips it")
+		})
+	})
+
+	Describe("user switches to a different BYO EIP", func() {
+		It("should delete the old managed EIP if it is not in use", func() {
+			setManagedEIP(managedEIP)
+
+			oldEIP := &awsclient.ElasticIP{AllocationId: managedEIP, AssociationID: nil}
+			f.client.EXPECT().GetElasticIP(f.ctx, managedEIP).Return(oldEIP, nil).Times(1)
+			f.client.EXPECT().DeleteElasticIP(f.ctx, managedEIP).Return(nil).Times(1)
+
+			Expect(f.c.ensureElasticIP(zone(ptr.To(differentEIP)))(f.ctx)).To(Succeed())
+
+			Expect(getManagedEIPState()).To(BeNil())
+		})
+
+		It("should not delete the old managed EIP if it is still associated", func() {
+			setManagedEIP(managedEIP)
+
+			oldEIP := &awsclient.ElasticIP{AllocationId: managedEIP, AssociationID: ptr.To("eipassoc-abc")}
+			f.client.EXPECT().GetElasticIP(f.ctx, managedEIP).Return(oldEIP, nil).Times(1)
+
+			Expect(f.c.ensureElasticIP(zone(ptr.To(differentEIP)))(f.ctx)).To(Succeed())
+
+			// State entry is NOT cleared: the EIP is still in use and will be retried on next reconcile.
+			Expect(getManagedEIPState()).To(HaveValue(Equal(managedEIP)))
+		})
+	})
+
+	Describe("no managed EIP in state, user provides BYO EIP", func() {
+		It("should be a no-op", func() {
+			// No state, no AWS calls expected.
+			Expect(f.c.ensureElasticIP(zone(ptr.To(differentEIP)))(f.ctx)).To(Succeed())
+
+			Expect(getManagedEIPState()).To(BeNil())
+		})
+	})
+
+	Describe("no ElasticIPAllocationID set (gardener manages the EIP)", func() {
+		// The EIP tag Name is "<namespace>-eip-natgw-<zone-suffix>". In tests, namespace is empty.
+		eipTagName := func() awsclient.Tags { return f.c.commonTagsWithSuffix("eip-natgw-z0") }
+
+		It("should create a new EIP if none exists in state or by tags", func() {
+			tags := eipTagName()
+			created := &awsclient.ElasticIP{AllocationId: managedEIP}
+
+			f.client.EXPECT().FindElasticIPsByTags(f.ctx, tags).Return(nil, nil).Times(1)
+			f.client.EXPECT().CreateElasticIP(f.ctx, &awsclient.ElasticIP{Tags: tags, Vpc: true}).Return(created, nil).Times(1)
+
+			Expect(f.c.ensureElasticIP(zone(nil))(f.ctx)).To(Succeed())
+
+			Expect(getManagedEIPState()).To(HaveValue(Equal(managedEIP)))
+		})
+
+		It("should reuse an existing EIP found by tags", func() {
+			tags := eipTagName()
+			existing := &awsclient.ElasticIP{AllocationId: managedEIP, Tags: tags}
+
+			f.client.EXPECT().FindElasticIPsByTags(f.ctx, tags).Return([]*awsclient.ElasticIP{existing}, nil).Times(1)
+			f.updater.EXPECT().UpdateEC2Tags(f.ctx, managedEIP, tags, tags).Return(false, nil).Times(1)
+
+			Expect(f.c.ensureElasticIP(zone(nil))(f.ctx)).To(Succeed())
+
+			Expect(getManagedEIPState()).To(HaveValue(Equal(managedEIP)))
+		})
+
+		It("should reuse an existing EIP found by state ID", func() {
+			setManagedEIP(managedEIP)
+			tags := eipTagName()
+			existing := &awsclient.ElasticIP{AllocationId: managedEIP, Tags: tags}
+
+			// FindExisting: ID is present → calls GetElasticIP first.
+			f.client.EXPECT().GetElasticIP(f.ctx, managedEIP).Return(existing, nil).Times(1)
+			f.updater.EXPECT().UpdateEC2Tags(f.ctx, managedEIP, tags, tags).Return(false, nil).Times(1)
+
+			Expect(f.c.ensureElasticIP(zone(nil))(f.ctx)).To(Succeed())
+
+			Expect(getManagedEIPState()).To(HaveValue(Equal(managedEIP)))
+		})
+	})
+})

--- a/pkg/controller/infrastructure/infraflow/reconcile_elastic_ip_test.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile_elastic_ip_test.go
@@ -77,6 +77,18 @@ var _ = Describe("#ensureElasticIP", func() {
 			// State entry is NOT cleared: the EIP is still in use and will be retried on next reconcile.
 			Expect(getManagedEIPState()).To(HaveValue(Equal(managedEIP)))
 		})
+
+		It("should clear state if the old managed EIP no longer exists", func() {
+			setManagedEIP(managedEIP)
+
+			// The old EIP was already released out-of-band; GetElasticIP returns (nil, nil).
+			f.client.EXPECT().GetElasticIP(f.ctx, managedEIP).Return(nil, nil).Times(1)
+
+			Expect(f.c.ensureElasticIP(zone(ptr.To(differentEIP)))(f.ctx)).To(Succeed())
+
+			// Nothing to delete, but the stale state entry must be cleared.
+			Expect(getManagedEIPState()).To(BeNil())
+		})
 	})
 
 	Describe("no managed EIP in state, user provides BYO EIP", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area user-management
/kind bug
/platform aws

**What this PR does / why we need it**:
When a user sets elasticIPAllocationID to the allocation ID of an Elastic IP that was originally created by the AWS extension, the intent is to take ownership of that IP and preserve it beyond the shoot lifecycle.
However, the IP was still deleted with shoot deletion because the state was not cleaned up.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-aws/issues/1897

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Support switching to byo eip with the one gardener created
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of configured elastic IP addresses during infrastructure reconciliation.
  - Prevents user-provided IPs from being treated as system-managed resources during deletion.
  - Preserves in-use or unavailable previous IPs for retry while safely removing unused managed IPs.
  - Clears stale tracking when a previously managed address has been released externally.

- **Tests**
  - Added coverage for address switching, missing state, external release, creation, and resource reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->