### PR TITLE
Align with provider local

### DIFF
--- a/cmd/gardener-extension-provider-aws/app/app.go
+++ b/cmd/gardener-extension-provider-aws/app/app.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -312,13 +313,13 @@ func applyGeneralOptions(generalOpts *controllercmd.GeneralOptions) {
 
 	awsworker.DefaultAddOptions.SelfHostedShootCluster = config.SelfHostedShootCluster
 
-	awsinfrastructure.DefaultAddOptions.ExtensionClasses = config.ExtensionClasses
-	awscontrolplane.DefaultAddOptions.ExtensionClasses = config.ExtensionClasses
-	awsworker.DefaultAddOptions.ExtensionClasses = config.ExtensionClasses
-	awsbastion.DefaultAddOptions.ExtensionClasses = config.ExtensionClasses
-	awsbackupbucket.DefaultAddOptions.ExtensionClasses = config.ExtensionClasses
-	awsbackupentry.DefaultAddOptions.ExtensionClasses = config.ExtensionClasses
-	awsdnsrecord.DefaultAddOptions.ExtensionClasses = config.ExtensionClasses
+	awsinfrastructure.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	awscontrolplane.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	awsworker.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	awsbastion.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	awsbackupbucket.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	awsbackupentry.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	awsdnsrecord.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
 }
 
 // TODO (kon-angelo): Remove after the release of version 1.68.0

--- a/pkg/controller/backupbucket/add.go
+++ b/pkg/controller/backupbucket/add.go
@@ -12,7 +12,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
@@ -44,11 +43,6 @@ func AddToManagerWithOptions(_ context.Context, mgr manager.Manager, opts AddOpt
 	classes := slices.DeleteFunc(opts.ExtensionClasses, func(class extensionsv1alpha1.ExtensionClass) bool {
 		return !supportedExtensionClasses.Has(class)
 	})
-	if len(classes) == 0 {
-		log.Log.Info("No supported extension classes left after filtering, skipping backupbucket controller registration")
-		return nil
-	}
-
 	return backupbucket.Add(mgr, backupbucket.AddArgs{
 		Actuator:          NewActuator(mgr, awsclient.FactoryFunc(awsclient.NewInterface)),
 		ControllerOptions: opts.Controller,

--- a/pkg/controller/backupentry/add.go
+++ b/pkg/controller/backupentry/add.go
@@ -13,7 +13,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
@@ -44,11 +43,6 @@ func AddToManagerWithOptions(_ context.Context, mgr manager.Manager, opts AddOpt
 	classes := slices.DeleteFunc(opts.ExtensionClasses, func(class extensionsv1alpha1.ExtensionClass) bool {
 		return !supportedExtensionClasses.Has(class)
 	})
-	if len(classes) == 0 {
-		log.Log.Info("No supported extension classes left after filtering, skipping backupentry controller registration")
-		return nil
-	}
-
 	return backupentry.Add(mgr, backupentry.AddArgs{
 		Actuator:          genericactuator.NewActuator(mgr, newActuator(mgr)),
 		ControllerOptions: opts.Controller,

--- a/pkg/controller/bastion/add.go
+++ b/pkg/controller/bastion/add.go
@@ -12,7 +12,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
@@ -43,11 +42,6 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	classes := slices.DeleteFunc(opts.ExtensionClasses, func(class extensionsv1alpha1.ExtensionClass) bool {
 		return !supportedExtensionClasses.Has(class)
 	})
-	if len(classes) == 0 {
-		log.Log.Info("No supported extension classes left after filtering, skipping bastion controller registration")
-		return nil
-	}
-
 	return bastion.Add(mgr, bastion.AddArgs{
 		Actuator:          newActuator(mgr),
 		ControllerOptions: opts.Controller,

--- a/pkg/controller/controlplane/add.go
+++ b/pkg/controller/controlplane/add.go
@@ -16,7 +16,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/gardener/gardener-extension-provider-aws/imagevector"
@@ -52,11 +51,6 @@ func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddO
 	classes := slices.DeleteFunc(opts.ExtensionClasses, func(class extensionsv1alpha1.ExtensionClass) bool {
 		return !supportedExtensionClasses.Has(class)
 	})
-	if len(classes) == 0 {
-		log.Log.Info("No supported extension classes left after filtering, skipping controlplane controller registration")
-		return nil
-	}
-
 	genericActuator, err := genericactuator.NewActuator(mgr, aws.Name,
 		secretConfigsFunc, shootAccessSecretsFunc,
 		configChart, controlPlaneChart, controlPlaneShootChart, controlPlaneShootCRDsChart, storageClassChart,

--- a/pkg/controller/dnsrecord/add.go
+++ b/pkg/controller/dnsrecord/add.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
@@ -62,11 +61,6 @@ func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddO
 	classes := slices.DeleteFunc(opts.ExtensionClasses, func(class extensionsv1alpha1.ExtensionClass) bool {
 		return !supportedExtensionClasses.Has(class)
 	})
-	if len(classes) == 0 {
-		log.Log.Info("No supported extension classes left after filtering, skipping dnsrecord controller registration")
-		return nil
-	}
-
 	return dnsrecord.Add(mgr, dnsrecord.AddArgs{
 		Actuator:          NewActuator(mgr, awsclient.NewRoute53Factory(opts.RateLimiter.Limit, opts.RateLimiter.Burst, opts.RateLimiter.WaitTimeout)),
 		ControllerOptions: opts.Controller,

--- a/pkg/controller/infrastructure/add.go
+++ b/pkg/controller/infrastructure/add.go
@@ -45,11 +45,6 @@ func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddO
 	classes := slices.DeleteFunc(opts.ExtensionClasses, func(class extensionsv1alpha1.ExtensionClass) bool {
 		return !supportedExtensionClasses.Has(class)
 	})
-	if len(classes) == 0 {
-		log.Log.Info("No supported extension classes left after filtering, skipping infrastructure controller registration")
-		return nil
-	}
-
 	return infrastructure.Add(mgr, infrastructure.AddArgs{
 		Actuator:          NewActuator(mgr),
 		ConfigValidator:   NewConfigValidator(mgr, awsclient.FactoryFunc(awsclient.NewInterface), log.Log),

--- a/pkg/controller/worker/add.go
+++ b/pkg/controller/worker/add.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/gardener/gardener-extension-provider-aws/pkg/aws"
@@ -59,11 +58,6 @@ func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddO
 	classes := slices.DeleteFunc(opts.ExtensionClasses, func(class extensionsv1alpha1.ExtensionClass) bool {
 		return !supportedExtensionClasses.Has(class)
 	})
-	if len(classes) == 0 {
-		log.Log.Info("No supported extension classes left after filtering, skipping worker controller registration")
-		return nil
-	}
-
 	return worker.Add(ctx, mgr, worker.AddArgs{
 		Actuator:               NewActuator(mgr, opts.GardenCluster),
 		ControllerOptions:      opts.Controller,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area robustness
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Aligns the extension-class filtering in all controllers with the approach used in provider-local.
- Removes the early-return skip-guard (if len(classes) == 0 { return nil }) from all controller add.go files. The guard was added defensively but is unnecessary — when no supported classes remain after filtering, the HasClass predicate (which defaults an empty list to [shoot]) and the --controllers name-based switch already handle controller gating correctly.
- Moves slices.Clone of ExtensionClasses to the app.go assignment site (one clone per controller), matching provider-local exactly. This fixes a subtle shared-slice mutation bug: slices.DeleteFunc compacts the backing array in place, so without cloning, filtering in one controller registration path could corrupt the slice seen by a later controller, leading to incomplete controller registration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved controller registration when no supported extension classes are configured.
  - Ensured AWS controller options are isolated when shared configuration is used.
  - Prevented valid controllers from being skipped due to empty filtered configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->